### PR TITLE
feat: sandbox shell and runtime defaults

### DIFF
--- a/cmd/boxapi/main.go
+++ b/cmd/boxapi/main.go
@@ -37,7 +37,7 @@ func main() {
 	cmd.Flags().StringVar(&opts.RootDir, "root", opts.RootDir, "NovitaBox root directory")
 	cmd.Flags().StringVar(&opts.Addr, "addr", opts.Addr, "boxapi listen address")
 	cmd.Flags().IntVar(&opts.Port, "port", 0, "boxapi listen port, overrides the port in --addr")
-	cmd.Flags().StringVar(&opts.DBPath, "db-path", opts.DBPath, "SQLite database path, defaults to $root/novitabox.db")
+	cmd.Flags().StringVar(&opts.DBPath, "db-path", opts.DBPath, "SQLite database path, defaults to $root/db/novitabox.db")
 	cmd.Flags().StringVar(&opts.BoxletAddr, "boxlet-addr", opts.BoxletAddr, "boxlet gRPC address")
 
 	if err := cmd.Execute(); err != nil {

--- a/cmd/boxctl/main.go
+++ b/cmd/boxctl/main.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/net/websocket"
+)
+
+type startProcessRequest struct {
+	Cmd  []string `json:"cmd"`
+	Cwd  string   `json:"cwd,omitempty"`
+	TTY  bool     `json:"tty,omitempty"`
+	Rows uint16   `json:"rows,omitempty"`
+	Cols uint16   `json:"cols,omitempty"`
+}
+
+type startProcessResponse struct {
+	Process processInfo `json:"process"`
+}
+
+type processInfo struct {
+	ID  string `json:"id"`
+	PID int    `json:"pid,omitempty"`
+}
+
+func main() {
+	var proxyAddr string
+	var cwd string
+	var attachStdin bool
+	var tty bool
+
+	cmd := &cobra.Command{
+		Use:   "boxctl",
+		Short: "NovitaBox command line client",
+	}
+	execCmd := &cobra.Command{
+		Use:   "exec [-it] <sandbox_id> <cmd> [args...]",
+		Short: "Execute a command in a sandbox",
+		Args:  cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runExec(proxyAddr, args[0], args[1:], cwd, attachStdin || tty)
+		},
+	}
+	execCmd.Flags().BoolVarP(&attachStdin, "interactive", "i", false, "attach stdin")
+	execCmd.Flags().BoolVarP(&tty, "tty", "t", false, "allocate a terminal")
+	execCmd.Flags().StringVar(&cwd, "cwd", "", "working directory inside the sandbox")
+	cmd.PersistentFlags().StringVar(&proxyAddr, "proxy", "http://127.0.0.1:8082", "boxproxy base URL")
+	cmd.AddCommand(execCmd)
+
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "boxctl: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runExec(proxyAddr string, sandboxID string, command []string, cwd string, interactive bool) error {
+	rows, cols := terminalSize()
+	startReq := startProcessRequest{
+		Cmd:  command,
+		Cwd:  cwd,
+		TTY:  true,
+		Rows: rows,
+		Cols: cols,
+	}
+	body, err := json.Marshal(startReq)
+	if err != nil {
+		return err
+	}
+
+	base := strings.TrimRight(proxyAddr, "/")
+	startURL := fmt.Sprintf("%s/v1/sandboxes/%s/processes", base, url.PathEscape(sandboxID))
+	resp, err := http.Post(startURL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("start process: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("start process failed: %s: %s", resp.Status, strings.TrimSpace(string(data)))
+	}
+	var startResp startProcessResponse
+	if err := json.NewDecoder(resp.Body).Decode(&startResp); err != nil {
+		return fmt.Errorf("decode start process response: %w", err)
+	}
+	if startResp.Process.ID == "" {
+		return fmt.Errorf("start process response missing process id")
+	}
+
+	wsURL, err := processWebSocketURL(base, sandboxID, startResp.Process.ID)
+	if err != nil {
+		return err
+	}
+	origin := "http://127.0.0.1"
+	conn, err := websocket.Dial(wsURL, "", origin)
+	if err != nil {
+		return fmt.Errorf("connect process: %w", err)
+	}
+	defer conn.Close()
+	var startFrame []byte
+	_ = websocket.Message.Receive(conn, &startFrame)
+
+	var restore func() error
+	if interactive {
+		restore, err = makeRaw(int(os.Stdin.Fd()))
+		if err != nil {
+			return fmt.Errorf("set terminal raw mode: %w", err)
+		}
+		defer restore()
+		go resizeLoop(base, sandboxID, startResp.Process.ID)
+	}
+
+	errCh := make(chan error, 2)
+	go func() {
+		_, err := io.Copy(conn, os.Stdin)
+		errCh <- err
+	}()
+	go func() {
+		_, err := io.Copy(os.Stdout, conn)
+		errCh <- err
+	}()
+	err = <-errCh
+	if err != nil && !isClosed(err) {
+		return err
+	}
+	return nil
+}
+
+func processWebSocketURL(base string, sandboxID string, processID string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	switch u.Scheme {
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	case "ws", "wss":
+	default:
+		return "", fmt.Errorf("unsupported proxy scheme %q", u.Scheme)
+	}
+	u.Path = fmt.Sprintf("/v1/sandboxes/%s/processes/%s/connect", url.PathEscape(sandboxID), url.PathEscape(processID))
+	u.RawQuery = ""
+	return u.String(), nil
+}
+
+func resizeLoop(base string, sandboxID string, processID string) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGWINCH)
+	defer signal.Stop(ch)
+	for {
+		<-ch
+		rows, cols := terminalSize()
+		payload, _ := json.Marshal(map[string]uint16{"rows": rows, "cols": cols})
+		_, _ = http.Post(
+			fmt.Sprintf("%s/v1/sandboxes/%s/processes/%s/resize", strings.TrimRight(base, "/"), url.PathEscape(sandboxID), url.PathEscape(processID)),
+			"application/json",
+			bytes.NewReader(payload),
+		)
+	}
+}
+
+func terminalSize() (uint16, uint16) {
+	return getTerminalSize(int(os.Stdout.Fd()))
+}
+
+func isClosed(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	text := err.Error()
+	return strings.Contains(text, "use of closed network connection") ||
+		strings.Contains(text, "websocket: close") ||
+		strings.Contains(text, "EOF") ||
+		strings.Contains(text, "i/o timeout") ||
+		strings.Contains(text, "broken pipe")
+}

--- a/cmd/boxctl/term_darwin.go
+++ b/cmd/boxctl/term_darwin.go
@@ -1,0 +1,34 @@
+//go:build darwin
+
+package main
+
+import "golang.org/x/sys/unix"
+
+func getTerminalSize(fd int) (uint16, uint16) {
+	ws, err := unix.IoctlGetWinsize(fd, unix.TIOCGWINSZ)
+	if err != nil || ws == nil || ws.Row == 0 || ws.Col == 0 {
+		return 24, 80
+	}
+	return ws.Row, ws.Col
+}
+
+func makeRaw(fd int) (func() error, error) {
+	oldState, err := unix.IoctlGetTermios(fd, unix.TIOCGETA)
+	if err != nil {
+		return nil, err
+	}
+	newState := *oldState
+	newState.Iflag &^= unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON
+	newState.Oflag &^= unix.OPOST
+	newState.Lflag &^= unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN
+	newState.Cflag &^= unix.CSIZE | unix.PARENB
+	newState.Cflag |= unix.CS8
+	newState.Cc[unix.VMIN] = 1
+	newState.Cc[unix.VTIME] = 0
+	if err := unix.IoctlSetTermios(fd, unix.TIOCSETA, &newState); err != nil {
+		return nil, err
+	}
+	return func() error {
+		return unix.IoctlSetTermios(fd, unix.TIOCSETA, oldState)
+	}, nil
+}

--- a/cmd/boxctl/term_linux.go
+++ b/cmd/boxctl/term_linux.go
@@ -1,0 +1,34 @@
+//go:build linux
+
+package main
+
+import "golang.org/x/sys/unix"
+
+func getTerminalSize(fd int) (uint16, uint16) {
+	ws, err := unix.IoctlGetWinsize(fd, unix.TIOCGWINSZ)
+	if err != nil || ws == nil || ws.Row == 0 || ws.Col == 0 {
+		return 24, 80
+	}
+	return ws.Row, ws.Col
+}
+
+func makeRaw(fd int) (func() error, error) {
+	oldState, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+	if err != nil {
+		return nil, err
+	}
+	newState := *oldState
+	newState.Iflag &^= unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON
+	newState.Oflag &^= unix.OPOST
+	newState.Lflag &^= unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN
+	newState.Cflag &^= unix.CSIZE | unix.PARENB
+	newState.Cflag |= unix.CS8
+	newState.Cc[unix.VMIN] = 1
+	newState.Cc[unix.VTIME] = 0
+	if err := unix.IoctlSetTermios(fd, unix.TCSETS, &newState); err != nil {
+		return nil, err
+	}
+	return func() error {
+		return unix.IoctlSetTermios(fd, unix.TCSETS, oldState)
+	}, nil
+}

--- a/cmd/boxctl/term_unsupported.go
+++ b/cmd/boxctl/term_unsupported.go
@@ -1,0 +1,13 @@
+//go:build !linux && !darwin
+
+package main
+
+import "fmt"
+
+func getTerminalSize(fd int) (uint16, uint16) {
+	return 24, 80
+}
+
+func makeRaw(fd int) (func() error, error) {
+	return nil, fmt.Errorf("raw terminal mode is not supported on this platform")
+}

