### PR TITLE
feat: add boxctl management commands and installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ NOVITABOX_GOCACHE := $(CURDIR)/.gocache
 NOVITABOX_GOMODCACHE := $(CURDIR)/.gomodcache
 NOVITABOX_BUF_CACHE_DIR := $(CURDIR)/.bufcache
 
-.PHONY: build build-linux-amd64 test fmt proto tools
+.PHONY: build build-linux-amd64 build-linux-arm64 test fmt proto tools
 
 COMMANDS := boxapi boxctl boxd boxlet boxproxy boxshim
 
@@ -16,6 +16,12 @@ build-linux-amd64:
 	mkdir -p bin/linux-amd64
 	for cmd in $(COMMANDS); do \
 		GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go build -o "bin/linux-amd64/$$cmd" "./cmd/$$cmd"; \
+	done
+
+build-linux-arm64:
+	mkdir -p bin/linux-arm64
+	for cmd in $(COMMANDS); do \
+		GOOS=linux GOARCH=arm64 CGO_ENABLED=0 GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go build -o "bin/linux-arm64/$$cmd" "./cmd/$$cmd"; \
 	done
 
 test:

--- a/cmd/boxctl/main.go
+++ b/cmd/boxctl/main.go
@@ -34,34 +34,516 @@ type processInfo struct {
 	PID int    `json:"pid,omitempty"`
 }
 
-func main() {
-	var proxyAddr string
-	var cwd string
-	var attachStdin bool
-	var tty bool
+type apiClient struct {
+	base string
+}
 
-	cmd := &cobra.Command{
+type templateCreateResponse struct {
+	TemplateID string `json:"templateID"`
+	BuildID    string `json:"buildID"`
+}
+
+func main() {
+	var apiAddr string
+	var proxyAddr string
+
+	root := &cobra.Command{
 		Use:   "boxctl",
 		Short: "NovitaBox command line client",
 	}
-	execCmd := &cobra.Command{
-		Use:   "exec [-it] <sandbox_id> <cmd> [args...]",
-		Short: "Execute a command in a sandbox",
-		Args:  cobra.MinimumNArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runExec(proxyAddr, args[0], args[1:], cwd, attachStdin || tty)
-		},
-	}
-	execCmd.Flags().BoolVarP(&attachStdin, "interactive", "i", false, "attach stdin")
-	execCmd.Flags().BoolVarP(&tty, "tty", "t", false, "allocate a terminal")
-	execCmd.Flags().StringVar(&cwd, "cwd", "", "working directory inside the sandbox")
-	cmd.PersistentFlags().StringVar(&proxyAddr, "proxy", "http://127.0.0.1:8082", "boxproxy base URL")
-	cmd.AddCommand(execCmd)
+	root.PersistentFlags().StringVar(&apiAddr, "api", "http://127.0.0.1:8080", "boxapi base URL")
+	root.PersistentFlags().StringVar(&proxyAddr, "proxy", "http://127.0.0.1:8082", "boxproxy base URL")
 
-	if err := cmd.Execute(); err != nil {
+	root.AddCommand(newSandboxCommand(&apiAddr, &proxyAddr))
+	root.AddCommand(newTemplateCommand(&apiAddr))
+	root.AddCommand(newImageCommand(&apiAddr))
+	root.AddCommand(newRuntimeCommand(&apiAddr))
+	root.AddCommand(newExecCommand(&proxyAddr, "exec [-it] <sandbox_id> <cmd> [args...]", "Execute a command in a sandbox"))
+
+	if err := root.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "boxctl: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func newSandboxCommand(apiAddr *string, proxyAddr *string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sandbox",
+		Short: "Manage sandboxes",
+	}
+
+	var createTemplateID string
+	var createImageID string
+	var createSnapshotID string
+	var createRuntimeType string
+	createCmd := &cobra.Command{
+		Use:   "create [template_id]",
+		Short: "Create a sandbox",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			templateID := createTemplateID
+			if templateID == "" && len(args) > 0 {
+				templateID = args[0]
+			}
+			if templateID == "" && createImageID == "" && createSnapshotID == "" {
+				return fmt.Errorf("template id, image id, or snapshot id is required")
+			}
+			body := map[string]any{
+				"templateID": templateID,
+			}
+			if createImageID != "" {
+				body["image_id"] = createImageID
+			}
+			if createSnapshotID != "" {
+				body["snapshot_id"] = createSnapshotID
+			}
+			if createRuntimeType != "" {
+				body["runtime_type"] = createRuntimeType
+			}
+			return requestAndPrint(*apiAddr, http.MethodPost, "/v1/sandboxes", body)
+		},
+	}
+	createCmd.Flags().StringVar(&createTemplateID, "template", "", "template id")
+	createCmd.Flags().StringVar(&createImageID, "image", "", "image id")
+	createCmd.Flags().StringVar(&createSnapshotID, "snapshot", "", "snapshot id")
+	createCmd.Flags().StringVar(&createRuntimeType, "runtime", "", "runtime type")
+
+	cmd.AddCommand(createCmd)
+	cmd.AddCommand(listAPICommand(apiAddr, "list", "List sandboxes", "/v1/sandboxes"))
+	cmd.AddCommand(simpleAPICommand(apiAddr, "get <sandbox_id>", "Get sandbox information", http.MethodGet, "/v1/sandboxes/%s", 1, nil))
+	cmd.AddCommand(simpleAPICommand(apiAddr, "pause <sandbox_id>", "Pause a sandbox", http.MethodPost, "/v1/sandboxes/%s/pause", 1, map[string]any{}))
+	cmd.AddCommand(simpleAPICommand(apiAddr, "resume <sandbox_id>", "Resume a sandbox", http.MethodPost, "/v1/sandboxes/%s/resume", 1, map[string]any{}))
+	cmd.AddCommand(simpleAPICommand(apiAddr, "poweroff <sandbox_id>", "Power off a sandbox", http.MethodPost, "/v1/sandboxes/%s/poweroff", 1, map[string]any{}))
+	cmd.AddCommand(simpleAPICommand(apiAddr, "poweron <sandbox_id>", "Power on a sandbox", http.MethodPost, "/v1/sandboxes/%s/poweron", 1, map[string]any{}))
+	cmd.AddCommand(simpleAPICommand(apiAddr, "reboot <sandbox_id>", "Reboot a sandbox", http.MethodPost, "/v1/sandboxes/%s/reboot", 1, map[string]any{}))
+
+	deleteCmd := simpleAPICommand(apiAddr, "delete <sandbox_id>", "Delete a sandbox", http.MethodDelete, "/v1/sandboxes/%s", 1, nil)
+	deleteCmd.Aliases = []string{"kill", "rm"}
+	cmd.AddCommand(deleteCmd)
+
+	stopCmd := simpleAPICommand(apiAddr, "stop <sandbox_id>", "Power off a sandbox", http.MethodPost, "/v1/sandboxes/%s/poweroff", 1, map[string]any{})
+	stopCmd.Hidden = true
+	startCmd := simpleAPICommand(apiAddr, "start <sandbox_id>", "Power on a sandbox", http.MethodPost, "/v1/sandboxes/%s/poweron", 1, map[string]any{})
+	startCmd.Hidden = true
+	restartCmd := simpleAPICommand(apiAddr, "restart <sandbox_id>", "Reboot a sandbox", http.MethodPost, "/v1/sandboxes/%s/reboot", 1, map[string]any{})
+	restartCmd.Hidden = true
+	cmd.AddCommand(stopCmd, startCmd, restartCmd)
+
+	cmd.AddCommand(newSandboxExecCommand(proxyAddr))
+	cmd.AddCommand(newShellCommand(proxyAddr))
+
+	return cmd
+}
+
+func newTemplateCommand(apiAddr *string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "template",
+		Short: "Manage templates",
+	}
+
+	cmd.AddCommand(newTemplateCreateCommand(apiAddr))
+	cmd.AddCommand(newTemplateBuildCommand(apiAddr))
+	cmd.AddCommand(listAPICommand(apiAddr, "list", "List templates", "/templates"))
+	cmd.AddCommand(simpleAPICommand(apiAddr, "get <template_id>", "Get template information", http.MethodGet, "/templates/%s", 1, nil))
+	cmd.AddCommand(simpleAPICommand(apiAddr, "status <template_id> <build_id>", "Get template build status", http.MethodGet, "/v2/templates/%s/builds/%s/status", 2, nil))
+	cmd.AddCommand(newTemplateConvertCommand(apiAddr))
+
+	deleteCmd := simpleAPICommand(apiAddr, "delete <template_id>", "Delete a template", http.MethodDelete, "/templates/%s", 1, nil)
+	deleteCmd.Aliases = []string{"rm"}
+	cmd.AddCommand(deleteCmd)
+
+	return cmd
+}
+
+func newTemplateCreateCommand(apiAddr *string) *cobra.Command {
+	var templateID string
+	var cpuCount int32
+	var memoryMB int32
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a template record and build id",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			body := map[string]any{
+				"name": args[0],
+			}
+			if templateID != "" {
+				body["templateID"] = templateID
+			}
+			if cpuCount > 0 {
+				body["cpuCount"] = cpuCount
+			}
+			if memoryMB > 0 {
+				body["memoryMB"] = memoryMB
+			}
+			return requestAndPrint(*apiAddr, http.MethodPost, "/v3/templates", body)
+		},
+	}
+	cmd.Flags().StringVar(&templateID, "template", "", "template id")
+	cmd.Flags().Int32Var(&cpuCount, "cpu", 0, "template CPU count")
+	cmd.Flags().Int32Var(&memoryMB, "memory", 0, "template memory in MB")
+	return cmd
+}
+
+func newTemplateBuildCommand(apiAddr *string) *cobra.Command {
+	var templateID string
+	var cpuCount int32
+	var memoryMB int32
+	var fromImage string
+	var fromTemplate string
+	var startCmd string
+	var readyCmd string
+	var runSteps []string
+	var execSteps []string
+
+	cmd := &cobra.Command{
+		Use:   "build <name>",
+		Short: "Create and build a template",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := apiClient{base: *apiAddr}
+			createBody := map[string]any{
+				"name": args[0],
+			}
+			if templateID != "" {
+				createBody["templateID"] = templateID
+			}
+			if cpuCount > 0 {
+				createBody["cpuCount"] = cpuCount
+			}
+			if memoryMB > 0 {
+				createBody["memoryMB"] = memoryMB
+			}
+
+			createData, err := client.request(http.MethodPost, "/v3/templates", createBody)
+			if err != nil {
+				return err
+			}
+			var createResp templateCreateResponse
+			if err := json.Unmarshal(createData, &createResp); err != nil {
+				return fmt.Errorf("decode template create response: %w", err)
+			}
+			if createResp.TemplateID == "" || createResp.BuildID == "" {
+				return fmt.Errorf("template create response missing templateID or buildID")
+			}
+
+			buildBody := map[string]any{}
+			if fromImage != "" {
+				buildBody["fromImage"] = fromImage
+			}
+			if fromTemplate != "" {
+				buildBody["fromTemplate"] = fromTemplate
+			}
+			if startCmd != "" {
+				buildBody["startCmd"] = startCmd
+			}
+			if readyCmd != "" {
+				buildBody["readyCmd"] = readyCmd
+			}
+			steps := make([]map[string]any, 0, len(runSteps)+len(execSteps))
+			for _, step := range runSteps {
+				steps = append(steps, map[string]any{
+					"type": "RUN",
+					"args": []string{step},
+				})
+			}
+			for _, step := range execSteps {
+				args := strings.Fields(step)
+				if len(args) == 0 {
+					return fmt.Errorf("--exec command cannot be empty")
+				}
+				steps = append(steps, map[string]any{
+					"type": "EXEC",
+					"args": args,
+				})
+			}
+			if len(steps) > 0 {
+				buildBody["steps"] = steps
+			}
+
+			path := fmt.Sprintf("/v2/templates/%s/builds/%s", url.PathEscape(createResp.TemplateID), url.PathEscape(createResp.BuildID))
+			if _, err := client.request(http.MethodPost, path, buildBody); err != nil {
+				return err
+			}
+			return printJSON(map[string]string{
+				"templateID": createResp.TemplateID,
+				"buildID":    createResp.BuildID,
+				"status":     "accepted",
+			})
+		},
+	}
+	cmd.Flags().StringVar(&templateID, "template", "", "template id")
+	cmd.Flags().Int32Var(&cpuCount, "cpu", 0, "template CPU count")
+	cmd.Flags().Int32Var(&memoryMB, "memory", 0, "template memory in MB")
+	cmd.Flags().StringVar(&fromImage, "from-image", "", "source docker image")
+	cmd.Flags().StringVar(&fromTemplate, "from-template", "", "source template id")
+	cmd.Flags().StringVar(&startCmd, "start-cmd", "", "template start command")
+	cmd.Flags().StringVar(&readyCmd, "ready-cmd", "", "template ready command")
+	cmd.Flags().StringArrayVar(&runSteps, "run", nil, "shell build step; can be repeated")
+	cmd.Flags().StringArrayVar(&execSteps, "exec", nil, "exec build step split by whitespace; can be repeated")
+	return cmd
+}
+
+func newTemplateConvertCommand(apiAddr *string) *cobra.Command {
+	var imageID string
+	cmd := &cobra.Command{
+		Use:   "convert <template_id>",
+		Short: "Convert a template to an image",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			body := map[string]any{
+				"templateID": args[0],
+			}
+			if imageID != "" {
+				body["imageID"] = imageID
+			}
+			return requestAndPrint(*apiAddr, http.MethodPost, "/v1/templates/convert", body)
+		},
+	}
+	cmd.Flags().StringVar(&imageID, "image", "", "image id")
+	return cmd
+}
+
+func newImageCommand(apiAddr *string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "image",
+		Short: "Manage images",
+	}
+
+	createCmd := newImageCreateCommand(apiAddr)
+	saveCmd := newImageCreateCommand(apiAddr)
+	saveCmd.Use = "save <template_id>"
+	saveCmd.Short = "Create an image from a template"
+	saveCmd.Hidden = true
+
+	cmd.AddCommand(createCmd, saveCmd)
+	cmd.AddCommand(listAPICommand(apiAddr, "list", "List images", "/v1/images"))
+	cmd.AddCommand(simpleAPICommand(apiAddr, "get <image_id>", "Get image information", http.MethodGet, "/v1/images/%s", 1, nil))
+	deleteCmd := simpleAPICommand(apiAddr, "delete <image_id>", "Delete an image", http.MethodDelete, "/v1/images/%s", 1, nil)
+	deleteCmd.Aliases = []string{"rm"}
+	cmd.AddCommand(deleteCmd)
+
+	return cmd
+}
+
+func newImageCreateCommand(apiAddr *string) *cobra.Command {
+	var imageID string
+	var labels []string
+	cmd := &cobra.Command{
+		Use:   "create <template_id>",
+		Short: "Create an image from a template",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			body := map[string]any{
+				"templateID": args[0],
+			}
+			if imageID != "" {
+				body["imageID"] = imageID
+			}
+			parsedLabels, err := parseKeyValues(labels)
+			if err != nil {
+				return err
+			}
+			if len(parsedLabels) > 0 {
+				body["labels"] = parsedLabels
+			}
+			return requestAndPrint(*apiAddr, http.MethodPost, "/v1/images", body)
+		},
+	}
+	cmd.Flags().StringVar(&imageID, "image", "", "image id")
+	cmd.Flags().StringArrayVar(&labels, "label", nil, "image label in key=value form; can be repeated")
+	return cmd
+}
+
+func newRuntimeCommand(apiAddr *string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "runtime",
+		Short: "Show runtime capabilities",
+	}
+	cmd.AddCommand(listAPICommand(apiAddr, "list", "List runtimes", "/v1/runtimes"))
+	cmd.AddCommand(simpleAPICommand(apiAddr, "show <runtime_type>", "Show runtime information", http.MethodGet, "/v1/runtimes/%s", 1, nil))
+	cmd.AddCommand(simpleAPICommand(apiAddr, "capabilities <runtime_type>", "Show runtime capabilities", http.MethodGet, "/v1/runtimes/%s/capabilities", 1, nil))
+	return cmd
+}
+
+func newSandboxExecCommand(proxyAddr *string) *cobra.Command {
+	return newExecCommand(proxyAddr, "exec [-it] <sandbox_id> <cmd> [args...]", "Execute a command in a sandbox")
+}
+
+func newExecCommand(proxyAddr *string, use string, short string) *cobra.Command {
+	var cwd string
+	var attachStdin bool
+	var tty bool
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runExec(*proxyAddr, args[0], args[1:], cwd, attachStdin || tty)
+		},
+	}
+	cmd.Flags().BoolVarP(&attachStdin, "interactive", "i", false, "attach stdin")
+	cmd.Flags().BoolVarP(&tty, "tty", "t", false, "allocate a terminal")
+	cmd.Flags().StringVar(&cwd, "cwd", "", "working directory inside the sandbox")
+	return cmd
+}
+
+func newShellCommand(proxyAddr *string) *cobra.Command {
+	var shell string
+	var cwd string
+	cmd := &cobra.Command{
+		Use:   "shell <sandbox_id>",
+		Short: "Launch an interactive shell in a sandbox",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runExec(*proxyAddr, args[0], []string{shell}, cwd, true)
+		},
+	}
+	cmd.Flags().StringVar(&shell, "shell", "/bin/sh", "shell executable")
+	cmd.Flags().StringVar(&cwd, "cwd", "", "working directory inside the sandbox")
+	return cmd
+}
+
+func simpleAPICommand(apiAddr *string, use string, short string, method string, pathFormat string, argCount int, body any) *cobra.Command {
+	return &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.ExactArgs(argCount),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pathArgs := make([]any, 0, len(args))
+			for _, arg := range args {
+				pathArgs = append(pathArgs, url.PathEscape(arg))
+			}
+			path := pathFormat
+			if len(pathArgs) > 0 {
+				path = fmt.Sprintf(pathFormat, pathArgs...)
+			}
+			return requestAndPrint(*apiAddr, method, path, body)
+		},
+	}
+}
+
+func listAPICommand(apiAddr *string, use string, short string, path string) *cobra.Command {
+	cmd := simpleAPICommand(apiAddr, use, short, http.MethodGet, path, 0, nil)
+	cmd.Aliases = []string{"ls"}
+	return cmd
+}
+
+func requestAndPrint(apiAddr string, method string, path string, body any) error {
+	data, err := apiClient{base: apiAddr}.request(method, path, body)
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		fmt.Println("ok")
+		return nil
+	}
+	return printRawJSON(data)
+}
+
+func (c apiClient) request(method string, path string, body any) ([]byte, error) {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		reader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequest(method, controlURL(c.base, path), reader)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, apiError(resp.Status, data)
+	}
+	return data, nil
+}
+
+func controlURL(base string, path string) string {
+	return strings.TrimRight(base, "/") + "/" + strings.TrimLeft(path, "/")
+}
+
+func apiError(status string, data []byte) error {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return fmt.Errorf("%s", status)
+	}
+
+	var flat struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(data, &flat); err == nil && flat.Message != "" {
+		if flat.Code != "" {
+			return fmt.Errorf("%s: %s: %s", status, flat.Code, flat.Message)
+		}
+		return fmt.Errorf("%s: %s", status, flat.Message)
+	}
+
+	var nested struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(data, &nested); err == nil && nested.Error.Message != "" {
+		if nested.Error.Code != "" {
+			return fmt.Errorf("%s: %s: %s", status, nested.Error.Code, nested.Error.Message)
+		}
+		return fmt.Errorf("%s: %s", status, nested.Error.Message)
+	}
+
+	return fmt.Errorf("%s: %s", status, trimmed)
+}
+
+func printRawJSON(data []byte) error {
+	var out bytes.Buffer
+	if err := json.Indent(&out, data, "", "  "); err != nil {
+		fmt.Println(strings.TrimSpace(string(data)))
+		return nil
+	}
+	_, err := out.WriteTo(os.Stdout)
+	if err != nil {
+		return err
+	}
+	fmt.Println()
+	return nil
+}
+
+func printJSON(value any) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return printRawJSON(data)
+}
+
+func parseKeyValues(values []string) (map[string]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(values))
+	for _, value := range values {
+		key, val, ok := strings.Cut(value, "=")
+		if !ok || key == "" {
+			return nil, fmt.Errorf("invalid key=value pair %q", value)
+		}
+		out[key] = val
+	}
+	return out, nil
 }
 
 func runExec(proxyAddr string, sandboxID string, command []string, cwd string, interactive bool) error {

--- a/internal/app/boxproxy/app.go
+++ b/internal/app/boxproxy/app.go
@@ -2,20 +2,36 @@ package boxproxy
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/novitalabs/NovitaBox/internal/boxproxy/server"
 	"github.com/novitalabs/NovitaBox/internal/config"
 	"github.com/novitalabs/NovitaBox/internal/log"
+	"github.com/novitalabs/NovitaBox/internal/storage/store/sqlite"
 )
 
 type App struct {
 	server *server.Server
+	store  *sqlite.Store
 }
 
 func New(cfg config.Config, logger *log.Logger) (*App, error) {
-	return &App{server: server.New(cfg, logger.Component("boxproxy"))}, nil
+	dbPath := cfg.Storage.DBPath
+	if dbPath == "" {
+		dbPath = config.DefaultDBPath(cfg.RootDir)
+	}
+	logger.Info("opening sqlite database", "db_path", dbPath)
+	st, err := sqlite.Open(context.Background(), dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite store: %w", err)
+	}
+	return &App{
+		server: server.New(cfg, logger.Component("boxproxy"), st),
+		store:  st,
+	}, nil
 }
 
 func (a *App) Run(ctx context.Context) error {
+	defer a.store.Close()
 	return a.server.Start(ctx)
 }

--- a/internal/boxapi/handler/runtime.go
+++ b/internal/boxapi/handler/runtime.go
@@ -1,15 +1,121 @@
 package handler
 
-import "github.com/gin-gonic/gin"
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/novitalabs/NovitaBox/internal/boxapi/response"
+)
+
+type runtimeSummaryResponse struct {
+	RuntimeType  string                      `json:"runtimeType"`
+	Capabilities runtimeCapabilitiesResponse `json:"capabilities"`
+}
+
+type listRuntimesResponse struct {
+	Runtimes []runtimeSummaryResponse `json:"runtimes"`
+}
+
+type runtimeCapabilitiesResponse struct {
+	StartFromImage    bool `json:"startFromImage"`
+	StartFromTemplate bool `json:"startFromTemplate"`
+	StartFromSnapshot bool `json:"startFromSnapshot"`
+	Pause             bool `json:"pause"`
+	Resume            bool `json:"resume"`
+	FullSnapshot      bool `json:"fullSnapshot"`
+	DiffSnapshot      bool `json:"diffSnapshot"`
+	GPU               bool `json:"gpu"`
+	Vsock             bool `json:"vsock"`
+	TapNetwork        bool `json:"tapNetwork"`
+	HotplugDisk       bool `json:"hotplugDisk"`
+	HotplugNetwork    bool `json:"hotplugNetwork"`
+	LiveResizeCPU     bool `json:"liveResizeCPU"`
+	LiveResizeMemory  bool `json:"liveResizeMemory"`
+	GracefulShutdown  bool `json:"gracefulShutdown"`
+	SerialConsole     bool `json:"serialConsole"`
+	Jailer            bool `json:"jailer"`
+}
 
 func (h *Handler) ListRuntimes(c *gin.Context) {
-	notImplemented(c, "list runtimes")
+	response.JSON(c, http.StatusOK, listRuntimesResponse{
+		Runtimes: []runtimeSummaryResponse{
+			{RuntimeType: "firecracker", Capabilities: firecrackerRuntimeCapabilities()},
+			{RuntimeType: "cloud-hypervisor", Capabilities: cloudHypervisorRuntimeCapabilities()},
+		},
+	})
 }
 
 func (h *Handler) GetRuntime(c *gin.Context) {
-	notImplemented(c, "get runtime")
+	runtimeType := normalizeRuntimeName(c.Param("runtime_type"))
+	caps, ok := runtimeCapabilities(runtimeType)
+	if !ok {
+		response.Error(c, response.ErrNotFound("runtime not found"))
+		return
+	}
+	response.JSON(c, http.StatusOK, runtimeSummaryResponse{
+		RuntimeType:  runtimeType,
+		Capabilities: caps,
+	})
 }
 
 func (h *Handler) GetRuntimeCapabilities(c *gin.Context) {
-	notImplemented(c, "get runtime capabilities")
+	runtimeType := normalizeRuntimeName(c.Param("runtime_type"))
+	caps, ok := runtimeCapabilities(runtimeType)
+	if !ok {
+		response.Error(c, response.ErrNotFound("runtime not found"))
+		return
+	}
+	response.JSON(c, http.StatusOK, caps)
+}
+
+func runtimeCapabilities(runtimeType string) (runtimeCapabilitiesResponse, bool) {
+	switch runtimeType {
+	case "firecracker":
+		return firecrackerRuntimeCapabilities(), true
+	case "cloud-hypervisor":
+		return cloudHypervisorRuntimeCapabilities(), true
+	default:
+		return runtimeCapabilitiesResponse{}, false
+	}
+}
+
+func normalizeRuntimeName(runtimeType string) string {
+	switch strings.ReplaceAll(strings.ToLower(strings.TrimSpace(runtimeType)), "_", "-") {
+	case "runtime-type-firecracker", "firecracker":
+		return "firecracker"
+	case "runtime-type-cloud-hypervisor", "cloud-hypervisor":
+		return "cloud-hypervisor"
+	case "runtime-type-container", "container":
+		return "container"
+	default:
+		return ""
+	}
+}
+
+func firecrackerRuntimeCapabilities() runtimeCapabilitiesResponse {
+	return runtimeCapabilitiesResponse{
+		StartFromImage:    true,
+		StartFromTemplate: true,
+		StartFromSnapshot: true,
+		Pause:             true,
+		Resume:            true,
+		FullSnapshot:      true,
+		DiffSnapshot:      false,
+		GPU:               false,
+		Vsock:             true,
+		TapNetwork:        true,
+		GracefulShutdown:  true,
+		SerialConsole:     true,
+		Jailer:            true,
+	}
+}
+
+func cloudHypervisorRuntimeCapabilities() runtimeCapabilitiesResponse {
+	caps := firecrackerRuntimeCapabilities()
+	caps.GPU = true
+	caps.HotplugDisk = true
+	caps.HotplugNetwork = true
+	return caps
 }