--- a/cmd/boxlet/main.go
+++ b/cmd/boxlet/main.go
@@ -20,8 +20,6 @@ func main() {
 		RootDir:               defaults.RootDir,
 		Addr:                  defaults.Boxlet.Addr,
 		RuntimeDriver:         defaults.Boxshim.RuntimeDriver,
-		BoxshimBinaryPath:     defaults.Boxshim.BinaryPath,
-		FirecrackerBinaryPath: defaults.Firecracker.BinaryPath,
 		TemplateSnapshotWait:  defaults.Template.SnapshotWaitSecs,
 		TemplateAgentWait:     defaults.Template.AgentWaitSecs,
 		TemplateBoxdGuestPath: defaults.Template.BoxdGuestPath,
@@ -49,17 +47,14 @@ func main() {
 	cmd.Flags().StringVar(&opts.RootDir, "root", opts.RootDir, "NovitaBox root directory")
 	cmd.Flags().StringVar(&opts.Addr, "addr", opts.Addr, "boxlet listen address")
 	cmd.Flags().IntVar(&opts.Port, "port", 0, "boxlet listen port, overrides the port in --addr")
-	cmd.Flags().StringVar(&opts.DBPath, "db-path", opts.DBPath, "SQLite database path, defaults to $root/novitabox.db")
-	cmd.Flags().StringVar(&opts.RuntimeDriver, "runtime-driver", opts.RuntimeDriver, "runtime driver passed to boxshim: stub or firecracker")
-	cmd.Flags().StringVar(&opts.BoxshimBinaryPath, "boxshim-bin", opts.BoxshimBinaryPath, "boxshim binary path")
-	cmd.Flags().StringVar(&opts.FirecrackerBinaryPath, "firecracker-bin", opts.FirecrackerBinaryPath, "Firecracker binary path passed to boxshim")
-	cmd.Flags().StringVar(&opts.TemplateKernelPath, "template-kernel", opts.TemplateKernelPath, "kernel image used when building template snapshots")
-	cmd.Flags().BoolVar(&opts.TemplateSnapshot, "template-snapshot", opts.TemplateSnapshot, "start Firecracker and export memfile/snapfile during template build")
+	cmd.Flags().StringVar(&opts.DBPath, "db-path", opts.DBPath, "SQLite database path, defaults to $root/db/novitabox.db")
+	cmd.Flags().StringVar(&opts.RuntimeDriver, "runtime-driver", opts.RuntimeDriver, "runtime driver passed to boxshim, defaults to firecracker")
+	cmd.Flags().StringVar(&opts.TemplateKernelPath, "template-kernel", opts.TemplateKernelPath, "kernel image used when building template snapshots, defaults to $root/vmlinux.bin")
 	cmd.Flags().Uint32Var(&opts.TemplateSnapshotWait, "template-snapshot-wait", opts.TemplateSnapshotWait, "seconds to wait before exporting template snapshot")
 	cmd.Flags().StringVar(&opts.TemplateAgentHealth, "template-agent-health", opts.TemplateAgentHealth, "boxd health URL used before exporting template snapshot")
 	cmd.Flags().StringVar(&opts.TemplateAgentExec, "template-agent-exec", opts.TemplateAgentExec, "boxd exec URL used for template build commands")
 	cmd.Flags().Uint32Var(&opts.TemplateAgentWait, "template-agent-wait", opts.TemplateAgentWait, "seconds to wait for boxd health before exporting template snapshot")
-	cmd.Flags().StringVar(&opts.TemplateBoxdBinary, "template-boxd-bin", opts.TemplateBoxdBinary, "host boxd binary path injected into template rootfs")
+	cmd.Flags().StringVar(&opts.TemplateBoxdBinary, "template-boxd-bin", opts.TemplateBoxdBinary, "host boxd binary path injected into template rootfs, defaults to $root/boxd")
 	cmd.Flags().StringVar(&opts.TemplateBoxdGuestPath, "template-boxd-guest-path", opts.TemplateBoxdGuestPath, "guest path for injected boxd binary")
 	cmd.Flags().StringVar(&opts.TemplateBoxdGuestAddr, "template-boxd-guest-addr", opts.TemplateBoxdGuestAddr, "guest listen address for injected boxd")
 	cmd.Flags().BoolVar(&opts.NetworkEnabled, "network", opts.NetworkEnabled, "prepare sandbox network namespace and tap network")

--- a/cmd/boxshim/main.go
+++ b/cmd/boxshim/main.go
@@ -17,10 +17,9 @@ import (
 func main() {
 	defaults := config.Default()
 	opts := config.BoxshimOptions{
-		RootDir:               defaults.RootDir,
-		SocketPath:            defaults.Boxshim.SocketPath,
-		RuntimeDriver:         defaults.Boxshim.RuntimeDriver,
-		FirecrackerBinaryPath: defaults.Firecracker.BinaryPath,
+		RootDir:       defaults.RootDir,
+		SocketPath:    defaults.Boxshim.SocketPath,
+		RuntimeDriver: defaults.Boxshim.RuntimeDriver,
 	}
 
 	cmd := &cobra.Command{
@@ -33,7 +32,7 @@ func main() {
 	cmd.Flags().StringVar(&opts.RootDir, "root", opts.RootDir, "NovitaBox root directory")
 	cmd.Flags().StringVar(&opts.SocketPath, "socket", opts.SocketPath, "boxshim Unix socket path")
 	cmd.Flags().StringVar(&opts.RuntimeDriver, "runtime-driver", opts.RuntimeDriver, "runtime driver: stub or firecracker")
-	cmd.Flags().StringVar(&opts.FirecrackerBinaryPath, "firecracker-bin", opts.FirecrackerBinaryPath, "Firecracker binary path")
+	cmd.Flags().StringVar(&opts.FirecrackerBinaryPath, "firecracker-bin", opts.FirecrackerBinaryPath, "Firecracker binary path, defaults to $root/firecracker")
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "boxshim: %v\n", err)

--- a/internal/app/boxapi/app.go
+++ b/internal/app/boxapi/app.go
@@ -7,7 +7,6 @@ import (
 	"github.com/novitalabs/NovitaBox/internal/boxapi/server"
 	"github.com/novitalabs/NovitaBox/internal/config"
 	"github.com/novitalabs/NovitaBox/internal/log"
-	"github.com/novitalabs/NovitaBox/internal/storage/layout"
 	"github.com/novitalabs/NovitaBox/internal/storage/store"
 	"github.com/novitalabs/NovitaBox/internal/storage/store/sqlite"
 )
@@ -21,8 +20,9 @@ type App struct {
 func New(cfg config.Config, logger *log.Logger) (*App, error) {
 	dbPath := cfg.Storage.DBPath
 	if dbPath == "" {
-		dbPath = layout.New(cfg.RootDir).DBPath()
+		dbPath = config.DefaultDBPath(cfg.RootDir)
 	}
+	logger.Info("opening sqlite database", "db_path", dbPath)
 
 	st, err := sqlite.Open(context.Background(), dbPath)
 	if err != nil {

--- a/internal/app/boxlet/app.go
+++ b/internal/app/boxlet/app.go
@@ -6,7 +6,6 @@ import (
 	"github.com/novitalabs/NovitaBox/internal/boxlet/server"
 	"github.com/novitalabs/NovitaBox/internal/config"
 	"github.com/novitalabs/NovitaBox/internal/log"
-	"github.com/novitalabs/NovitaBox/internal/storage/layout"
 	"github.com/novitalabs/NovitaBox/internal/storage/store"
 	"github.com/novitalabs/NovitaBox/internal/storage/store/sqlite"
 )
@@ -19,8 +18,15 @@ type App struct {
 func New(cfg config.Config, logger *log.Logger) (*App, error) {
 	dbPath := cfg.Storage.DBPath
 	if dbPath == "" {
-		dbPath = layout.New(cfg.RootDir).DBPath()
+		dbPath = config.DefaultDBPath(cfg.RootDir)
 	}
+	logger.Info("opening sqlite database", "db_path", dbPath)
+	logger.Info("using template defaults",
+		"template_kernel", cfg.Template.KernelPath,
+		"template_boxd_bin", cfg.Template.BoxdBinaryPath,
+		"template_boxd_guest_path", cfg.Template.BoxdGuestPath,
+		"template_boxd_guest_addr", cfg.Template.BoxdGuestAddr,
+	)
 
 	st, err := sqlite.Open(context.Background(), dbPath)
 	if err != nil {

--- a/internal/app/boxproxy/app.go
+++ b/internal/app/boxproxy/app.go
@@ -17,8 +17,5 @@ func New(cfg config.Config, logger *log.Logger) (*App, error) {
 }
 
 func (a *App) Run(ctx context.Context) error {
-	a.server.Start(ctx)
-	<-ctx.Done()
-	a.server.Stop(context.Background())
-	return nil
+	return a.server.Start(ctx)
 }

--- a/internal/boxapi/handler/image.go
+++ b/internal/boxapi/handler/image.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"net/http"
@@ -43,6 +44,15 @@ func (h *Handler) CreateImage(c *gin.Context) {
 	if err := c.ShouldBindJSON(&req); err != nil {
 		response.Error(c, response.ErrBadRequest("invalid image request body"))
 		return
+	}
+	req.ImageID = strings.TrimSpace(req.ImageID)
+	if req.ImageID == "" {
+		imageID, err := newImageID()
+		if err != nil {
+			response.Error(c, response.ErrInternal("generate image id failed"))
+			return
+		}
+		req.ImageID = imageID
 	}
 	if err := validateImageID(req.ImageID); err != nil {
 		response.Error(c, response.ErrBadRequest(err.Error()))
@@ -293,6 +303,18 @@ func validateImageID(imageID string) error {
 		return errors.New("imageID contains invalid path characters")
 	}
 	return nil
+}
+
+func newImageID() (string, error) {
+	const alphabet = "abcdefghijklmnopqrstuvwxyz1234567890"
+	var b [20]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	for i := range b {
+		b[i] = alphabet[int(b[i])%len(alphabet)]
+	}
+	return "img-" + string(b[:]), nil
 }
 
 func shouldRemoveImageDir(rootDir string, imageID string, rootfsPath string) bool {

--- a/internal/boxapi/handler/sandbox.go
+++ b/internal/boxapi/handler/sandbox.go
@@ -363,7 +363,7 @@ func newSandboxID() (string, error) {
 		b[i] = alphabet[int(b[i])%len(alphabet)]
 	}
 
-	return "i" + string(b[:]), nil
+	return "sbx-" + string(b[:]), nil
 }
 
 func sandboxRecordResponse(record store.SandboxRecord) sandboxResponse {

--- a/internal/boxapi/server/router_test.go
+++ b/internal/boxapi/server/router_test.go
@@ -215,8 +215,17 @@ func TestRouterCreateSandbox(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if got.SandboxID == "" || !strings.HasPrefix(got.SandboxID, "i") || got.SandboxID == "client-id-is-ignored" {
-		t.Fatalf("sandboxID = %q, want generated i* id", got.SandboxID)
+	if got.SandboxID == "" || !strings.HasPrefix(got.SandboxID, "sbx-") || got.SandboxID == "client-id-is-ignored" {
+		t.Fatalf("sandboxID = %q, want generated sbx-* id", got.SandboxID)
+	}
+	suffix := strings.TrimPrefix(got.SandboxID, "sbx-")
+	if len(suffix) != 20 {
+		t.Fatalf("sandboxID suffix length = %d, want 20", len(suffix))
+	}
+	for _, ch := range suffix {
+		if (ch < 'a' || ch > 'z') && (ch < '0' || ch > '9') {
+			t.Fatalf("sandboxID suffix = %q, want lowercase alphanumeric", suffix)
+		}
 	}
 	if got.TemplateID != "tpl-test" {
 		t.Fatalf("templateID = %q, want tpl-test", got.TemplateID)
@@ -616,6 +625,45 @@ func TestRouterImageCRUD(t *testing.T) {
 	}
 }
 
+func TestRouterCreateImageGeneratesID(t *testing.T) {
+	s := newTestServer(t)
+	source := filepath.Join(s.cfg.RootDir, "source-rootfs.ext4")
+	if err := os.WriteFile(source, []byte("rootfs"), 0o644); err != nil {
+		t.Fatalf("write source rootfs: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images", bytes.NewBufferString(`{"rootfsPath":"`+source+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusCreated, rec.Code, rec.Body.String())
+	}
+	var got struct {
+		ImageID    string `json:"imageID"`
+		RootfsPath string `json:"rootfsPath"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !strings.HasPrefix(got.ImageID, "img-") {
+		t.Fatalf("imageID = %q, want generated img-* id", got.ImageID)
+	}
+	suffix := strings.TrimPrefix(got.ImageID, "img-")
+	if len(suffix) != 20 {
+		t.Fatalf("imageID suffix length = %d, want 20", len(suffix))
+	}
+	for _, ch := range suffix {
+		if (ch < 'a' || ch > 'z') && (ch < '0' || ch > '9') {
+			t.Fatalf("imageID suffix = %q, want lowercase alphanumeric", suffix)
+		}
+	}
+	if !strings.HasSuffix(got.RootfsPath, filepath.Join("images", got.ImageID, "rootfs.ext4")) {
+		t.Fatalf("rootfsPath = %q, want generated image path", got.RootfsPath)
+	}
+}
+
 func TestRouterCreateTemplateV3RequiresName(t *testing.T) {
 	s := newTestServer(t)
 	req := httptest.NewRequest(http.MethodPost, "/v3/templates", bytes.NewBufferString(`{"tags":["latest"]}`))
@@ -661,7 +709,7 @@ func newTestServer(t *testing.T) *Server {
 	root := t.TempDir()
 	cfg := config.Default()
 	cfg.RootDir = root
-	cfg.Storage.DBPath = filepath.Join(root, "novitabox.db")
+	cfg.Storage.DBPath = filepath.Join(root, "db", "novitabox.db")
 
 	st, err := sqlite.Open(t.Context(), cfg.Storage.DBPath)
 	if err != nil {

--- a/internal/boxd/server/process.go
+++ b/internal/boxd/server/process.go
@@ -1,0 +1,518 @@
+package server
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/novitalabs/NovitaBox/internal/wsutil"
+	"golang.org/x/net/websocket"
+)
+
+const processOutputBuffer = 64
+
+type processManager struct {
+	mu        sync.RWMutex
+	processes map[string]*managedProcess
+}
+
+func newProcessManager() *processManager {
+	return &processManager{processes: make(map[string]*managedProcess)}
+}
+
+func (m *processManager) add(proc *managedProcess) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.processes[proc.ID] = proc
+}
+
+func (m *processManager) get(id string) (*managedProcess, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	proc, ok := m.processes[id]
+	return proc, ok
+}
+
+func (m *processManager) list() []processInfo {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]processInfo, 0, len(m.processes))
+	for _, proc := range m.processes {
+		out = append(out, proc.info())
+	}
+	return out
+}
+
+func (m *processManager) remove(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.processes, id)
+}
+
+type managedProcess struct {
+	ID       string
+	Tag      string
+	Cmd      []string
+	Cwd      string
+	TTY      bool
+	Started  time.Time
+	cmd      *exec.Cmd
+	terminal processTerminal
+	manager  *processManager
+
+	mu       sync.RWMutex
+	exit     *processExit
+	done     chan struct{}
+	output   *outputHub
+	waitOnce sync.Once
+}
+
+type processTerminal interface {
+	io.Reader
+	io.Writer
+	io.Closer
+}
+
+type processExit struct {
+	ExitCode int    `json:"exitCode"`
+	Exited   bool   `json:"exited"`
+	Status   string `json:"status"`
+	Error    string `json:"error,omitempty"`
+}
+
+type processInfo struct {
+	ID        string       `json:"id"`
+	Tag       string       `json:"tag,omitempty"`
+	PID       int          `json:"pid,omitempty"`
+	Cmd       []string     `json:"cmd"`
+	Cwd       string       `json:"cwd,omitempty"`
+	TTY       bool         `json:"tty"`
+	State     string       `json:"state"`
+	StartedAt string       `json:"startedAt"`
+	Exit      *processExit `json:"exit,omitempty"`
+}
+
+type outputHub struct {
+	mu     sync.RWMutex
+	closed bool
+	subs   map[chan []byte]struct{}
+}
+
+func newOutputHub() *outputHub {
+	return &outputHub{subs: make(map[chan []byte]struct{})}
+}
+
+func (h *outputHub) publish(data []byte) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	if h.closed {
+		return
+	}
+	for sub := range h.subs {
+		payload := append([]byte(nil), data...)
+		select {
+		case sub <- payload:
+		default:
+		}
+	}
+}
+
+func (h *outputHub) subscribe() (chan []byte, func()) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	ch := make(chan []byte, processOutputBuffer)
+	if h.closed {
+		close(ch)
+		return ch, func() {}
+	}
+	h.subs[ch] = struct{}{}
+	return ch, func() {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		if _, ok := h.subs[ch]; ok {
+			delete(h.subs, ch)
+			close(ch)
+		}
+	}
+}
+
+func (h *outputHub) close() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
+	h.closed = true
+	for sub := range h.subs {
+		close(sub)
+		delete(h.subs, sub)
+	}
+}
+
+type startProcessRequest struct {
+	Cmd  []string          `json:"cmd"`
+	Cwd  string            `json:"cwd,omitempty"`
+	Env  map[string]string `json:"env,omitempty"`
+	TTY  bool              `json:"tty,omitempty"`
+	Rows uint16            `json:"rows,omitempty"`
+	Cols uint16            `json:"cols,omitempty"`
+	Tag  string            `json:"tag,omitempty"`
+}
+
+type startProcessResponse struct {
+	Process processInfo `json:"process"`
+}
+
+type listProcessesResponse struct {
+	Processes []processInfo `json:"processes"`
+}
+
+type resizeProcessRequest struct {
+	Rows uint16 `json:"rows"`
+	Cols uint16 `json:"cols"`
+}
+
+type signalProcessRequest struct {
+	Signal string `json:"signal"`
+}
+
+type waitProcessResponse struct {
+	Process processInfo `json:"process"`
+}
+
+type processEvent struct {
+	Type    string       `json:"type"`
+	Process processInfo  `json:"process,omitempty"`
+	Exit    *processExit `json:"exit,omitempty"`
+}
+
+func (s *Server) handleProcesses(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, listProcessesResponse{Processes: s.processes.list()})
+	case http.MethodPost:
+		s.handleStartProcess(w, r)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleStartProcess(w http.ResponseWriter, r *http.Request) {
+	var req startProcessRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid process request body", http.StatusBadRequest)
+		return
+	}
+	if len(req.Cmd) == 0 || req.Cmd[0] == "" {
+		http.Error(w, "cmd is required", http.StatusBadRequest)
+		return
+	}
+
+	env := make([]string, 0, len(req.Env))
+	for key, value := range req.Env {
+		env = append(env, key+"="+value)
+	}
+
+	id, err := newProcessID()
+	if err != nil {
+		http.Error(w, "generate process id failed", http.StatusInternalServerError)
+		return
+	}
+
+	cmd, terminal, err := startPTYProcess(req.Cmd[0], req.Cmd[1:], req.Cwd, env, req.Cols, req.Rows)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	proc := &managedProcess{
+		ID:       id,
+		Tag:      req.Tag,
+		Cmd:      append([]string(nil), req.Cmd...),
+		Cwd:      req.Cwd,
+		TTY:      true,
+		Started:  time.Now().UTC(),
+		cmd:      cmd,
+		terminal: terminal,
+		manager:  s.processes,
+		done:     make(chan struct{}),
+		output:   newOutputHub(),
+	}
+	s.processes.add(proc)
+	proc.start()
+
+	writeJSON(w, http.StatusCreated, startProcessResponse{Process: proc.info()})
+}
+
+func (s *Server) handleProcess(w http.ResponseWriter, r *http.Request) {
+	id, action, ok := parseProcessPath(r.URL.Path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	if action == "connect" {
+		websocket.Server{
+			Handler:   websocket.Handler(s.handleProcessConnect),
+			Handshake: acceptWebSocket,
+		}.ServeHTTP(w, r)
+		return
+	}
+	proc, exists := s.processes.get(id)
+	if !exists {
+		http.Error(w, "process not found", http.StatusNotFound)
+		return
+	}
+
+	switch action {
+	case "resize":
+		s.handleResizeProcess(w, r, proc)
+	case "signal":
+		s.handleSignalProcess(w, r, proc)
+	case "wait":
+		s.handleWaitProcess(w, r, proc)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *Server) handleProcessConnect(ws *websocket.Conn) {
+	id, action, ok := parseProcessPath(ws.Request().URL.Path)
+	if !ok || action != "connect" {
+		_ = websocket.Message.Send(ws, []byte("unsupported process websocket route"))
+		wsutil.CloseWebSocket(ws)
+		return
+	}
+	proc, exists := s.processes.get(id)
+	if !exists {
+		_ = websocket.Message.Send(ws, []byte("process not found"))
+		wsutil.CloseWebSocket(ws)
+		return
+	}
+	defer wsutil.CloseWebSocket(ws)
+
+	if err := websocket.JSON.Send(ws, processEvent{Type: "start", Process: proc.info()}); err != nil {
+		return
+	}
+
+	output, cancel := proc.output.subscribe()
+	defer cancel()
+
+	errCh := make(chan error, 2)
+	go func() {
+		errCh <- proc.copyWebSocketInput(ws)
+	}()
+	go func() {
+		errCh <- copyProcessOutput(ws, output, proc.done, proc)
+	}()
+
+	if err := <-errCh; err != nil && !errors.Is(err, io.EOF) {
+		s.logger.Warn("process websocket closed with error", "process_id", id, "error", err)
+	}
+}
+
+func (s *Server) handleResizeProcess(w http.ResponseWriter, r *http.Request, proc *managedProcess) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	var req resizeProcessRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid resize request body", http.StatusBadRequest)
+		return
+	}
+	if err := resizePTY(proc.terminal, req.Cols, req.Rows); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleSignalProcess(w http.ResponseWriter, r *http.Request, proc *managedProcess) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	var req signalProcessRequest
+	_ = json.NewDecoder(r.Body).Decode(&req)
+	sig := syscall.SIGTERM
+	switch req.Signal {
+	case "SIGKILL", "KILL", "9":
+		sig = syscall.SIGKILL
+	case "SIGINT", "INT", "2":
+		sig = syscall.SIGINT
+	case "SIGHUP", "HUP", "1":
+		sig = syscall.SIGHUP
+	}
+	if proc.cmd.Process == nil {
+		http.Error(w, "process is not running", http.StatusConflict)
+		return
+	}
+	if err := proc.cmd.Process.Signal(sig); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleWaitProcess(w http.ResponseWriter, r *http.Request, proc *managedProcess) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	<-proc.done
+	writeJSON(w, http.StatusOK, waitProcessResponse{Process: proc.info()})
+}
+
+func (p *managedProcess) start() {
+	go func() {
+		buf := make([]byte, 32*1024)
+		for {
+			n, err := p.terminal.Read(buf)
+			if n > 0 {
+				p.output.publish(buf[:n])
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	go func() {
+		err := p.cmd.Wait()
+		exit := processExit{ExitCode: 0, Exited: true}
+		if p.cmd.ProcessState != nil {
+			exit.ExitCode = p.cmd.ProcessState.ExitCode()
+			exit.Exited = p.cmd.ProcessState.Exited()
+			exit.Status = p.cmd.ProcessState.String()
+		}
+		if err != nil {
+			exit.Error = err.Error()
+		}
+		p.mu.Lock()
+		p.exit = &exit
+		p.mu.Unlock()
+		_ = p.terminal.Close()
+		p.output.close()
+		close(p.done)
+		time.AfterFunc(5*time.Minute, func() {
+			p.manager.remove(p.ID)
+		})
+	}()
+}
+
+func (p *managedProcess) copyWebSocketInput(ws *websocket.Conn) error {
+	var payload []byte
+	for {
+		if err := websocket.Message.Receive(ws, &payload); err != nil {
+			if wsutil.IsCloseErr(err) {
+				return nil
+			}
+			return err
+		}
+		if len(payload) == 0 {
+			continue
+		}
+		if _, err := p.terminal.Write(payload); err != nil {
+			if wsutil.IsCloseErr(err) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+func copyProcessOutput(ws *websocket.Conn, output <-chan []byte, done <-chan struct{}, proc *managedProcess) error {
+	for {
+		select {
+		case payload, ok := <-output:
+			if !ok {
+				return websocket.JSON.Send(ws, processEvent{Type: "end", Exit: proc.exitInfo()})
+			}
+			if err := websocket.Message.Send(ws, payload); err != nil {
+				if wsutil.IsCloseErr(err) {
+					return nil
+				}
+				return err
+			}
+		case <-done:
+			return websocket.JSON.Send(ws, processEvent{Type: "end", Exit: proc.exitInfo()})
+		}
+	}
+}
+
+func (p *managedProcess) info() processInfo {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	state := "running"
+	var exit *processExit
+	if p.exit != nil {
+		state = "exited"
+		copyExit := *p.exit
+		exit = &copyExit
+	}
+	pid := 0
+	if p.cmd.Process != nil {
+		pid = p.cmd.Process.Pid
+	}
+	return processInfo{
+		ID:        p.ID,
+		Tag:       p.Tag,
+		PID:       pid,
+		Cmd:       append([]string(nil), p.Cmd...),
+		Cwd:       p.Cwd,
+		TTY:       p.TTY,
+		State:     state,
+		StartedAt: p.Started.Format(time.RFC3339Nano),
+		Exit:      exit,
+	}
+}
+
+func (p *managedProcess) exitInfo() *processExit {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.exit == nil {
+		return nil
+	}
+	out := *p.exit
+	return &out
+}
+
+func parseProcessPath(path string) (string, string, bool) {
+	const prefix = "/processes/"
+	if len(path) <= len(prefix) || path[:len(prefix)] != prefix {
+		return "", "", false
+	}
+	rest := path[len(prefix):]
+	slash := -1
+	for i := range rest {
+		if rest[i] == '/' {
+			slash = i
+			break
+		}
+	}
+	if slash <= 0 || slash == len(rest)-1 {
+		return "", "", false
+	}
+	return rest[:slash], rest[slash+1:], true
+}
+
+func newProcessID() (string, error) {
+	var raw [10]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	return "prc-" + hex.EncodeToString(raw[:]), nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/internal/boxd/server/pty_linux.go
+++ b/internal/boxd/server/pty_linux.go
@@ -1,0 +1,91 @@
+//go:build linux
+
+package server
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func startShellProcess(shellPath string, cols uint16, rows uint16) (*exec.Cmd, *os.File, error) {
+	if shellPath == "" {
+		shellPath = "/bin/sh"
+	}
+	return startPTYProcess(shellPath, nil, "", nil, cols, rows)
+}
+
+func startPTYProcess(cmdPath string, args []string, cwd string, env []string, cols uint16, rows uint16) (*exec.Cmd, *os.File, error) {
+	if cmdPath == "" {
+		cmdPath = "/bin/sh"
+	}
+	ptm, err := os.OpenFile("/dev/ptmx", os.O_RDWR|unix.O_NOCTTY, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open pty master: %w", err)
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = ptm.Close()
+		}
+	}()
+
+	if err := unix.IoctlSetPointerInt(int(ptm.Fd()), unix.TIOCSPTLCK, 0); err != nil {
+		return nil, nil, fmt.Errorf("unlock pty: %w", err)
+	}
+	ptyNum, err := unix.IoctlGetInt(int(ptm.Fd()), unix.TIOCGPTN)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get pty number: %w", err)
+	}
+	ptsPath := fmt.Sprintf("/dev/pts/%d", ptyNum)
+	pts, err := os.OpenFile(ptsPath, os.O_RDWR|unix.O_NOCTTY, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open pty slave %s: %w", ptsPath, err)
+	}
+	defer pts.Close()
+
+	if cols == 0 {
+		cols = 80
+	}
+	if rows == 0 {
+		rows = 24
+	}
+	_ = unix.IoctlSetWinsize(int(ptm.Fd()), unix.TIOCSWINSZ, &unix.Winsize{Col: cols, Row: rows})
+
+	cmd := exec.Command(cmdPath, args...)
+	cmd.Env = append(os.Environ(), env...)
+	cmd.Env = append(cmd.Env, "TERM=xterm-256color")
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+	cmd.Stdin = pts
+	cmd.Stdout = pts
+	cmd.Stderr = pts
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true, Setctty: true, Ctty: 0}
+	if err := cmd.Start(); err != nil {
+		return nil, nil, fmt.Errorf("start shell: %w", err)
+	}
+
+	cleanup = false
+	return cmd, ptm, nil
+}
+
+func resizePTY(terminal processTerminal, cols uint16, rows uint16) error {
+	if terminal == nil {
+		return fmt.Errorf("pty is not assigned")
+	}
+	file, ok := terminal.(*os.File)
+	if !ok {
+		return fmt.Errorf("pty terminal has unsupported type")
+	}
+	if cols == 0 {
+		cols = 80
+	}
+	if rows == 0 {
+		rows = 24
+	}
+	return unix.IoctlSetWinsize(int(file.Fd()), unix.TIOCSWINSZ, &unix.Winsize{Col: cols, Row: rows})
+}

--- a/internal/boxd/server/pty_unsupported.go
+++ b/internal/boxd/server/pty_unsupported.go
@@ -1,0 +1,69 @@
+//go:build !linux
+
+package server
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
+type processPipe struct {
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+}
+
+func startShellProcess(shellPath string, cols uint16, rows uint16) (*exec.Cmd, *processPipe, error) {
+	if shellPath == "" {
+		shellPath = "/bin/sh"
+	}
+	return startPTYProcess(shellPath, nil, "", nil, cols, rows)
+}
+
+func startPTYProcess(cmdPath string, args []string, cwd string, env []string, cols uint16, rows uint16) (*exec.Cmd, *processPipe, error) {
+	if cmdPath == "" {
+		cmdPath = "/bin/sh"
+	}
+	cmd := exec.Command(cmdPath, args...)
+	cmd.Env = append(os.Environ(), env...)
+	cmd.Env = append(cmd.Env, "TERM=xterm-256color")
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, nil, fmt.Errorf("open shell stdin: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, nil, fmt.Errorf("open shell stdout: %w", err)
+	}
+	cmd.Stderr = cmd.Stdout
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		return nil, nil, fmt.Errorf("start shell: %w", err)
+	}
+	return cmd, &processPipe{stdin: stdin, stdout: stdout}, nil
+}
+
+func resizePTY(terminal processTerminal, cols uint16, rows uint16) error {
+	if terminal == nil {
+		return fmt.Errorf("pty is not assigned")
+	}
+	return nil
+}
+
+func (p *processPipe) Read(data []byte) (int, error) {
+	return p.stdout.Read(data)
+}
+
+func (p *processPipe) Write(data []byte) (int, error) {
+	return p.stdin.Write(data)
+}
+
+func (p *processPipe) Close() error {
+	_ = p.stdin.Close()
+	return p.stdout.Close()
+}

--- a/internal/boxd/server/server.go
+++ b/internal/boxd/server/server.go
@@ -5,32 +5,52 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"time"
 
 	"github.com/novitalabs/NovitaBox/internal/config"
 	"github.com/novitalabs/NovitaBox/internal/log"
+	"github.com/novitalabs/NovitaBox/internal/wsutil"
+	"golang.org/x/net/websocket"
 )
 
 type Server struct {
 	cfg        config.Config
 	logger     *log.Logger
 	httpServer *http.Server
+	processes  *processManager
 }
 
 func New(cfg config.Config, logger *log.Logger) *Server {
-	s := &Server{cfg: cfg, logger: logger}
+	s := &Server{cfg: cfg, logger: logger, processes: newProcessManager()}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", s.handleHealthz)
 	mux.HandleFunc("/exec", s.handleExec)
+	mux.HandleFunc("/processes", s.handleProcesses)
+	mux.HandleFunc("/processes/", s.handleProcess)
+	mux.Handle("/shell", websocket.Server{
+		Handler:   websocket.Handler(s.handleShell),
+		Handshake: acceptWebSocket,
+	})
 	s.httpServer = &http.Server{
 		Addr:              cfg.Boxd.Addr,
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	return s
+}
+
+func acceptWebSocket(config *websocket.Config, req *http.Request) error {
+	origin, err := websocket.Origin(config, req)
+	if err != nil {
+		return err
+	}
+	config.Origin = origin
+	return nil
 }
 
 func (s *Server) Start(ctx context.Context) error {
@@ -139,4 +159,50 @@ func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
 		Stdout:   stdout.String(),
 		Stderr:   stderr.String(),
 	})
+}
+
+func (s *Server) handleShell(ws *websocket.Conn) {
+	shellPath := ws.Request().URL.Query().Get("cmd")
+	cols := parseUint16(ws.Request().URL.Query().Get("cols"), 80)
+	rows := parseUint16(ws.Request().URL.Query().Get("rows"), 24)
+
+	cmd, terminal, err := startShellProcess(shellPath, cols, rows)
+	if err != nil {
+		s.logger.Error("start shell failed", "error", err)
+		_ = websocket.Message.Send(ws, []byte(err.Error()))
+		wsutil.CloseWebSocket(ws)
+		return
+	}
+	defer func() {
+		_ = terminal.Close()
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+		wsutil.CloseWebSocket(ws)
+	}()
+
+	errCh := make(chan error, 2)
+	go func() {
+		errCh <- wsutil.CopyWebSocketToWriter(terminal, ws)
+	}()
+	go func() {
+		errCh <- wsutil.CopyReaderToWebSocket(ws, terminal)
+	}()
+
+	err = <-errCh
+	if err != nil && !errors.Is(err, io.EOF) {
+		s.logger.Warn("shell stream closed with error", "error", err)
+	}
+}
+
+func parseUint16(raw string, fallback uint16) uint16 {
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.ParseUint(raw, 10, 16)
+	if err != nil || value == 0 {
+		return fallback
+	}
+	return uint16(value)
 }

--- a/internal/boxlet/server/artifact_test.go
+++ b/internal/boxlet/server/artifact_test.go
@@ -19,6 +19,20 @@ import (
 	"github.com/novitalabs/NovitaBox/internal/storage/store/sqlite"
 )
 
+func configureStubTemplateBuild(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	cfg.Boxshim.RuntimeDriver = "stub"
+	cfg.Template.KernelPath = filepath.Join(cfg.RootDir, "vmlinux.bin")
+	cfg.Template.BoxdBinaryPath = filepath.Join(cfg.RootDir, "boxd")
+	cfg.Template.AgentWaitSecs = 1
+	if err := os.WriteFile(cfg.Template.KernelPath, []byte("kernel"), 0o644); err != nil {
+		t.Fatalf("write kernel: %v", err)
+	}
+	if err := os.WriteFile(cfg.Template.BoxdBinaryPath, []byte("boxd"), 0o755); err != nil {
+		t.Fatalf("write boxd: %v", err)
+	}
+}
+
 func TestArtifactServiceCreateTemplateFromLocalRootfs(t *testing.T) {
 	root := t.TempDir()
 	source := filepath.Join(root, "source-rootfs.ext4")
@@ -34,6 +48,7 @@ func TestArtifactServiceCreateTemplateFromLocalRootfs(t *testing.T) {
 
 	cfg := config.Default()
 	cfg.RootDir = root
+	configureStubTemplateBuild(t, &cfg)
 	svc := newArtifactService(cfg, log.NewNop(), st)
 
 	info, err := svc.CreateTemplate(context.Background(), &novitaboxv1.CreateTemplateRequest{
@@ -102,7 +117,6 @@ func TestArtifactServiceCreateTemplateSnapshotRequiresKernel(t *testing.T) {
 
 	cfg := config.Default()
 	cfg.RootDir = root
-	cfg.Template.SnapshotEnabled = true
 	svc := newArtifactService(cfg, log.NewNop(), st)
 
 	_, err = svc.CreateTemplate(context.Background(), &novitaboxv1.CreateTemplateRequest{
@@ -129,6 +143,7 @@ func TestArtifactServiceTemplateCRUD(t *testing.T) {
 
 	cfg := config.Default()
 	cfg.RootDir = root
+	configureStubTemplateBuild(t, &cfg)
 	svc := newArtifactService(cfg, log.NewNop(), st)
 
 	if _, err := svc.CreateTemplate(context.Background(), &novitaboxv1.CreateTemplateRequest{
@@ -216,6 +231,42 @@ func TestArtifactServiceImageCRUD(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(root, "images", "img-crud")); !os.IsNotExist(err) {
 		t.Fatalf("image dir stat error = %v, want not exist", err)
+	}
+}
+
+func TestArtifactServiceCreateImageGeneratesID(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source-rootfs.ext4")
+	if err := os.WriteFile(source, []byte("rootfs"), 0o644); err != nil {
+		t.Fatalf("write source rootfs: %v", err)
+	}
+
+	st, err := sqlite.Open(context.Background(), filepath.Join(root, "novitabox.db"))
+	if err != nil {
+		t.Fatalf("open sqlite store: %v", err)
+	}
+	defer st.Close()
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	svc := newArtifactService(cfg, log.NewNop(), st)
+
+	got, err := svc.CreateImage(context.Background(), &novitaboxv1.CreateImageRequest{
+		DockerImage: source,
+	})
+	if err != nil {
+		t.Fatalf("CreateImage() error = %v", err)
+	}
+	if !strings.HasPrefix(got.GetImageId(), "img-") {
+		t.Fatalf("imageID = %q, want generated img-* id", got.GetImageId())
+	}
+	suffix := strings.TrimPrefix(got.GetImageId(), "img-")
+	if len(suffix) != 20 {
+		t.Fatalf("imageID suffix length = %d, want 20", len(suffix))
+	}
+	wantRootfs := filepath.Join(root, "images", got.GetImageId(), "rootfs.ext4")
+	if got.GetRootfsPath() != wantRootfs {
+		t.Fatalf("rootfs path = %q, want %q", got.GetRootfsPath(), wantRootfs)
 	}
 }
 

--- a/internal/boxlet/server/network.go
+++ b/internal/boxlet/server/network.go
@@ -140,7 +140,7 @@ func (m sandboxNetworkManager) Ensure(ctx context.Context, spec *novitaboxv1.Net
 		return fmt.Errorf("configure namespace default route: %w", err)
 	}
 
-	if err := runCommand(ctx, "ip", "route", "replace", spec.GetHostAccessIp()+"/32", "via", veth.peerIP); err != nil {
+	if err := runCommand(ctx, "ip", "route", "replace", spec.GetHostAccessIp()+"/32", "via", veth.peerIP, "dev", hostVeth); err != nil {
 		return fmt.Errorf("configure host access route: %w", err)
 	}
 	if err := ensureNAT(ctx, spec); err != nil {

--- a/internal/boxlet/server/server_test.go
+++ b/internal/boxlet/server/server_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"net"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/novitalabs/NovitaBox/internal/config"
 	"github.com/novitalabs/NovitaBox/internal/log"
 	novitaboxv1 "github.com/novitalabs/NovitaBox/internal/pb/novitabox/v1"
+	"github.com/novitalabs/NovitaBox/internal/sandbox"
+	"github.com/novitalabs/NovitaBox/internal/storage/store"
 	"github.com/novitalabs/NovitaBox/internal/storage/store/sqlite"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
@@ -20,7 +23,7 @@ func TestNodeService(t *testing.T) {
 	listener := bufconn.Listen(bufSize)
 	cfg := config.Default()
 	cfg.RootDir = t.TempDir()
-	st, err := sqlite.Open(context.Background(), filepath.Join(cfg.RootDir, "novitabox.db"))
+	st, err := sqlite.Open(context.Background(), filepath.Join(cfg.RootDir, "db", "novitabox.db"))
 	if err != nil {
 		t.Fatalf("open sqlite store: %v", err)
 	}
@@ -62,6 +65,45 @@ func TestNodeService(t *testing.T) {
 	}
 	if len(runtimes.GetRuntimes()) != 2 {
 		t.Fatalf("expected 2 runtimes, got %d", len(runtimes.GetRuntimes()))
+	}
+}
+
+func TestSandboxRuntimeSpecUsesBoxdInit(t *testing.T) {
+	cfg := config.Default()
+	cfg.RootDir = t.TempDir()
+	svc := newSandboxService(cfg, log.NewNop(), nil)
+
+	spec := svc.runtimeSpecForSandbox(store.SandboxRecord{
+		ID:          "sbx-test",
+		State:       sandbox.StateRunning,
+		RuntimeType: "firecracker",
+		TemplateID:  "tpl-test",
+	})
+
+	args := strings.Join(spec.GetKernel().GetKernelArgs(), " ")
+	if !strings.Contains(args, "init=/novitabox/init") {
+		t.Fatalf("kernel args = %q, want init=/novitabox/init", args)
+	}
+}
+
+func TestCompleteRuntimeSpecFillsBoxdInit(t *testing.T) {
+	cfg := config.Default()
+	cfg.RootDir = t.TempDir()
+	svc := newSandboxService(cfg, log.NewNop(), nil)
+
+	spec := svc.completeRuntimeSpec(store.SandboxRecord{
+		ID:          "sbx-test",
+		State:       sandbox.StateRunning,
+		RuntimeType: "firecracker",
+		TemplateID:  "tpl-test",
+	}, &novitaboxv1.RuntimeSpec{
+		SandboxId:   "sbx-test",
+		RuntimeType: novitaboxv1.RuntimeType_RUNTIME_TYPE_FIRECRACKER,
+	})
+
+	args := strings.Join(spec.GetKernel().GetKernelArgs(), " ")
+	if !strings.Contains(args, "init=/novitabox/init") {
+		t.Fatalf("kernel args = %q, want init=/novitabox/init", args)
 	}
 }
 

--- a/internal/boxlet/server/services.go
+++ b/internal/boxlet/server/services.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -238,9 +240,13 @@ func (s *sandboxService) KillSandbox(ctx context.Context, req *novitaboxv1.KillS
 	if err := s.setSandboxState(ctx, record.ID, sandbox.StateKilling, "kill"); err != nil {
 		return nil, err
 	}
+	sandboxDir := layout.New(s.cfg.RootDir).SandboxDir(record.ID)
 	if shim, closeShim, err := s.dialSandboxShim(ctx, record.ID); err == nil {
 		_, _ = shim.KillRuntime(ctx, &novitaboxv1.KillRuntimeRequest{SandboxId: record.ID})
 		_ = closeShim()
+	}
+	if err := terminateShimProcess(sandboxDir, 5*time.Second); err != nil {
+		s.logger.Warn("terminate sandbox shim failed", "sandbox_id", record.ID, "error", err)
 	}
 	if err := s.setSandboxState(ctx, record.ID, sandbox.StateKilled, "kill"); err != nil {
 		return nil, err
@@ -251,7 +257,7 @@ func (s *sandboxService) KillSandbox(ctx context.Context, req *novitaboxv1.KillS
 	if err := s.store.DeleteSandbox(ctx, record.ID); err != nil {
 		return nil, err
 	}
-	if err := os.RemoveAll(layout.New(s.cfg.RootDir).SandboxDir(record.ID)); err != nil {
+	if err := os.RemoveAll(sandboxDir); err != nil {
 		return nil, fmt.Errorf("remove sandbox directory: %w", err)
 	}
 	if err := newSandboxNetworkManager(s.cfg).Cleanup(ctx, record.ID); err != nil {
@@ -405,7 +411,7 @@ func (s *sandboxService) runtimeSpecForSandbox(record store.SandboxRecord) *novi
 		},
 		Kernel: &novitaboxv1.KernelSpec{
 			KernelPath: paths.KernelPath,
-			KernelArgs: s.cfg.Template.KernelArgs,
+			KernelArgs: templateKernelArgs(s.cfg.Template.KernelArgs),
 		},
 		Rootfs: &novitaboxv1.RootfsSpec{
 			Path:   paths.RootfsPath,
@@ -438,6 +444,9 @@ func (s *sandboxService) completeRuntimeSpec(record store.SandboxRecord, spec *n
 	}
 	if spec.Kernel.KernelPath == "" {
 		spec.Kernel.KernelPath = paths.KernelPath
+	}
+	if len(spec.Kernel.KernelArgs) == 0 {
+		spec.Kernel.KernelArgs = templateKernelArgs(s.cfg.Template.KernelArgs)
 	}
 	if spec.Rootfs == nil {
 		spec.Rootfs = &novitaboxv1.RootfsSpec{
@@ -555,6 +564,51 @@ func ensureShim(ctx context.Context, cfg config.Config, socketPath string) error
 		return fmt.Errorf("wait for boxshim %q ready: %w", socketPath, err)
 	}
 	return nil
+}
+
+func terminateShimProcess(sandboxDir string, timeout time.Duration) error {
+	pidPath := filepath.Join(sandboxDir, "shim.pid")
+	raw, err := os.ReadFile(pidPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read shim pid: %w", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || pid <= 0 {
+		return fmt.Errorf("parse shim pid %q: %w", strings.TrimSpace(string(raw)), err)
+	}
+
+	if waitProcessGone(pid, timeout) {
+		return nil
+	}
+	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+		if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return fmt.Errorf("terminate shim pid %d: %w", pid, err)
+	}
+	if waitProcessGone(pid, timeout) {
+		return nil
+	}
+	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("kill shim pid %d: %w", pid, err)
+	}
+	return nil
+}
+
+func waitProcessGone(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if err := syscall.Kill(pid, 0); err != nil {
+			return errors.Is(err, syscall.ESRCH)
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 }
 
 func resolveShimBinary(path string) (string, error) {
@@ -754,7 +808,6 @@ func (s *artifactService) CreateTemplate(ctx context.Context, req *novitaboxv1.C
 		"from_template", req.GetFromTemplate(),
 		"image_id", req.GetImageId(),
 		"sandbox_id", req.GetSandboxId(),
-		"snapshot_enabled", s.cfg.Template.SnapshotEnabled,
 	)
 
 	l := layout.New(s.cfg.RootDir)
@@ -770,24 +823,15 @@ func (s *artifactService) CreateTemplate(ctx context.Context, req *novitaboxv1.C
 		return nil, err
 	}
 
-	if s.cfg.Template.SnapshotEnabled {
-		s.logger.Info("injecting boxd into template rootfs", "template_id", templateID, "boxd_bin", s.cfg.Template.BoxdBinaryPath)
-		if err := s.injectTemplateBoxd(ctx, paths.RootfsPath); err != nil {
-			s.logger.Error("inject boxd into template rootfs failed", "template_id", templateID, "error", err)
-			return nil, err
-		}
-		s.logger.Info("creating template snapshot", "template_id", templateID, "memfile_path", paths.MemfilePath, "snapfile_path", paths.SnapfilePath)
-		if err := s.createTemplateSnapshot(ctx, req, templateID, paths); err != nil {
-			s.logger.Error("create template snapshot failed", "template_id", templateID, "error", err)
-			return nil, err
-		}
-	} else {
-		if err := ensureFile(paths.MemfilePath); err != nil {
-			return nil, fmt.Errorf("create template memfile placeholder: %w", err)
-		}
-		if err := ensureFile(paths.SnapfilePath); err != nil {
-			return nil, fmt.Errorf("create template snapfile placeholder: %w", err)
-		}
+	s.logger.Info("injecting boxd into template rootfs", "template_id", templateID, "boxd_bin", s.cfg.Template.BoxdBinaryPath)
+	if err := s.injectTemplateBoxd(ctx, paths.RootfsPath); err != nil {
+		s.logger.Error("inject boxd into template rootfs failed", "template_id", templateID, "error", err)
+		return nil, err
+	}
+	s.logger.Info("creating template snapshot", "template_id", templateID, "memfile_path", paths.MemfilePath, "snapfile_path", paths.SnapfilePath)
+	if err := s.createTemplateSnapshot(ctx, req, templateID, paths); err != nil {
+		s.logger.Error("create template snapshot failed", "template_id", templateID, "error", err)
+		return nil, err
 	}
 
 	record := store.TemplateRecord{
@@ -814,6 +858,9 @@ func (s *artifactService) CreateTemplate(ctx context.Context, req *novitaboxv1.C
 }
 
 func (s *artifactService) injectTemplateBoxd(ctx context.Context, rootfsPath string) error {
+	if strings.EqualFold(s.cfg.Boxshim.RuntimeDriver, "stub") {
+		return nil
+	}
 	if s.cfg.Template.BoxdBinaryPath == "" {
 		return nil
 	}
@@ -856,6 +903,8 @@ func templateBoxdInitScript(boxdPath string, listenAddr string) string {
 mount -t proc proc /proc 2>/dev/null || true
 mount -t sysfs sysfs /sys 2>/dev/null || true
 mount -t devtmpfs devtmpfs /dev 2>/dev/null || true
+mkdir -p /dev/pts 2>/dev/null || true
+mount -t devpts devpts /dev/pts 2>/dev/null || true
 exec ` + boxdPath + ` --addr ` + listenAddr + `
 `
 }
@@ -879,6 +928,15 @@ func (s *artifactService) createTemplateSnapshot(ctx context.Context, req *novit
 	if s.cfg.Template.KernelPath == "" {
 		return errors.New("template snapshot build requires --template-kernel")
 	}
+	if strings.EqualFold(s.cfg.Boxshim.RuntimeDriver, "stub") {
+		if err := ensureFile(paths.MemfilePath); err != nil {
+			return fmt.Errorf("create template memfile placeholder: %w", err)
+		}
+		if err := ensureFile(paths.SnapfilePath); err != nil {
+			return fmt.Errorf("create template snapfile placeholder: %w", err)
+		}
+		return nil
+	}
 
 	buildID := "template-build-" + templateID
 	buildDir := filepath.Join(layout.New(s.cfg.RootDir).SandboxDir(buildID))
@@ -887,9 +945,7 @@ func (s *artifactService) createTemplateSnapshot(ctx context.Context, req *novit
 	}
 
 	shimSocket := filepath.Join(buildDir, "shim.sock")
-	shimCfg := s.cfg
-	shimCfg.Boxshim.RuntimeDriver = "firecracker"
-	if err := ensureShim(ctx, shimCfg, shimSocket); err != nil {
+	if err := ensureShim(ctx, s.cfg, shimSocket); err != nil {
 		return fmt.Errorf("start template build shim: %w", err)
 	}
 
@@ -901,7 +957,7 @@ func (s *artifactService) createTemplateSnapshot(ctx context.Context, req *novit
 
 	spec := &novitaboxv1.RuntimeSpec{
 		SandboxId:   buildID,
-		RuntimeType: novitaboxv1.RuntimeType_RUNTIME_TYPE_FIRECRACKER,
+		RuntimeType: runtimeTypeFromRecord(s.cfg.Boxshim.RuntimeDriver),
 		Machine: &novitaboxv1.MachineSpec{
 			Vcpu:     s.cfg.Template.VCPU,
 			MemoryMb: s.cfg.Template.MemoryMB,
@@ -1227,9 +1283,13 @@ func (s *artifactService) DeleteTemplate(ctx context.Context, req *novitaboxv1.D
 }
 
 func (s *artifactService) CreateImage(ctx context.Context, req *novitaboxv1.CreateImageRequest) (*novitaboxv1.ImageInfo, error) {
-	imageID := req.GetImageId()
+	imageID := strings.TrimSpace(req.GetImageId())
 	if imageID == "" {
-		return nil, status.Error(codes.InvalidArgument, "image_id is required")
+		generated, err := newImageID()
+		if err != nil {
+			return nil, fmt.Errorf("generate image id: %w", err)
+		}
+		imageID = generated
 	}
 	if _, err := s.store.GetImage(ctx, imageID); err == nil {
 		return nil, status.Error(codes.AlreadyExists, "image already exists")
@@ -1264,6 +1324,18 @@ func (s *artifactService) CreateImage(ctx context.Context, req *novitaboxv1.Crea
 	}
 
 	return imageRecordToProto(*created), nil
+}
+
+func newImageID() (string, error) {
+	const alphabet = "abcdefghijklmnopqrstuvwxyz1234567890"
+	var b [20]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	for i := range b {
+		b[i] = alphabet[int(b[i])%len(alphabet)]
+	}
+	return "img-" + string(b[:]), nil
 }
 
 func (s *artifactService) materializeImageRootfs(ctx context.Context, req *novitaboxv1.CreateImageRequest, dest string) error {

--- a/internal/boxproxy/server/server.go
+++ b/internal/boxproxy/server/server.go
@@ -2,24 +2,314 @@ package server
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
 
 	"github.com/novitalabs/NovitaBox/internal/config"
 	"github.com/novitalabs/NovitaBox/internal/log"
+	"github.com/novitalabs/NovitaBox/internal/wsutil"
+	"golang.org/x/net/websocket"
 )
 
+const shellPrefix = "/v1/sandboxes/"
+
 type Server struct {
-	cfg    config.Config
-	logger *log.Logger
+	cfg        config.Config
+	logger     *log.Logger
+	httpServer *http.Server
 }
 
 func New(cfg config.Config, logger *log.Logger) *Server {
-	return &Server{cfg: cfg, logger: logger}
+	s := &Server{cfg: cfg, logger: logger}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", s.handleHealthz)
+	mux.HandleFunc(shellPrefix, s.handleSandbox)
+	s.httpServer = &http.Server{
+		Addr:              cfg.BoxProxy.Addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	return s
 }
 
-func (s *Server) Start(ctx context.Context) {
+func acceptWebSocket(config *websocket.Config, req *http.Request) error {
+	origin, err := websocket.Origin(config, req)
+	if err != nil {
+		return err
+	}
+	config.Origin = origin
+	return nil
+}
+
+func (s *Server) Start(ctx context.Context) error {
 	s.logger.Info("starting boxproxy", "addr", s.cfg.BoxProxy.Addr)
+	errCh := make(chan error, 1)
+	go func() {
+		if err := s.httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return s.Stop(context.Background())
+	}
 }
 
-func (s *Server) Stop(ctx context.Context) {
+func (s *Server) Stop(ctx context.Context) error {
+	shutdownCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	if err := s.httpServer.Shutdown(shutdownCtx); err != nil {
+		return err
+	}
+
 	s.logger.Info("stopped boxproxy")
+	return nil
+}
+
+func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status":"ok","service":"boxproxy"}` + "\n"))
+}
+
+func (s *Server) handleSandbox(w http.ResponseWriter, r *http.Request) {
+	sandboxID, rest, ok := parseSandboxPath(r.URL.Path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	if rest == "shell" || isProcessConnectPath(rest) {
+		websocket.Server{
+			Handler:   websocket.Handler(s.handleSandboxWebSocket),
+			Handshake: acceptWebSocket,
+		}.ServeHTTP(w, r)
+		return
+	}
+	if rest == "processes" || strings.HasPrefix(rest, "processes/") {
+		s.proxySandboxHTTP(w, r, sandboxID, rest)
+		return
+	}
+	http.NotFound(w, r)
+}
+
+func (s *Server) handleSandboxWebSocket(client *websocket.Conn) {
+	sandboxID, rest, ok := parseSandboxPath(client.Request().URL.Path)
+	if !ok {
+		_ = websocket.Message.Send(client, []byte("unsupported sandbox websocket route"))
+		wsutil.CloseWebSocket(client)
+		return
+	}
+
+	targetURL, err := s.boxdWebSocketURL(sandboxID, rest, client.Request().URL.Query())
+	if err != nil {
+		s.logger.Error("resolve sandbox websocket target failed", "sandbox_id", sandboxID, "path", rest, "error", err)
+		_ = websocket.Message.Send(client, []byte(err.Error()))
+		wsutil.CloseWebSocket(client)
+		return
+	}
+
+	origin := "http://" + client.Request().Host
+	guest, err := websocket.Dial(targetURL, "", origin)
+	if err != nil {
+		s.logger.Error("connect sandbox websocket failed", "sandbox_id", sandboxID, "target", targetURL, "error", err)
+		_ = websocket.Message.Send(client, []byte(fmt.Sprintf("connect sandbox websocket failed: %v", err)))
+		wsutil.CloseWebSocket(client)
+		return
+	}
+	defer wsutil.CloseWebSocket(guest)
+	defer wsutil.CloseWebSocket(client)
+
+	s.logger.Info("proxying sandbox websocket", "sandbox_id", sandboxID, "target", targetURL)
+	var clientInputTransform func([]byte) []byte
+	if client.Request().URL.Query().Get("lineMode") == "true" {
+		clientInputTransform = wsutil.AppendNewline
+	}
+	errCh := make(chan error, 2)
+	go func() {
+		errCh <- wsutil.CopyWebSocketWithTransform(guest, client, clientInputTransform)
+	}()
+	go func() {
+		errCh <- wsutil.CopyWebSocket(client, guest)
+	}()
+	if err := <-errCh; err != nil {
+		s.logger.Warn("sandbox websocket stream closed with error", "sandbox_id", sandboxID, "error", err)
+	}
+}
+
+func (s *Server) proxySandboxHTTP(w http.ResponseWriter, r *http.Request, sandboxID string, rest string) {
+	target, err := s.boxdHTTPURL(sandboxID, rest, r.URL.RawQuery)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, target, r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	req.Header = r.Header.Clone()
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		s.logger.Error("proxy sandbox http failed", "sandbox_id", sandboxID, "target", target, "error", err)
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	for key, values := range resp.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+func (s *Server) boxdWebSocketURL(sandboxID string, rest string, query url.Values) (string, error) {
+	path, err := boxdPathFromSandboxRest(rest)
+	if err != nil {
+		return "", err
+	}
+	host, err := s.boxdHost(sandboxID)
+	if err != nil {
+		return "", err
+	}
+	out := url.URL{
+		Scheme:   "ws",
+		Host:     host,
+		Path:     path,
+		RawQuery: query.Encode(),
+	}
+	return out.String(), nil
+}
+
+func (s *Server) boxdHTTPURL(sandboxID string, rest string, rawQuery string) (string, error) {
+	path, err := boxdPathFromSandboxRest(rest)
+	if err != nil {
+		return "", err
+	}
+	host, err := s.boxdHost(sandboxID)
+	if err != nil {
+		return "", err
+	}
+	out := url.URL{
+		Scheme:   "http",
+		Host:     host,
+		Path:     path,
+		RawQuery: rawQuery,
+	}
+	return out.String(), nil
+}
+
+func (s *Server) boxdHost(sandboxID string) (string, error) {
+	hostIP, err := hostAccessIP(s.cfg.Network.HostAccessCIDR, s.cfg.Network.VethCIDR, sandboxID)
+	if err != nil {
+		return "", err
+	}
+	_, port, err := net.SplitHostPort(s.cfg.Boxd.Addr)
+	if err != nil {
+		return "", fmt.Errorf("parse boxd address %q: %w", s.cfg.Boxd.Addr, err)
+	}
+	return net.JoinHostPort(hostIP, port), nil
+}
+
+func parseSandboxPath(path string) (string, string, bool) {
+	rest := strings.TrimPrefix(path, shellPrefix)
+	if rest == path {
+		return "", "", false
+	}
+	parts := strings.SplitN(strings.Trim(rest, "/"), "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+func boxdPathFromSandboxRest(rest string) (string, error) {
+	if rest == "shell" {
+		return "/shell", nil
+	}
+	if rest == "processes" {
+		return "/processes", nil
+	}
+	if strings.HasPrefix(rest, "processes/") {
+		return "/" + rest, nil
+	}
+	return "", fmt.Errorf("unsupported sandbox route %q", rest)
+}
+
+func isProcessConnectPath(rest string) bool {
+	if !strings.HasPrefix(rest, "processes/") {
+		return false
+	}
+	parts := strings.Split(strings.Trim(rest, "/"), "/")
+	return len(parts) == 3 && parts[0] == "processes" && parts[1] != "" && parts[2] == "connect"
+}
+
+func hostAccessIP(hostAccessCIDR string, vethCIDR string, sandboxID string) (string, error) {
+	slot, err := networkSlotForSandbox(vethCIDR, sandboxID)
+	if err != nil {
+		return "", err
+	}
+	return indexedIP(hostAccessCIDR, slot)
+}
+
+func networkSlotForSandbox(cidr string, sandboxID string) (uint32, error) {
+	_, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return 0, fmt.Errorf("parse network cidr %q: %w", cidr, err)
+	}
+	ones, bits := network.Mask.Size()
+	if bits != 32 {
+		return 0, fmt.Errorf("network cidr %q must be IPv4", cidr)
+	}
+	totalIPs := uint32(1) << uint(32-ones)
+	totalSlots := totalIPs / 2
+	if totalSlots <= 2 {
+		return 0, fmt.Errorf("network cidr %q is too small for sandbox slots", cidr)
+	}
+	hash := sha1.Sum([]byte(sandboxID))
+	return (binary.BigEndian.Uint32(hash[:4]) % (totalSlots - 2)) + 1, nil
+}
+
+func indexedIP(cidr string, index uint32) (string, error) {
+	_, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", fmt.Errorf("parse cidr %q: %w", cidr, err)
+	}
+	ip4 := network.IP.To4()
+	if ip4 == nil {
+		return "", fmt.Errorf("cidr %q must be IPv4", cidr)
+	}
+	ones, bits := network.Mask.Size()
+	if bits != 32 {
+		return "", fmt.Errorf("cidr %q must be IPv4", cidr)
+	}
+	totalIPs := uint32(1) << uint(32-ones)
+	if index == 0 || index >= totalIPs {
+		return "", fmt.Errorf("ip index %d is outside cidr %q", index, cidr)
+	}
+	base := binary.BigEndian.Uint32(ip4)
+	out := make(net.IP, net.IPv4len)
+	binary.BigEndian.PutUint32(out, base+index)
+	return out.String(), nil
 }

--- a/internal/boxshim/server/server.go
+++ b/internal/boxshim/server/server.go
@@ -24,6 +24,7 @@ type Server struct {
 	logger     *log.Logger
 	grpcServer *grpc.Server
 	runtime    *runtimeService
+	stopOnce   chan struct{}
 }
 
 func New(cfg config.Config, logger *log.Logger) *Server {
@@ -32,8 +33,9 @@ func New(cfg config.Config, logger *log.Logger) *Server {
 		cfg:        cfg,
 		logger:     logger,
 		grpcServer: grpc.NewServer(),
-		runtime:    newRuntimeService(driver),
+		stopOnce:   make(chan struct{}),
 	}
+	s.runtime = newRuntimeService(driver, s.requestStop)
 	novitaboxv1.RegisterBoxShimServer(s.grpcServer, s.runtime)
 	reflection.Register(s.grpcServer)
 
@@ -81,31 +83,47 @@ func (s *Server) Run(ctx context.Context) error {
 			return nil
 		}
 		return err
-	case <-ctx.Done():
-		stopped := make(chan struct{})
-		go func() {
-			s.grpcServer.GracefulStop()
-			close(stopped)
-		}()
-
-		select {
-		case <-stopped:
-		case <-time.After(10 * time.Second):
-			s.grpcServer.Stop()
-		}
-
+	case <-s.stopOnce:
+		s.stopGRPCServer()
 		s.logger.Info("stopped boxshim")
 		return nil
+	case <-ctx.Done():
+		s.stopGRPCServer()
+		s.logger.Info("stopped boxshim")
+		return nil
+	}
+}
+
+func (s *Server) requestStop() {
+	select {
+	case <-s.stopOnce:
+	default:
+		close(s.stopOnce)
+	}
+}
+
+func (s *Server) stopGRPCServer() {
+	stopped := make(chan struct{})
+	go func() {
+		s.grpcServer.GracefulStop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(10 * time.Second):
+		s.grpcServer.Stop()
 	}
 }
 
 type runtimeService struct {
 	novitaboxv1.UnimplementedBoxShimServer
 	driver shimruntime.Driver
+	onKill func()
 }
 
-func newRuntimeService(driver shimruntime.Driver) *runtimeService {
-	return &runtimeService{driver: driver}
+func newRuntimeService(driver shimruntime.Driver, onKill func()) *runtimeService {
+	return &runtimeService{driver: driver, onKill: onKill}
 }
 
 func (s *runtimeService) CreateRuntime(ctx context.Context, req *novitaboxv1.CreateRuntimeRequest) (*novitaboxv1.RuntimeInfo, error) {
@@ -123,6 +141,9 @@ func (s *runtimeService) ResumeRuntime(ctx context.Context, req *novitaboxv1.Res
 func (s *runtimeService) KillRuntime(ctx context.Context, req *novitaboxv1.KillRuntimeRequest) (*emptypb.Empty, error) {
 	if err := s.driver.Kill(ctx, req.GetSandboxId()); err != nil {
 		return nil, err
+	}
+	if s.onKill != nil {
+		go s.onKill()
 	}
 
 	return &emptypb.Empty{}, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,7 +46,6 @@ type NetworkConfig struct {
 type TemplateBuildConfig struct {
 	KernelPath       string
 	KernelArgs       []string
-	SnapshotEnabled  bool
 	SnapshotWaitSecs uint32
 	AgentHealthURL   string
 	AgentExecURL     string
@@ -64,10 +63,10 @@ func Default() Config {
 		BoxAPI:      ServiceConfig{Addr: "127.0.0.1:8080"},
 		Boxlet:      ServiceConfig{Addr: "127.0.0.1:8081"},
 		BoxProxy:    ServiceConfig{Addr: "127.0.0.1:8082"},
-		Boxshim:     ShimConfig{RuntimeDriver: "stub", BinaryPath: "boxshim"},
+		Boxshim:     ShimConfig{RuntimeDriver: "firecracker"},
 		Boxd:        ServiceConfig{Addr: "169.254.0.21:49983"},
 		Storage:     StorageConfig{},
-		Firecracker: FirecrackerConfig{BinaryPath: "firecracker"},
+		Firecracker: FirecrackerConfig{},
 		Network: NetworkConfig{
 			Enabled:        true,
 			HostAccessCIDR: "10.11.0.0/16",
@@ -77,7 +76,6 @@ func Default() Config {
 			GuestMAC:       "02:FC:00:00:00:05",
 		},
 		Template: TemplateBuildConfig{
-			SnapshotEnabled:  false,
 			SnapshotWaitSecs: 3,
 			AgentWaitSecs:    30,
 			BoxdGuestPath:    "/novitabox/boxd",

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net"
+	"path/filepath"
 )
 
 type ServiceOptions struct {
@@ -15,7 +16,6 @@ type ServiceOptions struct {
 	BoxshimBinaryPath     string
 	FirecrackerBinaryPath string
 	TemplateKernelPath    string
-	TemplateSnapshot      bool
 	TemplateSnapshotWait  uint32
 	TemplateAgentHealth   string
 	TemplateAgentExec     string
@@ -35,6 +35,9 @@ func ApplyServiceOptions(defaults Config, name string, opts ServiceOptions) (Con
 	cfg := defaults
 	cfg.RootDir = opts.RootDir
 	cfg.Storage.DBPath = opts.DBPath
+	if cfg.Storage.DBPath == "" {
+		cfg.Storage.DBPath = DefaultDBPath(cfg.RootDir)
+	}
 	if opts.BoxletAddr != "" {
 		cfg.Boxlet.Addr = opts.BoxletAddr
 	}
@@ -44,13 +47,21 @@ func ApplyServiceOptions(defaults Config, name string, opts ServiceOptions) (Con
 	if opts.BoxshimBinaryPath != "" {
 		cfg.Boxshim.BinaryPath = opts.BoxshimBinaryPath
 	}
+	if cfg.Boxshim.BinaryPath == "" {
+		cfg.Boxshim.BinaryPath = DefaultBoxshimBinaryPath(cfg.RootDir)
+	}
 	if opts.FirecrackerBinaryPath != "" {
 		cfg.Firecracker.BinaryPath = opts.FirecrackerBinaryPath
+	}
+	if cfg.Firecracker.BinaryPath == "" {
+		cfg.Firecracker.BinaryPath = DefaultFirecrackerBinaryPath(cfg.RootDir)
 	}
 	if opts.TemplateKernelPath != "" {
 		cfg.Template.KernelPath = opts.TemplateKernelPath
 	}
-	cfg.Template.SnapshotEnabled = opts.TemplateSnapshot
+	if cfg.Template.KernelPath == "" {
+		cfg.Template.KernelPath = DefaultKernelPath(cfg.RootDir)
+	}
 	if opts.TemplateSnapshotWait > 0 {
 		cfg.Template.SnapshotWaitSecs = opts.TemplateSnapshotWait
 	}
@@ -65,6 +76,9 @@ func ApplyServiceOptions(defaults Config, name string, opts ServiceOptions) (Con
 	}
 	if opts.TemplateBoxdBinary != "" {
 		cfg.Template.BoxdBinaryPath = opts.TemplateBoxdBinary
+	}
+	if cfg.Template.BoxdBinaryPath == "" {
+		cfg.Template.BoxdBinaryPath = DefaultBoxdBinaryPath(cfg.RootDir)
 	}
 	if opts.TemplateBoxdGuestPath != "" {
 		cfg.Template.BoxdGuestPath = opts.TemplateBoxdGuestPath
@@ -129,8 +143,34 @@ func ApplyBoxshimOptions(defaults Config, opts BoxshimOptions) Config {
 	cfg.Boxshim.RuntimeDriver = opts.RuntimeDriver
 	cfg.Firecracker.BinaryPath = opts.FirecrackerBinaryPath
 	cfg.Storage.DBPath = opts.DBPath
+	if cfg.Storage.DBPath == "" {
+		cfg.Storage.DBPath = DefaultDBPath(cfg.RootDir)
+	}
+	if cfg.Firecracker.BinaryPath == "" {
+		cfg.Firecracker.BinaryPath = DefaultFirecrackerBinaryPath(cfg.RootDir)
+	}
 
 	return cfg
+}
+
+func DefaultDBPath(rootDir string) string {
+	return filepath.Join(rootDir, "db", "novitabox.db")
+}
+
+func DefaultKernelPath(rootDir string) string {
+	return filepath.Join(rootDir, "vmlinux.bin")
+}
+
+func DefaultBoxdBinaryPath(rootDir string) string {
+	return filepath.Join(rootDir, "boxd")
+}
+
+func DefaultBoxshimBinaryPath(rootDir string) string {
+	return filepath.Join(rootDir, "boxshim")
+}
+
+func DefaultFirecrackerBinaryPath(rootDir string) string {
+	return filepath.Join(rootDir, "firecracker")
 }
 
 func withPort(addr string, port int) (string, error) {

--- a/internal/storage/layout/layout.go
+++ b/internal/storage/layout/layout.go
@@ -1,6 +1,10 @@
 package layout
 
-import "path/filepath"
+import (
+	"path/filepath"
+
+	"github.com/novitalabs/NovitaBox/internal/config"
+)
 
 type Layout struct {
 	root string
@@ -15,7 +19,7 @@ func (l Layout) SandboxDir(sandboxID string) string {
 }
 
 func (l Layout) DBPath() string {
-	return filepath.Join(l.root, "novitabox.db")
+	return config.DefaultDBPath(l.root)
 }
 
 func (l Layout) ImageDir(imageID string) string {

--- a/internal/wsutil/ws.go
+++ b/internal/wsutil/ws.go
@@ -1,0 +1,113 @@
+package wsutil
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"time"
+
+	"golang.org/x/net/websocket"
+)
+
+const binaryFrame = 2
+
+func CopyWebSocketToWriter(dst io.Writer, src *websocket.Conn) error {
+	var payload []byte
+	for {
+		if err := websocket.Message.Receive(src, &payload); err != nil {
+			if isCloseErr(err) {
+				return nil
+			}
+			return err
+		}
+		if len(payload) == 0 {
+			continue
+		}
+		if _, err := dst.Write(payload); err != nil {
+			if isCloseErr(err) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+func CopyReaderToWebSocket(dst *websocket.Conn, src io.Reader) error {
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := src.Read(buf)
+		if n > 0 {
+			if sendErr := websocket.Message.Send(dst, append([]byte(nil), buf[:n]...)); sendErr != nil {
+				if isCloseErr(sendErr) {
+					return nil
+				}
+				return sendErr
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) || isCloseErr(err) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+func CopyWebSocket(dst *websocket.Conn, src *websocket.Conn) error {
+	return CopyWebSocketWithTransform(dst, src, nil)
+}
+
+func CopyWebSocketWithTransform(dst *websocket.Conn, src *websocket.Conn, transform func([]byte) []byte) error {
+	var payload []byte
+	for {
+		if err := websocket.Message.Receive(src, &payload); err != nil {
+			if isCloseErr(err) {
+				return nil
+			}
+			return err
+		}
+		if transform != nil {
+			payload = transform(payload)
+		}
+		if err := websocket.Message.Send(dst, payload); err != nil {
+			if isCloseErr(err) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+func AppendNewline(payload []byte) []byte {
+	if len(payload) == 0 || bytes.HasSuffix(payload, []byte("\n")) || bytes.HasSuffix(payload, []byte("\r")) {
+		return payload
+	}
+	out := make([]byte, 0, len(payload)+1)
+	out = append(out, payload...)
+	out = append(out, '\n')
+	return out
+}
+
+func CloseWebSocket(conn *websocket.Conn) {
+	if conn == nil {
+		return
+	}
+	_ = conn.SetDeadline(time.Now().Add(100 * time.Millisecond))
+	_ = conn.Close()
+}
+
+func IsCloseErr(err error) bool {
+	return isCloseErr(err)
+}
+
+func isCloseErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	var closeErr *websocket.ProtocolError
+	return errors.As(err, &closeErr)
+}


### PR DESCRIPTION
- boxproxy: proxy sandbox shell and process websocket connections

- boxd: add pty-backed shell and managed process APIs

- boxlet: default firecracker paths, generated ids, db layout, and shim cleanup