--- a/internal/boxapi/server/router.go
+++ b/internal/boxapi/server/router.go
@@ -61,6 +61,7 @@ func registerV1Routes(r *gin.Engine, h *handler.Handler) {
 	v1 := r.Group("/v1")
 	{
 		registerV1SandboxRoutes(v1, h)
+		registerV1TemplateRoutes(v1, h)
 		registerV1ImageRoutes(v1, h)
 		registerV1RuntimeRoutes(v1, h)
 	}
@@ -79,6 +80,13 @@ func registerV1SandboxRoutes(v1 *gin.RouterGroup, h *handler.Handler) {
 		sandboxes.POST("/:sandbox_id/poweroff", h.PoweroffSandbox)
 		sandboxes.POST("/:sandbox_id/poweron", h.PoweronSandbox)
 		sandboxes.POST("/:sandbox_id/reboot", h.RebootSandbox)
+	}
+}
+
+func registerV1TemplateRoutes(v1 *gin.RouterGroup, h *handler.Handler) {
+	templates := v1.Group("/templates")
+	{
+		templates.POST("/convert", h.ConvertTemplate)
 	}
 }
 

--- a/internal/boxapi/server/router_test.go
+++ b/internal/boxapi/server/router_test.go
@@ -40,15 +40,26 @@ func TestRouterHealth(t *testing.T) {
 	}
 }
 
-func TestRouterNotImplemented(t *testing.T) {
+func TestRouterListRuntimes(t *testing.T) {
 	s := newTestServer(t)
 	req := httptest.NewRequest(http.MethodGet, "/v1/runtimes", nil)
 	rec := httptest.NewRecorder()
 
 	s.router().ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusNotImplemented {
-		t.Fatalf("expected status %d, got %d", http.StatusNotImplemented, rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	var got struct {
+		Runtimes []struct {
+			RuntimeType string `json:"runtimeType"`
+		} `json:"runtimes"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(got.Runtimes) == 0 || got.Runtimes[0].RuntimeType != "firecracker" {
+		t.Fatalf("runtimes = %#v, want firecracker first", got.Runtimes)
 	}
 }
 
@@ -718,7 +729,7 @@ func TestRouterTemplateCRUD(t *testing.T) {
 	}
 }
 
-func TestRouterV1TemplateRoutesNotRegistered(t *testing.T) {
+func TestRouterV1TemplateRoutes(t *testing.T) {
 	s := newTestServer(t)
 
 	for _, tc := range []struct {
@@ -728,7 +739,6 @@ func TestRouterV1TemplateRoutesNotRegistered(t *testing.T) {
 		{method: http.MethodGet, path: "/v1/templates"},
 		{method: http.MethodGet, path: "/v1/templates/tpl-test"},
 		{method: http.MethodDelete, path: "/v1/templates/tpl-test"},
-		{method: http.MethodPost, path: "/v1/templates/convert"},
 	} {
 		req := httptest.NewRequest(tc.method, tc.path, nil)
 		rec := httptest.NewRecorder()
@@ -738,6 +748,14 @@ func TestRouterV1TemplateRoutesNotRegistered(t *testing.T) {
 		if rec.Code != http.StatusNotFound {
 			t.Fatalf("%s %s expected status %d, got %d body=%s", tc.method, tc.path, http.StatusNotFound, rec.Code, rec.Body.String())
 		}
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/templates/convert", nil)
+	rec := httptest.NewRecorder()
+	s.router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("POST /v1/templates/convert expected status %d, got %d body=%s", http.StatusBadRequest, rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/boxlet/server/network.go
+++ b/internal/boxlet/server/network.go
@@ -33,9 +33,15 @@ func (m sandboxNetworkManager) Spec(sandboxID string) (*novitaboxv1.NetworkSpec,
 	if !m.cfg.Network.Enabled {
 		return nil, nil
 	}
-	slot, err := networkSlotForSandbox(m.cfg.Network.VethCIDR, sandboxID)
-	if err != nil {
-		return nil, err
+	return m.SpecForSlot(sandboxID, 1)
+}
+
+func (m sandboxNetworkManager) SpecForSlot(sandboxID string, slot uint32) (*novitaboxv1.NetworkSpec, error) {
+	if !m.cfg.Network.Enabled {
+		return nil, nil
+	}
+	if slot == 0 {
+		return nil, fmt.Errorf("network slot is required")
 	}
 	hostAccessIP, err := indexedIP(m.cfg.Network.HostAccessCIDR, slot)
 	if err != nil {
@@ -48,11 +54,12 @@ func (m sandboxNetworkManager) Spec(sandboxID string) (*novitaboxv1.NetworkSpec,
 		GatewayIp:     m.cfg.Network.GatewayIP,
 		HostAccessIp:  hostAccessIP,
 		Mac:           m.cfg.Network.GuestMAC,
+		Slot:          slot,
 	}, nil
 }
 
-func (m sandboxNetworkManager) Complete(sandboxID string, spec *novitaboxv1.NetworkSpec) (*novitaboxv1.NetworkSpec, error) {
-	defaults, err := m.Spec(sandboxID)
+func (m sandboxNetworkManager) Complete(sandboxID string, slot uint32, spec *novitaboxv1.NetworkSpec) (*novitaboxv1.NetworkSpec, error) {
+	defaults, err := m.SpecForSlot(sandboxID, slot)
 	if err != nil || defaults == nil {
 		return defaults, err
 	}
@@ -77,7 +84,25 @@ func (m sandboxNetworkManager) Complete(sandboxID string, spec *novitaboxv1.Netw
 	if spec.Mac == "" {
 		spec.Mac = defaults.GetMac()
 	}
+	if spec.Slot == 0 {
+		spec.Slot = defaults.GetSlot()
+	}
 	return spec, nil
+}
+
+func (m sandboxNetworkManager) MaxSlots() (uint32, error) {
+	hostAccessSlots, err := networkSlotsForCIDR(m.cfg.Network.HostAccessCIDR, 1)
+	if err != nil {
+		return 0, err
+	}
+	vethSlots, err := networkSlotsForCIDR(m.cfg.Network.VethCIDR, vethAddressesPerSlot)
+	if err != nil {
+		return 0, err
+	}
+	if hostAccessSlots < vethSlots {
+		return hostAccessSlots, nil
+	}
+	return vethSlots, nil
 }
 
 func (m sandboxNetworkManager) Ensure(ctx context.Context, spec *novitaboxv1.NetworkSpec) error {
@@ -150,8 +175,8 @@ func (m sandboxNetworkManager) Ensure(ctx context.Context, spec *novitaboxv1.Net
 	return nil
 }
 
-func (m sandboxNetworkManager) Cleanup(ctx context.Context, sandboxID string) error {
-	spec, err := m.Spec(sandboxID)
+func (m sandboxNetworkManager) Cleanup(ctx context.Context, sandboxID string, slot uint32) error {
+	spec, err := m.SpecForSlot(sandboxID, slot)
 	if err != nil || spec == nil {
 		return err
 	}
@@ -228,7 +253,7 @@ func vethAddrsForSlot(cidr string, slot uint32) (sandboxVethAddrs, error) {
 	return sandboxVethAddrs{hostIP: hostIP, peerIP: peerIP}, nil
 }
 
-func networkSlotForSandbox(cidr string, sandboxID string) (uint32, error) {
+func networkSlotsForCIDR(cidr string, addressesPerSlot uint32) (uint32, error) {
 	_, network, err := net.ParseCIDR(cidr)
 	if err != nil {
 		return 0, fmt.Errorf("parse network cidr %q: %w", cidr, err)
@@ -238,13 +263,11 @@ func networkSlotForSandbox(cidr string, sandboxID string) (uint32, error) {
 		return 0, fmt.Errorf("network cidr %q must be IPv4", cidr)
 	}
 	totalIPs := uint32(1) << uint(32-ones)
-	totalSlots := totalIPs / vethAddressesPerSlot
-	if totalSlots <= vethAddressesPerSlot {
+	totalSlots := totalIPs / addressesPerSlot
+	if totalSlots <= 1 {
 		return 0, fmt.Errorf("network cidr %q is too small for sandbox slots", cidr)
 	}
-	hash := sha1.Sum([]byte(sandboxID))
-	slot := (binary.BigEndian.Uint32(hash[:4]) % (totalSlots - vethAddressesPerSlot)) + 1
-	return slot, nil
+	return totalSlots - 1, nil
 }
 
 func networkSlotFromHostAccessIP(cidr string, hostAccessIP string) (uint32, error) {

--- a/internal/boxlet/server/network_test.go
+++ b/internal/boxlet/server/network_test.go
@@ -56,7 +56,7 @@ func TestSandboxNetworkCompletePreservesExplicitValues(t *testing.T) {
 	cfg := config.Default()
 	manager := newSandboxNetworkManager(cfg)
 
-	spec, err := manager.Complete("i-test-sandbox", &novitaboxv1.NetworkSpec{
+	spec, err := manager.Complete("i-test-sandbox", 1, &novitaboxv1.NetworkSpec{
 		NamespaceName: "custom-ns",
 		TapName:       "customtap",
 		GuestIp:       "10.0.0.2",

--- a/internal/boxlet/server/services.go
+++ b/internal/boxlet/server/services.go
@@ -69,35 +69,46 @@ func (s *sandboxService) CreateSandbox(ctx context.Context, req *novitaboxv1.Cre
 		ImageID:     req.GetImageId(),
 		SnapshotID:  req.GetSnapshotId(),
 	}
-	spec := s.completeRuntimeSpec(record, req.GetRuntimeSpec())
 	if err := s.store.CreateSandbox(ctx, record); err != nil {
 		if isAlreadyExistsError(err) {
 			return nil, status.Error(codes.AlreadyExists, "sandbox already exists")
 		}
 		return nil, err
 	}
+	slot, err := s.assignSandboxNetworkSlot(ctx, record.ID)
+	if err != nil {
+		_ = s.store.UpdateSandboxState(ctx, sandboxID, sandbox.StateCreating, sandbox.StateFailed, "create")
+		return nil, err
+	}
+	record.NetworkSlot = slot
+	spec := s.completeRuntimeSpec(record, req.GetRuntimeSpec())
 	if err := s.prepareSandboxRuntimeFiles(ctx, record, spec); err != nil {
 		_ = s.store.UpdateSandboxState(ctx, sandboxID, sandbox.StateCreating, sandbox.StateFailed, "create")
+		_ = s.releaseSandboxNetwork(ctx, record)
 		return nil, err
 	}
 	if err := ensureSnapshotSpecDirs(spec.Snapshot); err != nil {
 		_ = s.store.UpdateSandboxState(ctx, sandboxID, sandbox.StateCreating, sandbox.StateFailed, "create")
+		_ = s.releaseSandboxNetwork(ctx, record)
 		return nil, err
 	}
 	if err := newSandboxNetworkManager(s.cfg).Ensure(ctx, spec.GetNetwork()); err != nil {
 		_ = s.store.UpdateSandboxState(ctx, sandboxID, sandbox.StateCreating, sandbox.StateFailed, "create")
+		_ = s.releaseSandboxNetwork(ctx, record)
 		return nil, err
 	}
 
 	shimSocket := filepath.Join(sandboxDir, "shim.sock")
 	if err := ensureShim(ctx, s.cfg, shimSocket); err != nil {
 		_ = s.store.UpdateSandboxState(ctx, sandboxID, sandbox.StateCreating, sandbox.StateFailed, "create")
+		_ = s.releaseSandboxNetwork(ctx, record)
 		return nil, err
 	}
 
 	shim, closeShim, err := dialShim(ctx, shimSocket)
 	if err != nil {
 		_ = s.store.UpdateSandboxState(ctx, sandboxID, sandbox.StateCreating, sandbox.StateFailed, "create")
+		_ = s.releaseSandboxNetwork(ctx, record)
 		return nil, err
 	}
 	defer closeShim()
@@ -105,11 +116,13 @@ func (s *sandboxService) CreateSandbox(ctx context.Context, req *novitaboxv1.Cre
 	runtimeInfo, err := shim.CreateRuntime(ctx, &novitaboxv1.CreateRuntimeRequest{RuntimeSpec: spec})
 	if err != nil {
 		_ = s.store.UpdateSandboxState(ctx, sandboxID, sandbox.StateCreating, sandbox.StateFailed, "create")
+		_ = s.releaseSandboxNetwork(ctx, record)
 		return nil, fmt.Errorf("create runtime: %w", err)
 	}
 	if err := s.ensureSandboxAgentCurrent(ctx, record.ID, spec.GetNetwork()); err != nil {
 		_, _ = shim.KillRuntime(context.Background(), &novitaboxv1.KillRuntimeRequest{SandboxId: record.ID})
 		_ = s.store.UpdateSandboxState(ctx, sandboxID, sandbox.StateCreating, sandbox.StateFailed, "create")
+		_ = s.releaseSandboxNetwork(ctx, record)
 		return nil, fmt.Errorf("refresh sandbox agent: %w", err)
 	}
 
@@ -191,6 +204,9 @@ func (s *sandboxService) PauseSandbox(ctx context.Context, req *novitaboxv1.Paus
 	if err := s.setSandboxState(ctx, record.ID, sandbox.StatePaused, "pause"); err != nil {
 		return nil, err
 	}
+	if err := s.releaseSandboxNetwork(ctx, *record); err != nil {
+		return nil, err
+	}
 
 	return snapshotRecordToProto(snapshot), nil
 }
@@ -206,10 +222,17 @@ func (s *sandboxService) ResumeSandbox(ctx context.Context, req *novitaboxv1.Res
 	if err := s.setSandboxState(ctx, record.ID, sandbox.StateResuming, "resume"); err != nil {
 		return nil, err
 	}
+	slot, err := s.assignSandboxNetworkSlot(ctx, record.ID)
+	if err != nil {
+		_ = s.setSandboxState(ctx, record.ID, sandbox.StateFailed, "resume")
+		return nil, err
+	}
+	record.NetworkSlot = slot
 
 	shim, closeShim, err := s.dialSandboxShim(ctx, record.ID)
 	if err != nil {
 		_ = s.setSandboxState(ctx, record.ID, sandbox.StateFailed, "resume")
+		_ = s.releaseSandboxNetwork(ctx, *record)
 		return nil, err
 	}
 	defer closeShim()
@@ -217,18 +240,22 @@ func (s *sandboxService) ResumeSandbox(ctx context.Context, req *novitaboxv1.Res
 	spec := s.runtimeSpecForSandbox(*record)
 	if err := s.attachAgentDrive(ctx, spec); err != nil {
 		_ = s.setSandboxState(ctx, record.ID, sandbox.StateFailed, "resume")
+		_ = s.releaseSandboxNetwork(ctx, *record)
 		return nil, err
 	}
 	if err := newSandboxNetworkManager(s.cfg).Ensure(ctx, spec.GetNetwork()); err != nil {
 		_ = s.setSandboxState(ctx, record.ID, sandbox.StateFailed, "resume")
+		_ = s.releaseSandboxNetwork(ctx, *record)
 		return nil, err
 	}
 	if _, err := shim.ResumeRuntime(ctx, &novitaboxv1.ResumeRuntimeRequest{RuntimeSpec: spec}); err != nil {
 		_ = s.setSandboxState(ctx, record.ID, sandbox.StateFailed, "resume")
+		_ = s.releaseSandboxNetwork(ctx, *record)
 		return nil, fmt.Errorf("resume runtime: %w", err)
 	}
 	if err := s.ensureSandboxAgentCurrent(ctx, record.ID, spec.GetNetwork()); err != nil {
 		_ = s.setSandboxState(ctx, record.ID, sandbox.StateFailed, "resume")
+		_ = s.releaseSandboxNetwork(ctx, *record)
 		return nil, fmt.Errorf("refresh sandbox agent: %w", err)
 	}
 	if err := s.setSandboxState(ctx, record.ID, sandbox.StateRunning, "resume"); err != nil {
@@ -275,7 +302,7 @@ func (s *sandboxService) KillSandbox(ctx context.Context, req *novitaboxv1.KillS
 	if err := os.RemoveAll(sandboxDir); err != nil {
 		return nil, fmt.Errorf("remove sandbox directory: %w", err)
 	}
-	if err := newSandboxNetworkManager(s.cfg).Cleanup(ctx, record.ID); err != nil {
+	if err := s.releaseSandboxNetwork(ctx, *record); err != nil {
 		s.logger.Warn("cleanup sandbox network failed", "sandbox_id", record.ID, "error", err)
 	}
 
@@ -314,10 +341,17 @@ func (s *sandboxService) StartSandbox(ctx context.Context, req *novitaboxv1.Star
 	if err := s.setSandboxState(ctx, record.ID, sandbox.StateStarting, "start"); err != nil {
 		return nil, err
 	}
+	slot, err := s.assignSandboxNetworkSlot(ctx, record.ID)
+	if err != nil {
+		_ = s.setSandboxState(ctx, record.ID, sandbox.StateFailed, "start")
+		return nil, err
+	}
+	record.NetworkSlot = slot
 
 	shim, closeShim, err := s.dialSandboxShim(ctx, record.ID)
 	if err != nil {
 		_ = s.setSandboxState(ctx, record.ID, sandbox.StateFailed, "start")
+		_ = s.releaseSandboxNetwork(ctx, *record)
 		return nil, err
 	}
 	defer closeShim()
@@ -325,18 +359,22 @@ func (s *sandboxService) StartSandbox(ctx context.Context, req *novitaboxv1.Star
 	spec := s.runtimeSpecForSandbox(*record)
 	if err := s.attachAgentDrive(ctx, spec); err != nil {
 		_ = s.setSandboxState(ctx, record.ID, sandbox.StateFailed, "start")
+		_ = s.releaseSandboxNetwork(ctx, *record)
 		return nil, err
 	}
 	if err := newSandboxNetworkManager(s.cfg).Ensure(ctx, spec.GetNetwork()); err != nil {
 		_ = s.setSandboxState(ctx, record.ID, sandbox.StateFailed, "start")
+		_ = s.releaseSandboxNetwork(ctx, *record)
 		return nil, err
 	}
 	if _, err := shim.StartRuntime(ctx, &novitaboxv1.StartRuntimeRequest{RuntimeSpec: spec}); err != nil {
 		_ = s.setSandboxState(ctx, record.ID, sandbox.StateFailed, "start")
+		_ = s.releaseSandboxNetwork(ctx, *record)
 		return nil, fmt.Errorf("start runtime: %w", err)
 	}
 	if err := s.ensureSandboxAgentCurrent(ctx, record.ID, spec.GetNetwork()); err != nil {
 		_ = s.setSandboxState(ctx, record.ID, sandbox.StateFailed, "start")
+		_ = s.releaseSandboxNetwork(ctx, *record)
 		return nil, fmt.Errorf("refresh sandbox agent: %w", err)
 	}
 	if err := s.setSandboxState(ctx, record.ID, sandbox.StateRunning, "start"); err != nil {
@@ -384,6 +422,11 @@ func (s *sandboxService) runtimeAction(ctx context.Context, sandboxID string, tr
 	if err := s.setSandboxState(ctx, record.ID, finalState, action); err != nil {
 		return nil, err
 	}
+	if finalState == sandbox.StateStopped || finalState == sandbox.StatePaused || finalState == sandbox.StateKilled {
+		if err := s.releaseSandboxNetwork(ctx, *record); err != nil {
+			return nil, err
+		}
+	}
 
 	updated, err := s.store.GetSandbox(ctx, record.ID)
 	if err != nil {
@@ -413,6 +456,33 @@ func (s *sandboxService) setSandboxState(ctx context.Context, sandboxID string, 
 		if errors.Is(err, store.ErrNotFound) {
 			return status.Error(codes.NotFound, "sandbox not found")
 		}
+		return err
+	}
+	return nil
+}
+
+func (s *sandboxService) assignSandboxNetworkSlot(ctx context.Context, sandboxID string) (uint32, error) {
+	if !s.cfg.Network.Enabled {
+		return 0, nil
+	}
+	manager := newSandboxNetworkManager(s.cfg)
+	maxSlot, err := manager.MaxSlots()
+	if err != nil {
+		return 0, err
+	}
+	return s.store.AssignSandboxNetworkSlot(ctx, sandboxID, maxSlot)
+}
+
+func (s *sandboxService) releaseSandboxNetwork(ctx context.Context, record store.SandboxRecord) error {
+	if !s.cfg.Network.Enabled {
+		return nil
+	}
+	if record.NetworkSlot > 0 {
+		if err := newSandboxNetworkManager(s.cfg).Cleanup(ctx, record.ID, record.NetworkSlot); err != nil {
+			return err
+		}
+	}
+	if err := s.store.ReleaseSandboxNetworkSlot(ctx, record.ID); err != nil && !errors.Is(err, store.ErrNotFound) {
 		return err
 	}
 	return nil
@@ -532,7 +602,10 @@ func isAlreadyExistsError(err error) bool {
 
 func (s *sandboxService) runtimeSpecForSandbox(record store.SandboxRecord) *novitaboxv1.RuntimeSpec {
 	paths := sandboxRuntimePaths(s.cfg.RootDir, record.ID)
-	networkSpec, _ := newSandboxNetworkManager(s.cfg).Spec(record.ID)
+	var networkSpec *novitaboxv1.NetworkSpec
+	if record.NetworkSlot > 0 {
+		networkSpec, _ = newSandboxNetworkManager(s.cfg).SpecForSlot(record.ID, record.NetworkSlot)
+	}
 	return &novitaboxv1.RuntimeSpec{
 		SandboxId:   record.ID,
 		RuntimeType: runtimeTypeFromRecord(record.RuntimeType),
@@ -601,8 +674,10 @@ func (s *sandboxService) completeRuntimeSpec(record store.SandboxRecord, spec *n
 	if spec.Snapshot.SnapfilePath == "" {
 		spec.Snapshot.SnapfilePath = paths.SnapfilePath
 	}
-	if networkSpec, err := newSandboxNetworkManager(s.cfg).Complete(record.ID, spec.Network); err == nil {
-		spec.Network = networkSpec
+	if record.NetworkSlot > 0 {
+		if networkSpec, err := newSandboxNetworkManager(s.cfg).Complete(record.ID, record.NetworkSlot, spec.Network); err == nil {
+			spec.Network = networkSpec
+		}
 	}
 	if spec.Agent == nil {
 		spec.Agent = &novitaboxv1.AgentSpec{
@@ -1068,6 +1143,7 @@ func (s *artifactService) createTemplateSnapshot(ctx context.Context, req *novit
 
 	buildID := "template-build-" + templateID
 	buildDir := filepath.Join(layout.New(s.cfg.RootDir).SandboxDir(buildID))
+	var internalNetworkSlot uint32
 	if err := os.RemoveAll(buildDir); err != nil {
 		return fmt.Errorf("remove stale template build sandbox: %w", err)
 	}
@@ -1075,7 +1151,7 @@ func (s *artifactService) createTemplateSnapshot(ctx context.Context, req *novit
 		return fmt.Errorf("create template snapshot build dir: %w", err)
 	}
 	defer func() {
-		if err := cleanupInternalSandbox(context.Background(), s.cfg, buildID); err != nil {
+		if err := cleanupInternalSandbox(context.Background(), s.cfg, buildID, internalNetworkSlot); err != nil {
 			s.logger.Warn("cleanup template build sandbox failed", "sandbox_id", buildID, "error", err)
 		}
 	}()
@@ -1112,9 +1188,12 @@ func (s *artifactService) createTemplateSnapshot(ctx context.Context, req *novit
 			SnapshotType: "full",
 		},
 	}
-	networkSpec, err := newSandboxNetworkManager(s.cfg).Spec(buildID)
+	networkSpec, err := s.internalSandboxNetworkSpec(ctx, buildID)
 	if err != nil {
 		return fmt.Errorf("prepare template build network spec: %w", err)
+	}
+	if networkSpec != nil {
+		internalNetworkSlot = networkSpec.GetSlot()
 	}
 	spec.Network = networkSpec
 	if err := s.attachAgentDrive(ctx, spec); err != nil {
@@ -1148,6 +1227,35 @@ func (s *artifactService) createTemplateSnapshot(ctx context.Context, req *novit
 	}
 
 	return nil
+}
+
+func (s *artifactService) internalSandboxNetworkSpec(ctx context.Context, sandboxID string) (*novitaboxv1.NetworkSpec, error) {
+	manager := newSandboxNetworkManager(s.cfg)
+	if !s.cfg.Network.Enabled {
+		return nil, nil
+	}
+	maxSlot, err := manager.MaxSlots()
+	if err != nil {
+		return nil, err
+	}
+	used := map[uint32]struct{}{}
+	if s.store != nil {
+		records, err := s.store.ListSandboxes(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, record := range records {
+			if record.NetworkSlot > 0 {
+				used[record.NetworkSlot] = struct{}{}
+			}
+		}
+	}
+	for slot := maxSlot; slot > 0; slot-- {
+		if _, ok := used[slot]; !ok {
+			return manager.SpecForSlot(sandboxID, slot)
+		}
+	}
+	return nil, fmt.Errorf("no internal sandbox network slots available")
 }
 
 func templateKernelArgs(configured []string) []string {
@@ -1187,14 +1295,7 @@ func templateBuildAgentURL(cfg config.Config, buildID string, networkSpec *novit
 		hostIP = networkSpec.GetHostAccessIp()
 	}
 	if hostIP == "" {
-		spec, err := newSandboxNetworkManager(cfg).Spec(buildID)
-		if err != nil {
-			return templateBuildAgentURLs{}, err
-		}
-		hostIP = spec.GetHostAccessIp()
-	}
-	if hostIP == "" {
-		return templateBuildAgentURLs{}, errors.New("template build agent host access ip is empty")
+		return templateBuildAgentURLs{}, fmt.Errorf("template build %q agent host access ip is empty", buildID)
 	}
 	_, port, err := net.SplitHostPort(cfg.Boxd.Addr)
 	if err != nil {
@@ -1577,6 +1678,7 @@ func (s *artifactService) exportTemplateImageRootfs(ctx context.Context, templat
 	l := layout.New(s.cfg.RootDir)
 	buildDir := l.SandboxDir(buildID)
 	paths := sandboxRuntimePaths(s.cfg.RootDir, buildID)
+	var internalNetworkSlot uint32
 
 	if err := os.RemoveAll(buildDir); err != nil {
 		return fmt.Errorf("remove stale image build sandbox: %w", err)
@@ -1585,7 +1687,7 @@ func (s *artifactService) exportTemplateImageRootfs(ctx context.Context, templat
 		return fmt.Errorf("create image build snapshot directory: %w", err)
 	}
 	defer func() {
-		if err := cleanupInternalSandbox(context.Background(), s.cfg, buildID); err != nil {
+		if err := cleanupInternalSandbox(context.Background(), s.cfg, buildID, internalNetworkSlot); err != nil {
 			s.logger.Warn("cleanup image build sandbox failed", "sandbox_id", buildID, "error", err)
 		}
 	}()
@@ -1613,7 +1715,14 @@ func (s *artifactService) exportTemplateImageRootfs(ctx context.Context, templat
 	}
 	defer closeShim()
 
-	spec := s.imageBuildRuntimeSpec(buildID, template.RootfsPath, paths)
+	networkSpec, err := s.internalSandboxNetworkSpec(ctx, buildID)
+	if err != nil {
+		return fmt.Errorf("prepare image build network spec: %w", err)
+	}
+	if networkSpec != nil {
+		internalNetworkSlot = networkSpec.GetSlot()
+	}
+	spec := s.imageBuildRuntimeSpec(buildID, template.RootfsPath, paths, networkSpec)
 	if err := s.attachAgentDrive(ctx, spec); err != nil {
 		return err
 	}
@@ -1641,9 +1750,8 @@ func (s *artifactService) exportTemplateImageRootfs(ctx context.Context, templat
 	})
 }
 
-func (s *artifactService) imageBuildRuntimeSpec(sandboxID string, rootfsPath string, paths sandboxRuntimeArtifactPaths) *novitaboxv1.RuntimeSpec {
+func (s *artifactService) imageBuildRuntimeSpec(sandboxID string, rootfsPath string, paths sandboxRuntimeArtifactPaths, networkSpec *novitaboxv1.NetworkSpec) *novitaboxv1.RuntimeSpec {
 	runtimeType := runtimeTypeFromRecord(s.cfg.Boxshim.RuntimeDriver)
-	networkSpec, _ := newSandboxNetworkManager(s.cfg).Spec(sandboxID)
 	spec := &novitaboxv1.RuntimeSpec{
 		SandboxId:   sandboxID,
 		RuntimeType: runtimeType,
@@ -1812,7 +1920,7 @@ func restoreTemplateRootfs(rootfsPath string, backupPath string) error {
 	return nil
 }
 
-func cleanupInternalSandbox(ctx context.Context, cfg config.Config, sandboxID string) error {
+func cleanupInternalSandbox(ctx context.Context, cfg config.Config, sandboxID string, networkSlot uint32) error {
 	sandboxDir := layout.New(cfg.RootDir).SandboxDir(sandboxID)
 	shimSocket := filepath.Join(sandboxDir, "shim.sock")
 	if shim, closeShim, err := dialShim(ctx, shimSocket); err == nil {
@@ -1822,8 +1930,10 @@ func cleanupInternalSandbox(ctx context.Context, cfg config.Config, sandboxID st
 	if err := terminateShimProcess(sandboxDir, 5*time.Second); err != nil {
 		return err
 	}
-	if err := newSandboxNetworkManager(cfg).Cleanup(ctx, sandboxID); err != nil {
-		return err
+	if networkSlot > 0 {
+		if err := newSandboxNetworkManager(cfg).Cleanup(ctx, sandboxID, networkSlot); err != nil {
+			return err
+		}
 	}
 	return os.RemoveAll(sandboxDir)
 }

--- a/internal/boxproxy/server/server.go
+++ b/internal/boxproxy/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"crypto/sha1"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/novitalabs/NovitaBox/internal/config"
 	"github.com/novitalabs/NovitaBox/internal/log"
+	"github.com/novitalabs/NovitaBox/internal/storage/store"
 	"github.com/novitalabs/NovitaBox/internal/wsutil"
 	"golang.org/x/net/websocket"
 )
@@ -24,11 +24,12 @@ const sandboxIDHeader = "Novita-Sandbox-Id"
 type Server struct {
 	cfg        config.Config
 	logger     *log.Logger
+	store      store.Store
 	httpServer *http.Server
 }
 
-func New(cfg config.Config, logger *log.Logger) *Server {
-	s := &Server{cfg: cfg, logger: logger}
+func New(cfg config.Config, logger *log.Logger, st store.Store) *Server {
+	s := &Server{cfg: cfg, logger: logger, store: st}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", s.handleHealthz)
 	mux.HandleFunc("/", s.handleSandbox)
@@ -245,7 +246,7 @@ func (s *Server) boxdHTTPURL(sandboxID string, rest string, rawQuery string) (st
 }
 
 func (s *Server) boxdHost(sandboxID string) (string, error) {
-	hostIP, err := hostAccessIP(s.cfg.Network.HostAccessCIDR, s.cfg.Network.VethCIDR, sandboxID)
+	hostIP, err := s.hostAccessIP(sandboxID)
 	if err != nil {
 		return "", err
 	}
@@ -254,6 +255,23 @@ func (s *Server) boxdHost(sandboxID string) (string, error) {
 		return "", fmt.Errorf("parse boxd address %q: %w", s.cfg.Boxd.Addr, err)
 	}
 	return net.JoinHostPort(hostIP, port), nil
+}
+
+func (s *Server) hostAccessIP(sandboxID string) (string, error) {
+	if s.store == nil {
+		return "", errors.New("sandbox store is not configured")
+	}
+	record, err := s.store.GetSandbox(context.Background(), sandboxID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return "", fmt.Errorf("sandbox %q not found", sandboxID)
+		}
+		return "", err
+	}
+	if record.NetworkSlot == 0 {
+		return "", fmt.Errorf("sandbox %q has no active network slot", sandboxID)
+	}
+	return indexedIP(s.cfg.Network.HostAccessCIDR, record.NetworkSlot)
 }
 
 func sandboxIDFromRequest(r *http.Request) string {
@@ -298,32 +316,6 @@ func isProcessConnectPath(rest string) bool {
 	}
 	parts := strings.Split(strings.Trim(rest, "/"), "/")
 	return len(parts) == 3 && parts[0] == "processes" && parts[1] != "" && parts[2] == "connect"
-}
-
-func hostAccessIP(hostAccessCIDR string, vethCIDR string, sandboxID string) (string, error) {
-	slot, err := networkSlotForSandbox(vethCIDR, sandboxID)
-	if err != nil {
-		return "", err
-	}
-	return indexedIP(hostAccessCIDR, slot)
-}
-
-func networkSlotForSandbox(cidr string, sandboxID string) (uint32, error) {
-	_, network, err := net.ParseCIDR(cidr)
-	if err != nil {
-		return 0, fmt.Errorf("parse network cidr %q: %w", cidr, err)
-	}
-	ones, bits := network.Mask.Size()
-	if bits != 32 {
-		return 0, fmt.Errorf("network cidr %q must be IPv4", cidr)
-	}
-	totalIPs := uint32(1) << uint(32-ones)
-	totalSlots := totalIPs / 2
-	if totalSlots <= 2 {
-		return 0, fmt.Errorf("network cidr %q is too small for sandbox slots", cidr)
-	}
-	hash := sha1.Sum([]byte(sandboxID))
-	return (binary.BigEndian.Uint32(hash[:4]) % (totalSlots - 2)) + 1, nil
 }
 
 func indexedIP(cidr string, index uint32) (string, error) {

--- a/internal/boxshim/runtime/firecracker.go
+++ b/internal/boxshim/runtime/firecracker.go
@@ -3,12 +3,10 @@ package runtime
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -124,7 +122,7 @@ func (d *FirecrackerDriver) Pause(ctx context.Context, sandboxID string) (*novit
 		return nil, err
 	}
 
-	if err := d.client.patch(ctx, "/vm", firecrackerVMStateRequest{State: "Paused"}); err != nil {
+	if err := d.client.PauseVM(ctx); err != nil {
 		return nil, d.withLogTail(fmt.Errorf("pause firecracker vm: %w", err))
 	}
 
@@ -139,7 +137,7 @@ func (d *FirecrackerDriver) Pause(ctx context.Context, sandboxID string) (*novit
 		SnapshotPath: paths.tmpSnapfilePath,
 		MemFilePath:  paths.tmpMemfilePath,
 	}
-	if err := d.client.put(ctx, "/snapshot/create", req); err != nil {
+	if err := d.client.CreateSnapshot(ctx, req); err != nil {
 		return nil, d.withLogTail(fmt.Errorf("create firecracker snapshot: %w", err))
 	}
 	if err := paths.commit(); err != nil {
@@ -302,7 +300,7 @@ func (d *FirecrackerDriver) Resume(ctx context.Context, spec *novitaboxv1.Runtim
 		ResumeVM:            true,
 		EnableDiffSnapshots: false,
 	}
-	if err := d.client.put(ctx, "/snapshot/load", req); err != nil {
+	if err := d.client.LoadSnapshot(ctx, req); err != nil {
 		_ = d.killLocked()
 		return nil, d.withLogTail(fmt.Errorf("load firecracker snapshot: %w", err))
 	}
@@ -350,8 +348,7 @@ func (d *FirecrackerDriver) Stop(ctx context.Context, sandboxID string, timeout 
 	}
 
 	if d.client != nil {
-		req := firecrackerActionRequest{ActionType: "SendCtrlAltDel"}
-		if err := d.client.put(ctx, "/actions", req); err != nil {
+		if err := d.client.SendCtrlAltDel(ctx); err != nil {
 			d.logger.Warn("firecracker graceful shutdown failed", "sandbox_id", sandboxID, "error", err)
 		}
 	}
@@ -434,21 +431,21 @@ func (d *FirecrackerDriver) configureMachine(ctx context.Context, spec *novitabo
 		memoryMB = 512
 	}
 
-	if err := d.client.put(ctx, "/machine-config", firecrackerMachineConfig{
+	if err := d.client.PutMachineConfig(ctx, firecrackerMachineConfig{
 		VCPUCount:  int64(vcpu),
 		MemSizeMib: int64(memoryMB),
 	}); err != nil {
 		return fmt.Errorf("configure firecracker machine: %w", err)
 	}
 
-	if err := d.client.put(ctx, "/boot-source", firecrackerBootSource{
+	if err := d.client.PutBootSource(ctx, firecrackerBootSource{
 		KernelImagePath: spec.GetKernel().GetKernelPath(),
 		BootArgs:        bootArgs(spec),
 	}); err != nil {
 		return fmt.Errorf("configure firecracker boot source: %w", err)
 	}
 
-	if err := d.client.put(ctx, "/drives/rootfs", firecrackerDrive{
+	if err := d.client.PutDrive(ctx, firecrackerDrive{
 		DriveID:      "rootfs",
 		PathOnHost:   spec.GetRootfs().GetPath(),
 		IsRootDevice: true,
@@ -463,7 +460,7 @@ func (d *FirecrackerDriver) configureMachine(ctx context.Context, spec *novitabo
 		if drive.GetPath() == "" {
 			return fmt.Errorf("runtime_spec.extra_drives[%s].path is required for firecracker", drive.GetDriveId())
 		}
-		if err := d.client.put(ctx, "/drives/"+drive.GetDriveId(), firecrackerDrive{
+		if err := d.client.PutDrive(ctx, firecrackerDrive{
 			DriveID:      drive.GetDriveId(),
 			PathOnHost:   drive.GetPath(),
 			IsRootDevice: false,
@@ -474,7 +471,7 @@ func (d *FirecrackerDriver) configureMachine(ctx context.Context, spec *novitabo
 	}
 
 	if spec.GetNetwork() != nil && spec.GetNetwork().GetTapName() != "" {
-		if err := d.client.put(ctx, "/network-interfaces/eth0", firecrackerNetworkInterface{
+		if err := d.client.PutNetworkInterface(ctx, firecrackerNetworkInterface{
 			IfaceID:     "eth0",
 			HostDevName: spec.GetNetwork().GetTapName(),
 			GuestMAC:    spec.GetNetwork().GetMac(),
@@ -483,7 +480,7 @@ func (d *FirecrackerDriver) configureMachine(ctx context.Context, spec *novitabo
 		}
 	}
 
-	if err := d.client.put(ctx, "/actions", firecrackerActionRequest{ActionType: "InstanceStart"}); err != nil {
+	if err := d.client.StartInstance(ctx); err != nil {
 		return fmt.Errorf("start firecracker instance: %w", err)
 	}
 
@@ -793,115 +790,4 @@ func joinArgs(args []string) string {
 		buf.WriteString(arg)
 	}
 	return buf.String()
-}
-
-type firecrackerClient struct {
-	socketPath string
-	httpClient *http.Client
-}
-
-func newFirecrackerClient(socketPath string) *firecrackerClient {
-	return &firecrackerClient{
-		socketPath: socketPath,
-		httpClient: &http.Client{
-			Transport: &http.Transport{
-				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-					return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
-				},
-			},
-		},
-	}
-}
-
-func (c *firecrackerClient) get(ctx context.Context, path string) error {
-	return c.do(ctx, http.MethodGet, path, nil)
-}
-
-func (c *firecrackerClient) put(ctx context.Context, path string, body any) error {
-	return c.do(ctx, http.MethodPut, path, body)
-}
-
-func (c *firecrackerClient) patch(ctx context.Context, path string, body any) error {
-	return c.do(ctx, http.MethodPatch, path, body)
-}
-
-func (c *firecrackerClient) do(ctx context.Context, method string, path string, body any) error {
-	var r io.Reader
-	if body != nil {
-		data, err := json.Marshal(body)
-		if err != nil {
-			return fmt.Errorf("marshal firecracker request: %w", err)
-		}
-		r = bytes.NewReader(data)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, method, "http://unix"+path, r)
-	if err != nil {
-		return fmt.Errorf("create firecracker request: %w", err)
-	}
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		return nil
-	}
-
-	data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	return fmt.Errorf("firecracker api %s %s failed: status=%d body=%s", method, path, resp.StatusCode, string(data))
-}
-
-type firecrackerMachineConfig struct {
-	VCPUCount  int64 `json:"vcpu_count"`
-	MemSizeMib int64 `json:"mem_size_mib"`
-}
-
-type firecrackerBootSource struct {
-	KernelImagePath string `json:"kernel_image_path"`
-	BootArgs        string `json:"boot_args,omitempty"`
-}
-
-type firecrackerDrive struct {
-	DriveID      string `json:"drive_id"`
-	PathOnHost   string `json:"path_on_host"`
-	IsRootDevice bool   `json:"is_root_device"`
-	IsReadOnly   bool   `json:"is_read_only"`
-}
-
-type firecrackerNetworkInterface struct {
-	IfaceID     string `json:"iface_id"`
-	HostDevName string `json:"host_dev_name"`
-	GuestMAC    string `json:"guest_mac,omitempty"`
-}
-
-type firecrackerActionRequest struct {
-	ActionType string `json:"action_type"`
-}
-
-type firecrackerVMStateRequest struct {
-	State string `json:"state"`
-}
-
-type firecrackerSnapshotCreateRequest struct {
-	SnapshotType string `json:"snapshot_type"`
-	SnapshotPath string `json:"snapshot_path"`
-	MemFilePath  string `json:"mem_file_path"`
-}
-
-type firecrackerMemBackend struct {
-	BackendPath string `json:"backend_path"`
-	BackendType string `json:"backend_type"`
-}
-
-type firecrackerSnapshotLoadRequest struct {
-	SnapshotPath        string                `json:"snapshot_path"`
-	MemBackend          firecrackerMemBackend `json:"mem_backend"`
-	ResumeVM            bool                  `json:"resume_vm"`
-	EnableDiffSnapshots bool                  `json:"enable_diff_snapshots"`
 }

--- a/internal/boxshim/runtime/firecracker_api.go
+++ b/internal/boxshim/runtime/firecracker_api.go
@@ -1,0 +1,171 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+)
+
+const (
+	firecrackerPathMachineConfig  = "/machine-config"
+	firecrackerPathBootSource     = "/boot-source"
+	firecrackerPathActions        = "/actions"
+	firecrackerPathVM             = "/vm"
+	firecrackerPathSnapshotLoad   = "/snapshot/load"
+	firecrackerPathSnapshotCreate = "/snapshot/create"
+)
+
+func firecrackerDrivePath(driveID string) string {
+	return "/drives/" + driveID
+}
+
+func firecrackerNetworkInterfacePath(ifaceID string) string {
+	return "/network-interfaces/" + ifaceID
+}
+
+type firecrackerClient struct {
+	socketPath string
+	httpClient *http.Client
+}
+
+func newFirecrackerClient(socketPath string) *firecrackerClient {
+	return &firecrackerClient{
+		socketPath: socketPath,
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+				},
+			},
+		},
+	}
+}
+
+func (c *firecrackerClient) PutMachineConfig(ctx context.Context, req firecrackerMachineConfig) error {
+	return c.put(ctx, firecrackerPathMachineConfig, req)
+}
+
+func (c *firecrackerClient) PutBootSource(ctx context.Context, req firecrackerBootSource) error {
+	return c.put(ctx, firecrackerPathBootSource, req)
+}
+
+func (c *firecrackerClient) PutDrive(ctx context.Context, req firecrackerDrive) error {
+	return c.put(ctx, firecrackerDrivePath(req.DriveID), req)
+}
+
+func (c *firecrackerClient) PutNetworkInterface(ctx context.Context, req firecrackerNetworkInterface) error {
+	return c.put(ctx, firecrackerNetworkInterfacePath(req.IfaceID), req)
+}
+
+func (c *firecrackerClient) StartInstance(ctx context.Context) error {
+	return c.put(ctx, firecrackerPathActions, firecrackerActionRequest{ActionType: "InstanceStart"})
+}
+
+func (c *firecrackerClient) SendCtrlAltDel(ctx context.Context) error {
+	return c.put(ctx, firecrackerPathActions, firecrackerActionRequest{ActionType: "SendCtrlAltDel"})
+}
+
+func (c *firecrackerClient) PauseVM(ctx context.Context) error {
+	return c.patch(ctx, firecrackerPathVM, firecrackerVMStateRequest{State: "Paused"})
+}
+
+func (c *firecrackerClient) CreateSnapshot(ctx context.Context, req firecrackerSnapshotCreateRequest) error {
+	return c.put(ctx, firecrackerPathSnapshotCreate, req)
+}
+
+func (c *firecrackerClient) LoadSnapshot(ctx context.Context, req firecrackerSnapshotLoadRequest) error {
+	return c.put(ctx, firecrackerPathSnapshotLoad, req)
+}
+
+func (c *firecrackerClient) put(ctx context.Context, path string, body any) error {
+	return c.do(ctx, http.MethodPut, path, body)
+}
+
+func (c *firecrackerClient) patch(ctx context.Context, path string, body any) error {
+	return c.do(ctx, http.MethodPatch, path, body)
+}
+
+func (c *firecrackerClient) do(ctx context.Context, method string, path string, body any) error {
+	var r io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal firecracker request: %w", err)
+		}
+		r = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, "http://unix"+path, r)
+	if err != nil {
+		return fmt.Errorf("create firecracker request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	return fmt.Errorf("firecracker api %s %s failed: status=%d body=%s", method, path, resp.StatusCode, string(data))
+}
+
+type firecrackerMachineConfig struct {
+	VCPUCount  int64 `json:"vcpu_count"`
+	MemSizeMib int64 `json:"mem_size_mib"`
+}
+
+type firecrackerBootSource struct {
+	KernelImagePath string `json:"kernel_image_path"`
+	BootArgs        string `json:"boot_args,omitempty"`
+}
+
+type firecrackerDrive struct {
+	DriveID      string `json:"drive_id"`
+	PathOnHost   string `json:"path_on_host"`
+	IsRootDevice bool   `json:"is_root_device"`
+	IsReadOnly   bool   `json:"is_read_only"`
+}
+
+type firecrackerNetworkInterface struct {
+	IfaceID     string `json:"iface_id"`
+	HostDevName string `json:"host_dev_name"`
+	GuestMAC    string `json:"guest_mac,omitempty"`
+}
+
+type firecrackerActionRequest struct {
+	ActionType string `json:"action_type"`
+}
+
+type firecrackerVMStateRequest struct {
+	State string `json:"state"`
+}
+
+type firecrackerSnapshotCreateRequest struct {
+	SnapshotType string `json:"snapshot_type"`
+	SnapshotPath string `json:"snapshot_path"`
+	MemFilePath  string `json:"mem_file_path"`
+}
+
+type firecrackerMemBackend struct {
+	BackendPath string `json:"backend_path"`
+	BackendType string `json:"backend_type"`
+}
+
+type firecrackerSnapshotLoadRequest struct {
+	SnapshotPath        string                `json:"snapshot_path"`
+	MemBackend          firecrackerMemBackend `json:"mem_backend"`
+	ResumeVM            bool                  `json:"resume_vm"`
+	EnableDiffSnapshots bool                  `json:"enable_diff_snapshots"`
+}

--- a/internal/pb/novitabox/v1/types.pb.go
+++ b/internal/pb/novitabox/v1/types.pb.go
@@ -903,6 +903,7 @@ type NetworkSpec struct {
 	GatewayIp     string                 `protobuf:"bytes,4,opt,name=gateway_ip,json=gatewayIp,proto3" json:"gateway_ip,omitempty"`
 	HostAccessIp  string                 `protobuf:"bytes,5,opt,name=host_access_ip,json=hostAccessIp,proto3" json:"host_access_ip,omitempty"`
 	Mac           string                 `protobuf:"bytes,6,opt,name=mac,proto3" json:"mac,omitempty"`
+	Slot          uint32                 `protobuf:"varint,7,opt,name=slot,proto3" json:"slot,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -977,6 +978,13 @@ func (x *NetworkSpec) GetMac() string {
 		return x.Mac
 	}
 	return ""
+}
+
+func (x *NetworkSpec) GetSlot() uint32 {
+	if x != nil {
+		return x.Slot
+	}
+	return 0
 }
 
 type AgentSpec struct {
@@ -1612,7 +1620,7 @@ const file_novitabox_v1_types_proto_rawDesc = "" +
 	"\fSnapshotSpec\x12!\n" +
 	"\fmemfile_path\x18\x01 \x01(\tR\vmemfilePath\x12#\n" +
 	"\rsnapfile_path\x18\x02 \x01(\tR\fsnapfilePath\x12#\n" +
-	"\rsnapshot_type\x18\x03 \x01(\tR\fsnapshotType\"\xc1\x01\n" +
+	"\rsnapshot_type\x18\x03 \x01(\tR\fsnapshotType\"\xd5\x01\n" +
 	"\vNetworkSpec\x12%\n" +
 	"\x0enamespace_name\x18\x01 \x01(\tR\rnamespaceName\x12\x19\n" +
 	"\btap_name\x18\x02 \x01(\tR\atapName\x12\x19\n" +
@@ -1620,7 +1628,8 @@ const file_novitabox_v1_types_proto_rawDesc = "" +
 	"\n" +
 	"gateway_ip\x18\x04 \x01(\tR\tgatewayIp\x12$\n" +
 	"\x0ehost_access_ip\x18\x05 \x01(\tR\fhostAccessIp\x12\x10\n" +
-	"\x03mac\x18\x06 \x01(\tR\x03mac\"e\n" +
+	"\x03mac\x18\x06 \x01(\tR\x03mac\x12\x12\n" +
+	"\x04slot\x18\a \x01(\rR\x04slot\"e\n" +
 	"\tAgentSpec\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x1a\n" +
 	"\bprotocol\x18\x02 \x01(\tR\bprotocol\x12\x12\n" +

--- a/internal/storage/store/sqlite/migrations.go
+++ b/internal/storage/store/sqlite/migrations.go
@@ -108,6 +108,13 @@ ALTER TABLE templates ADD COLUMN cpu_count INTEGER NOT NULL DEFAULT 1;
 ALTER TABLE templates ADD COLUMN memory_mb INTEGER NOT NULL DEFAULT 512;
 `,
 	},
+	{
+		version: 3,
+		sql: `
+ALTER TABLE sandboxes ADD COLUMN network_slot INTEGER NOT NULL DEFAULT 0;
+CREATE UNIQUE INDEX idx_sandboxes_network_slot ON sandboxes(network_slot) WHERE network_slot > 0;
+`,
+	},
 }
 
 func (s *Store) migrate(ctx context.Context) error {

--- a/internal/storage/store/sqlite/sandbox.go
+++ b/internal/storage/store/sqlite/sandbox.go
@@ -20,15 +20,16 @@ func (s *Store) CreateSandbox(ctx context.Context, record store.SandboxRecord) e
 	}
 
 	_, err := s.db.ExecContext(ctx, `
-INSERT INTO sandboxes (
-  sandbox_id, state, runtime_type, template_id, image_id, snapshot_id, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+	INSERT INTO sandboxes (
+	  sandbox_id, state, runtime_type, template_id, image_id, snapshot_id, network_slot, created_at, updated_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		record.ID,
 		string(record.State),
 		record.RuntimeType,
 		record.TemplateID,
 		record.ImageID,
 		record.SnapshotID,
+		record.NetworkSlot,
 		record.CreatedAt.Unix(),
 		record.UpdatedAt.Unix(),
 	)
@@ -41,9 +42,9 @@ INSERT INTO sandboxes (
 
 func (s *Store) GetSandbox(ctx context.Context, sandboxID string) (*store.SandboxRecord, error) {
 	row := s.db.QueryRowContext(ctx, `
-SELECT sandbox_id, state, runtime_type, template_id, image_id, snapshot_id, created_at, updated_at
-FROM sandboxes
-WHERE sandbox_id = ?`, sandboxID)
+	SELECT sandbox_id, state, runtime_type, template_id, image_id, snapshot_id, network_slot, created_at, updated_at
+	FROM sandboxes
+	WHERE sandbox_id = ?`, sandboxID)
 
 	record, err := scanSandbox(row)
 	if err != nil {
@@ -55,9 +56,9 @@ WHERE sandbox_id = ?`, sandboxID)
 
 func (s *Store) ListSandboxes(ctx context.Context) ([]store.SandboxRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
-SELECT sandbox_id, state, runtime_type, template_id, image_id, snapshot_id, created_at, updated_at
-FROM sandboxes
-ORDER BY created_at DESC, sandbox_id DESC`)
+	SELECT sandbox_id, state, runtime_type, template_id, image_id, snapshot_id, network_slot, created_at, updated_at
+	FROM sandboxes
+	ORDER BY created_at DESC, sandbox_id DESC`)
 	if err != nil {
 		return nil, fmt.Errorf("list sandboxes: %w", err)
 	}
@@ -116,6 +117,102 @@ INSERT INTO state_transitions (
 	return nil
 }
 
+func (s *Store) AssignSandboxNetworkSlot(ctx context.Context, sandboxID string, maxSlot uint32) (uint32, error) {
+	if maxSlot == 0 {
+		return 0, fmt.Errorf("max network slot must be greater than 0")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin sandbox network slot assignment: %w", err)
+	}
+	defer tx.Rollback()
+
+	var existing uint32
+	err = tx.QueryRowContext(ctx, "SELECT network_slot FROM sandboxes WHERE sandbox_id = ?", sandboxID).Scan(&existing)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, store.ErrNotFound
+		}
+		return 0, fmt.Errorf("query sandbox %q network slot: %w", sandboxID, err)
+	}
+	if existing > 0 {
+		if err := tx.Commit(); err != nil {
+			return 0, fmt.Errorf("commit sandbox %q existing network slot: %w", sandboxID, err)
+		}
+		return existing, nil
+	}
+
+	rows, err := tx.QueryContext(ctx, "SELECT network_slot FROM sandboxes WHERE network_slot > 0 ORDER BY network_slot")
+	if err != nil {
+		return 0, fmt.Errorf("list assigned network slots: %w", err)
+	}
+	used := make(map[uint32]struct{})
+	for rows.Next() {
+		var slot uint32
+		if err := rows.Scan(&slot); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("scan assigned network slot: %w", err)
+		}
+		used[slot] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return 0, fmt.Errorf("iterate assigned network slots: %w", err)
+	}
+	rows.Close()
+
+	var slot uint32
+	for candidate := uint32(1); candidate <= maxSlot; candidate++ {
+		if _, ok := used[candidate]; !ok {
+			slot = candidate
+			break
+		}
+	}
+	if slot == 0 {
+		return 0, fmt.Errorf("no sandbox network slots available")
+	}
+
+	now := unixNow()
+	result, err := tx.ExecContext(ctx, `
+	UPDATE sandboxes
+	SET network_slot = ?, updated_at = ?
+	WHERE sandbox_id = ? AND network_slot = 0`, slot, now, sandboxID)
+	if err != nil {
+		return 0, fmt.Errorf("assign sandbox %q network slot: %w", sandboxID, err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("read sandbox %q network slot assignment result: %w", sandboxID, err)
+	}
+	if affected == 0 {
+		return 0, store.ErrNotFound
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit sandbox %q network slot assignment: %w", sandboxID, err)
+	}
+
+	return slot, nil
+}
+
+func (s *Store) ReleaseSandboxNetworkSlot(ctx context.Context, sandboxID string) error {
+	result, err := s.db.ExecContext(ctx, `
+	UPDATE sandboxes
+	SET network_slot = 0, updated_at = ?
+	WHERE sandbox_id = ?`, unixNow(), sandboxID)
+	if err != nil {
+		return fmt.Errorf("release sandbox %q network slot: %w", sandboxID, err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read sandbox %q network slot release result: %w", sandboxID, err)
+	}
+	if affected == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
 func (s *Store) DeleteSandbox(ctx context.Context, sandboxID string) error {
 	result, err := s.db.ExecContext(ctx, "DELETE FROM sandboxes WHERE sandbox_id = ?", sandboxID)
 	if err != nil {
@@ -150,6 +247,7 @@ func scanSandbox(row scanner) (store.SandboxRecord, error) {
 		&record.TemplateID,
 		&record.ImageID,
 		&record.SnapshotID,
+		&record.NetworkSlot,
 		&createdAt,
 		&updatedAt,
 	); err != nil {

--- a/internal/storage/store/sqlite/store_test.go
+++ b/internal/storage/store/sqlite/store_test.go
@@ -84,6 +84,45 @@ func TestSandboxStateUpdateRequiresExpectedState(t *testing.T) {
 	}
 }
 
+func TestSandboxNetworkSlotLease(t *testing.T) {
+	ctx := context.Background()
+	st := openStore(t)
+	defer st.Close()
+
+	if err := st.CreateSandbox(ctx, store.SandboxRecord{ID: "sbx-1", State: sandbox.StateRunning}); err != nil {
+		t.Fatalf("CreateSandbox(sbx-1) error = %v", err)
+	}
+	if err := st.CreateSandbox(ctx, store.SandboxRecord{ID: "sbx-2", State: sandbox.StateRunning}); err != nil {
+		t.Fatalf("CreateSandbox(sbx-2) error = %v", err)
+	}
+
+	slot1, err := st.AssignSandboxNetworkSlot(ctx, "sbx-1", 2)
+	if err != nil {
+		t.Fatalf("AssignSandboxNetworkSlot(sbx-1) error = %v", err)
+	}
+	if slot1 != 1 {
+		t.Fatalf("slot1 = %d, want 1", slot1)
+	}
+	slot2, err := st.AssignSandboxNetworkSlot(ctx, "sbx-2", 2)
+	if err != nil {
+		t.Fatalf("AssignSandboxNetworkSlot(sbx-2) error = %v", err)
+	}
+	if slot2 != 2 {
+		t.Fatalf("slot2 = %d, want 2", slot2)
+	}
+
+	if err := st.ReleaseSandboxNetworkSlot(ctx, "sbx-1"); err != nil {
+		t.Fatalf("ReleaseSandboxNetworkSlot() error = %v", err)
+	}
+	slot1Again, err := st.AssignSandboxNetworkSlot(ctx, "sbx-1", 2)
+	if err != nil {
+		t.Fatalf("AssignSandboxNetworkSlot(sbx-1 again) error = %v", err)
+	}
+	if slot1Again != 1 {
+		t.Fatalf("slot1Again = %d, want released slot 1", slot1Again)
+	}
+}
+
 func TestArtifactCRUD(t *testing.T) {
 	ctx := context.Background()
 	st := openStore(t)

--- a/internal/storage/store/store.go
+++ b/internal/storage/store/store.go
@@ -17,6 +17,7 @@ type SandboxRecord struct {
 	TemplateID  string
 	ImageID     string
 	SnapshotID  string
+	NetworkSlot uint32
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 }
@@ -87,6 +88,8 @@ type Store interface {
 	GetSandbox(ctx context.Context, sandboxID string) (*SandboxRecord, error)
 	ListSandboxes(ctx context.Context) ([]SandboxRecord, error)
 	UpdateSandboxState(ctx context.Context, sandboxID string, from, to sandbox.State, action string) error
+	AssignSandboxNetworkSlot(ctx context.Context, sandboxID string, maxSlot uint32) (uint32, error)
+	ReleaseSandboxNetworkSlot(ctx context.Context, sandboxID string) error
 	DeleteSandbox(ctx context.Context, sandboxID string) error
 
 	CreateImage(ctx context.Context, record ImageRecord) error

--- a/proto/novitabox/v1/types.proto
+++ b/proto/novitabox/v1/types.proto
@@ -117,6 +117,7 @@ message NetworkSpec {
   string gateway_ip = 4;
   string host_access_ip = 5;
   string mac = 6;
+  uint32 slot = 7;
 }
 
 message AgentSpec {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,498 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# One-command NovitaBox installer for a single Linux host.
+#
+# Default usage from the repository root:
+#   sudo scripts/install.sh
+#
+# Common overrides:
+#   ROOT_DIR=/data/novitabox IMAGE_SIZE=100G DOMAIN=novitabox.local sudo -E scripts/install.sh
+#   FIRECRACKER_URL=https://.../firecracker KERNEL_URL=https://.../vmlinux.bin sudo -E scripts/install.sh
+#   FIRECRACKER_PATH=/path/to/firecracker KERNEL_PATH=/path/to/vmlinux.bin sudo -E scripts/install.sh
+
+ROOT_DIR="${ROOT_DIR:-/data/novitabox}"
+IMAGE_PATH="${IMAGE_PATH:-/data/novitabox.img}"
+IMAGE_SIZE="${IMAGE_SIZE:-50G}"
+DOMAIN="${DOMAIN:-novitabox.local}"
+RELEASE_VERSION="${RELEASE_VERSION:-v0.0.1}"
+SOURCE_DIR="${SOURCE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+INSTALL_GO="${INSTALL_GO:-auto}"
+GO_VERSION="${GO_VERSION:-1.26.4}"
+ENABLE_DNS="${ENABLE_DNS:-1}"
+ENABLE_CADDY="${ENABLE_CADDY:-1}"
+REQUIRE_KVM="${REQUIRE_KVM:-1}"
+BOXAPI_ADDR="${BOXAPI_ADDR:-127.0.0.1:8080}"
+BOXLET_ADDR="${BOXLET_ADDR:-127.0.0.1:8081}"
+BOXPROXY_ADDR="${BOXPROXY_ADDR:-127.0.0.1:8082}"
+
+FIRECRACKER_URL="${FIRECRACKER_URL:-https://github.com/novitalabs/NovitaBox/releases/download/${RELEASE_VERSION}/firecracker}"
+KERNEL_URL="${KERNEL_URL:-https://github.com/novitalabs/NovitaBox/releases/download/${RELEASE_VERSION}/vmlinux.bin}"
+FIRECRACKER_PATH="${FIRECRACKER_PATH:-}"
+KERNEL_PATH="${KERNEL_PATH:-}"
+
+COMMANDS=(boxapi boxctl boxd boxlet boxproxy boxshim)
+
+log() {
+  printf '[novitabox] %s\n' "$*"
+}
+
+warn() {
+  printf '[novitabox] warning: %s\n' "$*" >&2
+}
+
+die() {
+  printf '[novitabox] error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_root() {
+  if [[ "${EUID}" -ne 0 ]]; then
+    die "run as root, for example: sudo -E scripts/install.sh"
+  fi
+}
+
+need_no_spaces() {
+  case "$ROOT_DIR $IMAGE_PATH $SOURCE_DIR" in
+    *" "*) die "ROOT_DIR, IMAGE_PATH, and SOURCE_DIR must not contain spaces" ;;
+  esac
+}
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64 | amd64) echo "amd64" ;;
+    aarch64 | arm64) echo "arm64" ;;
+    *) die "unsupported architecture: $(uname -m)" ;;
+  esac
+}
+
+install_packages() {
+ log "installing system packages"
+  local packages=(
+    bash ca-certificates curl git make gcc
+    btrfs-progs coreutils findutils iptables kmod util-linux
+  )
+  if command_exists apt-get; then
+    local apt_packages=("${packages[@]}" libc6-dev iproute2 procps)
+    if [[ "$ENABLE_DNS" == "1" ]]; then
+      apt_packages+=(dnsmasq)
+    fi
+    if [[ "$ENABLE_CADDY" == "1" ]]; then
+      apt_packages+=(caddy)
+    fi
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y "${apt_packages[@]}"
+    return
+  fi
+
+  if command_exists dnf; then
+    local dnf_packages=("${packages[@]}" glibc-devel iproute procps-ng)
+    if [[ "$ENABLE_DNS" == "1" ]]; then
+      dnf_packages+=(dnsmasq)
+    fi
+    if [[ "$ENABLE_CADDY" == "1" ]]; then
+      dnf_packages+=(caddy)
+    fi
+    dnf install -y "${dnf_packages[@]}"
+    return
+  fi
+
+  if command_exists yum; then
+    local yum_packages=("${packages[@]}" glibc-devel iproute procps-ng)
+    if [[ "$ENABLE_DNS" == "1" ]]; then
+      yum_packages+=(dnsmasq)
+    fi
+    if [[ "$ENABLE_CADDY" == "1" ]]; then
+      yum_packages+=(caddy)
+    fi
+    yum install -y "${yum_packages[@]}"
+    return
+  fi
+
+  die "unsupported package manager; install dependencies manually and rerun"
+}
+
+version_ge() {
+  local have="$1"
+  local want="$2"
+  [[ "$(printf '%s\n%s\n' "$want" "$have" | sort -V | head -n1)" == "$want" ]]
+}
+
+current_go_version() {
+  if ! command_exists go; then
+    return 1
+  fi
+  go env GOVERSION 2>/dev/null | sed 's/^go//'
+}
+
+ensure_go() {
+  local arch="$1"
+  local have=""
+  have="$(current_go_version || true)"
+
+  if [[ -n "$have" ]] && version_ge "$have" "1.26.0" && [[ "$INSTALL_GO" != "1" ]]; then
+    log "using existing Go $have"
+    return
+  fi
+
+  if [[ "$INSTALL_GO" == "0" ]]; then
+    die "Go >= 1.26.0 is required, found ${have:-none}"
+  fi
+
+  log "installing Go ${GO_VERSION} for linux-${arch}"
+  local tarball="/tmp/go${GO_VERSION}.linux-${arch}.tar.gz"
+  curl -fL "https://go.dev/dl/go${GO_VERSION}.linux-${arch}.tar.gz" -o "$tarball"
+  rm -rf "/usr/local/go${GO_VERSION}"
+  mkdir -p "/usr/local/go${GO_VERSION}"
+  tar -C "/usr/local/go${GO_VERSION}" --strip-components=1 -xzf "$tarball"
+  ln -sf "/usr/local/go${GO_VERSION}/bin/go" /usr/local/bin/go
+  ln -sf "/usr/local/go${GO_VERSION}/bin/gofmt" /usr/local/bin/gofmt
+}
+
+prepare_btrfs_root() {
+  log "preparing btrfs root at ${ROOT_DIR}"
+  mkdir -p "$(dirname "$IMAGE_PATH")" "$ROOT_DIR"
+
+  if findmnt -rn --target "$ROOT_DIR" >/dev/null 2>&1; then
+    local fstype
+    fstype="$(findmnt -rn --target "$ROOT_DIR" -o FSTYPE)"
+    if [[ "$fstype" != "btrfs" ]]; then
+      die "$ROOT_DIR is mounted as $fstype, but NovitaBox requires btrfs for this installer"
+    fi
+    log "$ROOT_DIR is already mounted as btrfs"
+    return
+  fi
+
+  if [[ -n "$(find "$ROOT_DIR" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]] && [[ "${ALLOW_MOUNT_OVER_NONEMPTY:-0}" != "1" ]]; then
+    die "$ROOT_DIR is not empty and is not a mount point; set ALLOW_MOUNT_OVER_NONEMPTY=1 to mount over it"
+  fi
+
+  if [[ ! -f "$IMAGE_PATH" ]]; then
+    log "creating btrfs image ${IMAGE_PATH} size ${IMAGE_SIZE}"
+    truncate -s "$IMAGE_SIZE" "$IMAGE_PATH"
+    mkfs.btrfs -f "$IMAGE_PATH"
+  else
+    local existing_type=""
+    existing_type="$(blkid -o value -s TYPE "$IMAGE_PATH" 2>/dev/null || true)"
+    if [[ -z "$existing_type" ]]; then
+      log "formatting existing image ${IMAGE_PATH} as btrfs"
+      mkfs.btrfs -f "$IMAGE_PATH"
+    elif [[ "$existing_type" != "btrfs" ]]; then
+      die "$IMAGE_PATH has filesystem $existing_type, expected btrfs"
+    fi
+  fi
+
+  mount -o loop,compress=zstd,noatime "$IMAGE_PATH" "$ROOT_DIR"
+
+  local fstab_line="${IMAGE_PATH} ${ROOT_DIR} btrfs loop,compress=zstd,noatime 0 0"
+  if ! grep -Fqs "$IMAGE_PATH $ROOT_DIR btrfs" /etc/fstab; then
+    printf '%s\n' "$fstab_line" >>/etc/fstab
+  fi
+}
+
+verify_reflink() {
+  log "verifying reflink support"
+  local tmpdir
+  tmpdir="$(mktemp -d "${ROOT_DIR}/.reflink-test.XXXXXX")"
+  printf test >"${tmpdir}/a"
+  cp --reflink=always "${tmpdir}/a" "${tmpdir}/b"
+  rm -rf "$tmpdir"
+}
+
+prepare_kernel_modules() {
+  log "checking KVM and TUN"
+  modprobe tun >/dev/null 2>&1 || true
+  if [[ ! -c /dev/net/tun ]]; then
+    die "/dev/net/tun is missing"
+  fi
+
+  modprobe kvm >/dev/null 2>&1 || true
+  case "$(uname -m)" in
+    x86_64 | amd64)
+      if grep -Eq 'vmx' /proc/cpuinfo 2>/dev/null; then
+        modprobe kvm_intel >/dev/null 2>&1 || true
+      elif grep -Eq 'svm' /proc/cpuinfo 2>/dev/null; then
+        modprobe kvm_amd >/dev/null 2>&1 || true
+      fi
+      ;;
+  esac
+
+  if [[ ! -e /dev/kvm ]]; then
+    if [[ "$REQUIRE_KVM" == "1" ]]; then
+      die "/dev/kvm is missing; enable virtualization/KVM or rerun with REQUIRE_KVM=0"
+    fi
+    warn "/dev/kvm is missing; Firecracker sandboxes will not start"
+  fi
+}
+
+configure_sysctl() {
+  log "configuring host networking sysctl"
+  cat >/etc/sysctl.d/99-novitabox.conf <<'EOF'
+net.ipv4.ip_forward=1
+EOF
+  sysctl --system >/dev/null
+}
+
+build_components() {
+  local arch="$1"
+  log "building NovitaBox linux-${arch} components"
+  make -C "$SOURCE_DIR" "build-linux-${arch}"
+}
+
+install_components() {
+  local arch="$1"
+  log "installing components to ${ROOT_DIR}"
+  mkdir -p "$ROOT_DIR/db" "$ROOT_DIR/templates" "$ROOT_DIR/images" "$ROOT_DIR/sandboxes" "$ROOT_DIR/logs"
+  for cmd in "${COMMANDS[@]}"; do
+    install -m 0755 "${SOURCE_DIR}/bin/linux-${arch}/${cmd}" "${ROOT_DIR}/${cmd}"
+  done
+}
+
+install_asset() {
+  local name="$1"
+  local src_path="$2"
+  local url="$3"
+  local dest="$4"
+  local mode="$5"
+
+  if [[ -n "$src_path" ]]; then
+    log "installing ${name} from ${src_path}"
+    install -m "$mode" "$src_path" "$dest"
+    return
+  fi
+
+  if [[ -s "$dest" ]]; then
+    log "${name} already exists at ${dest}"
+    chmod "$mode" "$dest"
+    return
+  fi
+
+  log "downloading ${name} from ${url}"
+  curl -fL "$url" -o "${dest}.tmp"
+  chmod "$mode" "${dest}.tmp"
+  mv -f "${dest}.tmp" "$dest"
+}
+
+install_runtime_assets() {
+  install_asset "firecracker" "$FIRECRACKER_PATH" "$FIRECRACKER_URL" "${ROOT_DIR}/firecracker" 0755
+  install_asset "kernel" "$KERNEL_PATH" "$KERNEL_URL" "${ROOT_DIR}/vmlinux.bin" 0644
+}
+
+write_systemd_units() {
+  log "writing systemd services"
+  cat >/etc/systemd/system/novitabox-boxlet.service <<EOF
+[Unit]
+Description=NovitaBox node agent
+After=network-online.target
+Wants=network-online.target
+RequiresMountsFor=${ROOT_DIR}
+
+[Service]
+Type=simple
+WorkingDirectory=${ROOT_DIR}
+ExecStart=${ROOT_DIR}/boxlet --root ${ROOT_DIR} --addr ${BOXLET_ADDR}
+Restart=always
+RestartSec=2
+KillMode=process
+LimitNOFILE=1048576
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  cat >/etc/systemd/system/novitabox-boxapi.service <<EOF
+[Unit]
+Description=NovitaBox HTTP API
+After=network-online.target novitabox-boxlet.service
+Wants=network-online.target
+Requires=novitabox-boxlet.service
+RequiresMountsFor=${ROOT_DIR}
+
+[Service]
+Type=simple
+WorkingDirectory=${ROOT_DIR}
+ExecStart=${ROOT_DIR}/boxapi --root ${ROOT_DIR} --addr ${BOXAPI_ADDR} --boxlet-addr ${BOXLET_ADDR}
+Restart=always
+RestartSec=2
+LimitNOFILE=1048576
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  cat >/etc/systemd/system/novitabox-boxproxy.service <<EOF
+[Unit]
+Description=NovitaBox sandbox proxy
+After=network-online.target novitabox-boxlet.service
+Wants=network-online.target
+RequiresMountsFor=${ROOT_DIR}
+
+[Service]
+Type=simple
+WorkingDirectory=${ROOT_DIR}
+ExecStart=${ROOT_DIR}/boxproxy --root ${ROOT_DIR} --addr ${BOXPROXY_ADDR}
+Restart=always
+RestartSec=2
+LimitNOFILE=1048576
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  systemctl daemon-reload
+  systemctl enable --now novitabox-boxlet.service novitabox-boxapi.service novitabox-boxproxy.service
+}
+
+configure_dnsmasq() {
+  if [[ "$ENABLE_DNS" != "1" ]]; then
+    log "skipping dnsmasq configuration"
+    return
+  fi
+
+  log "configuring dnsmasq for *.${DOMAIN}"
+  cat >/etc/dnsmasq.d/novitabox.conf <<EOF
+listen-address=127.0.0.1
+bind-interfaces
+no-resolv
+server=1.1.1.1
+server=8.8.8.8
+address=/.${DOMAIN}/127.0.0.1
+address=/.${DOMAIN}/::1
+EOF
+  systemctl enable --now dnsmasq
+  systemctl restart dnsmasq
+
+  if systemctl list-unit-files systemd-resolved.service >/dev/null 2>&1; then
+    mkdir -p /etc/systemd/resolved.conf.d
+    cat >/etc/systemd/resolved.conf.d/novitabox.conf <<EOF
+[Resolve]
+DNS=127.0.0.1
+Domains=~${DOMAIN}
+EOF
+    systemctl restart systemd-resolved || warn "failed to restart systemd-resolved"
+  fi
+}
+
+configure_caddy() {
+  if [[ "$ENABLE_CADDY" != "1" ]]; then
+    log "skipping Caddy reverse proxy"
+    return
+  fi
+  if ! command_exists caddy; then
+    die "caddy is not installed; install it manually or rerun with ENABLE_CADDY=0"
+  fi
+
+  log "configuring Caddy reverse proxy for ${DOMAIN}"
+  cat >/etc/caddy/Caddyfile <<EOF
+{
+	admin off
+}
+
+${DOMAIN} {
+	tls internal
+	reverse_proxy ${BOXAPI_ADDR}
+}
+
+*.${DOMAIN} {
+	tls internal
+	reverse_proxy ${BOXPROXY_ADDR}
+}
+EOF
+
+  systemctl enable --now caddy
+  systemctl restart caddy
+
+  curl -kfsS --resolve "${DOMAIN}:443:127.0.0.1" "https://${DOMAIN}/health" >/dev/null || true
+
+  local root_ca=""
+  root_ca="$(find /var/lib/caddy -path '*/pki/authorities/local/root.crt' -print -quit 2>/dev/null || true)"
+  if [[ -n "$root_ca" ]]; then
+    install -m 0644 "$root_ca" /usr/local/share/ca-certificates/caddy-local.crt
+    update-ca-certificates >/dev/null || true
+    log "installed Caddy local CA at /usr/local/share/ca-certificates/caddy-local.crt"
+  else
+    warn "Caddy local CA was not found; clients may need to trust Caddy's internal CA manually"
+  fi
+}
+
+wait_http() {
+  local url="$1"
+  local name="$2"
+  local deadline=$((SECONDS + 30))
+  until curl -fsS "$url" >/dev/null 2>&1; do
+    if (( SECONDS >= deadline )); then
+      systemctl --no-pager --full status "novitabox-${name}.service" || true
+      die "${name} did not become healthy at ${url}"
+    fi
+    sleep 1
+  done
+}
+
+health_check() {
+  log "checking services"
+  wait_http "http://${BOXAPI_ADDR}/health" "boxapi"
+  wait_http "http://${BOXPROXY_ADDR}/healthz" "boxproxy"
+  systemctl is-active --quiet novitabox-boxlet.service || die "boxlet is not active"
+
+  if [[ "$ENABLE_CADDY" == "1" ]]; then
+    curl -kfsS --resolve "${DOMAIN}:443:127.0.0.1" "https://${DOMAIN}/health" >/dev/null || die "Caddy HTTPS health check failed"
+  fi
+}
+
+print_summary() {
+  cat <<EOF
+
+NovitaBox is installed.
+
+Root directory:
+  ${ROOT_DIR}
+
+Local endpoints:
+  boxapi:   http://${BOXAPI_ADDR}
+  boxproxy: http://${BOXPROXY_ADDR}
+  public:   https://${DOMAIN}
+
+Useful commands:
+  systemctl status novitabox-boxlet novitabox-boxapi novitabox-boxproxy
+  journalctl -u novitabox-boxlet -f
+  ${ROOT_DIR}/boxctl --api http://${BOXAPI_ADDR} sandbox ls
+
+SDK/CLI environment:
+  export NOVITA_DOMAIN=${DOMAIN}
+  export NOVITA_API_KEY=dummy
+  export NOVITA_ACCESS_TOKEN=dummy
+  export NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/caddy-local.crt
+  export NO_PROXY=.${DOMAIN},localhost,127.0.0.1,::1
+
+EOF
+}
+
+main() {
+  need_root
+  need_no_spaces
+
+  local arch
+  arch="$(detect_arch)"
+
+  install_packages
+  ensure_go "$arch"
+  prepare_btrfs_root
+  verify_reflink
+  prepare_kernel_modules
+  configure_sysctl
+  build_components "$arch"
+  install_components "$arch"
+  install_runtime_assets
+  write_systemd_units
+  configure_dnsmasq
+  configure_caddy
+  health_check
+  print_summary
+}
+
+main "$@"


### PR DESCRIPTION
- boxctl: add sandbox, template, image, and runtime command groups
- boxctl: support ls aliases for list commands and keep exec/shell proxy flow
- boxapi: expose template convert route and runtime capability endpoints
- build: add linux arm64 build target
- scripts: add one-command Linux installer with btrfs, services, DNS, and reverse proxy setup