### PR TITLE
docs: complete NovitaBox usage and operation guides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 NOVITABOX_GOCACHE := $(CURDIR)/.gocache
 NOVITABOX_GOMODCACHE := $(CURDIR)/.gomodcache
 NOVITABOX_BUF_CACHE_DIR := $(CURDIR)/.bufcache
+GOPROXY ?= https://goproxy.cn,direct
 
 .PHONY: build build-linux-amd64 build-linux-arm64 test fmt proto tools
 
@@ -9,23 +10,23 @@ COMMANDS := boxapi boxctl boxd boxlet boxproxy boxshim
 build:
 	mkdir -p bin
 	for cmd in $(COMMANDS); do \
-		GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go build -o "bin/$$cmd" "./cmd/$$cmd"; \
+		GOPROXY="$(GOPROXY)" GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go build -o "bin/$$cmd" "./cmd/$$cmd"; \
 	done
 
 build-linux-amd64:
 	mkdir -p bin/linux-amd64
 	for cmd in $(COMMANDS); do \
-		GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go build -o "bin/linux-amd64/$$cmd" "./cmd/$$cmd"; \
+		GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GOPROXY="$(GOPROXY)" GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go build -o "bin/linux-amd64/$$cmd" "./cmd/$$cmd"; \
 	done
 
 build-linux-arm64:
 	mkdir -p bin/linux-arm64
 	for cmd in $(COMMANDS); do \
-		GOOS=linux GOARCH=arm64 CGO_ENABLED=0 GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go build -o "bin/linux-arm64/$$cmd" "./cmd/$$cmd"; \
+		GOOS=linux GOARCH=arm64 CGO_ENABLED=0 GOPROXY="$(GOPROXY)" GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go build -o "bin/linux-arm64/$$cmd" "./cmd/$$cmd"; \
 	done
 
 test:
-	GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go test ./...
+	GOPROXY="$(GOPROXY)" GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go test ./...
 
 fmt:
 	GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go fmt ./...
@@ -35,4 +36,4 @@ proto:
 
 tools:
 	mkdir -p .bin
-	cd tools && GOBIN="$(CURDIR)/.bin" GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go install tool
+	cd tools && GOBIN="$(CURDIR)/.bin" GOPROXY="$(GOPROXY)" GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go install tool

--- a/README.md
+++ b/README.md
@@ -10,188 +10,142 @@
 
 **The local edition of Novita Sandbox** — a secure, MicroVM-based execution environment for AI Agents.
 
-NovitaBox brings Novita's production sandbox stack to your laptop, on-prem servers, or edge devices. Run AI Agents locally with millisecond startup times, zero cloud latency, and complete data privacy. Use the standard **Novita Sandbox SDK** to write your agent code once, then run it locally with NovitaBox or in production with Novita Sandbox Cloud — same code, two runtimes.
+NovitaBox brings Novita's production sandbox stack to your laptop, on-prem servers, or edge devices. Run AI Agents
+locally with millisecond startup times, zero cloud latency, and complete data privacy. Use the standard **Novita Sandbox
+SDK** to write your agent code once, then run it locally with NovitaBox or in Novita production.
 
-> Already using E2B SDK? NovitaBox is also API-compatible — point `E2B_API_URL` to your NovitaBox instance and your existing code works as-is.
+> Already using E2B SDK? NovitaBox is also API-compatible — point `E2B_API_URL` to your NovitaBox instance and your
+> existing code works as-is.
 
 ---
 
 ## ✨ Features
 
-- **🏠 Local-first** — Built for single-host deployment. Runs on your laptop, on-prem servers, or edge devices, with no cloud dependency at runtime.
-- **🔒 Privacy by design** — Code, files, and execution traces never leave your machine. Suitable for air-gapped, regulated, or data-sensitive workloads.
-- **⚡ Millisecond startup** — Powered by MicroVM technology with kernel-level isolation. Spin up sandboxes in milliseconds with minimal memory overhead.
-- **🔁 Same SDK, two runtimes** — Use Novita Sandbox SDK for both NovitaBox (local) and Novita Sandbox Cloud. Code once, deploy anywhere.
+- **🏠 Local-first** — Built for single-host deployment. Runs on your laptop, on-prem servers, or edge devices, with no
+  cloud dependency at runtime.
+- **🔒 Privacy by design** — Code, files, and execution traces never leave your machine. Suitable for air-gapped,
+  regulated, or data-sensitive workloads.
+- **⚡ Millisecond startup** — Powered by MicroVM technology with kernel-level isolation. Spin up sandboxes in
+  milliseconds with minimal memory overhead.
+- **🔁 One codebase, local to production** — Use Novita Sandbox SDK for both NovitaBox local development and Novita
+  production.
 - **🛠️ Full template lifecycle** — Build, publish, and manage custom sandbox image templates locally.
-- **📦 Single binary, out-of-the-box** — No Kubernetes, no cluster, no orchestration overhead. Single binary deployment.
+- **🧩 Multiple runtimes** — Supports both Firecracker and Cloud Hypervisor runtimes, so you can choose the MicroVM
+  backend that fits your environment.
 - **🌐 E2B SDK compatible** — Existing E2B SDK code works without modification. Migrate by changing one endpoint.
-
----
-
-
-## Highlights
-
-### Multi-Runtime Sandbox Platform
-
-NovitaBox is built around a runtime abstraction instead of being tied to one backend.
-
-Currently supported runtimes:
-
-- Firecracker
-- Cloud Hypervisor
-
-Runtime behavior is capability-driven. If a runtime does not support a feature, such as pause/resume with GPU passthrough, NovitaBox can degrade the API behavior explicitly instead of failing unpredictably.
-
-### Fixed Guest IP Networking
-
-Every sandbox can see the same internal guest IP:
-
-```text
-guest_ip:   10.88.0.2
-gateway_ip: 10.88.0.1
-```
-
-The guest IP is not used as the global network identity. NovitaBox routes traffic by sandbox identity:
-
-```text
-sandbox_id -> host_access_ip -> guest_ip
-```
-
-This allows templates, pause state, and resumed sandboxes to keep stable guest networking without rewriting network configuration inside the sandbox.
-
-### Per-Sandbox Shim
-
-Each sandbox has a dedicated `boxshim` process.
-
-`boxshim` is the parent process of the runtime and owns the actual runtime state. If NovitaBox restarts or upgrades, running sandboxes can survive because their runtime process is owned by the shim, not by the API server.
-
-Recovery flow:
-
-```text
-novitabox restart
-  -> scan sandbox shim sockets
-  -> reconnect to boxshim
-  -> query runtime state
-  -> reconcile persisted state
-```
-
-### Clear Image, Template, and Snapshot State Flow
-
-NovitaBox keeps the public artifact model focused on three practical states:
-
-- Image: portable rootfs-only artifact
-- Template: fast-start artifact with rootfs, memory, and VM state
-- Snapshot: state files created after a Sandbox is paused
-
-The state flow is intentionally simple:
-
-```text
-docker image + start_cmd -> Template
-
-Template - memfile - snapfile -> Image
-Image -> sandbox -> Template
-
-Template -> Sandbox
-Sandbox -> Snapshot
-```
-
-This makes it clear which artifacts are portable, which artifacts are optimized for fast startup, and which state belongs to a running sandbox.
-
 
 ## 🚀 Quick Start
 
-### 1. Start the NovitaBox Server
+#### Prepare the filesystem
+
+NovitaBox requires a filesystem that supports reflink copies, such as XFS or Btrfs, to store templates, snapshots, and related runtime data.
+
+For local development, you can create a disk image, format it as XFS or Btrfs, and mount it as a loop device
+
+```bash
+truncate -s 50G /data/novitabox.img
+
+mkfs.btrfs /data/novitabox.img
+# or
+mkfs.xfs /data/novitabox.img
+
+mount -o loop /data/novitabox.img /data/novitabox
+```
+
+#### Prepare runtimes
+
+```bash
+# firecracker
+https://github.com/novitalabs/NovitaBox/releases/download/v0.0.1/firecracker
+# firecracker guest kernel
+https://github.com/novitalabs/NovitaBox/releases/download/v0.0.1/vmlinux.bin
+```
+
+#### Start the NovitaBox Server
 
 Ensure your local machine has KVM (Linux) or equivalent virtualization features enabled.
 
 ```bash
-# Clone the repository
+# clone the repository
 git clone https://github.com/novitalabs/NovitaBox.git
 cd NovitaBox
 
-# Build all components
-make build
+# build all components
+make build-linux-amd64
 
-# Run services
-./novita-box api --port 8080
-./novita-box boxlet --port 8081
-./novita-box proxy --port 8082
+# move all components to /data/novitabox
+mv bin/linux-amd64/* /data/novitabox
+
+# run services
+./boxapi --root /data/novitabox --addr 127.0.0.1:8080 --boxlet-addr 127.0.0.1:8081
+./boxlet --root /data/novitabox --addr 127.0.0.1:8081
+./boxproxy --root /data/novitabox --addr 127.0.0.1:8082
 ```
 
-## Cli
-
-#### Install the Novita Sandbox Cli
+#### DNS && proxy
 
 ```bash
+sudo apt-get install -y dnsmasq caddy
 
+sudo tee /etc/dnsmasq.d/novitabox.conf >/dev/null <<'EOF'
+listen-address=127.0.0.1
+bind-interfaces
+address=/.novitabox.local/127.0.0.1
+address=/.novitabox.local/::1
+EOF
+sudo systemctl restart dnsmasq
+
+sudo tee /etc/caddy/Caddyfile >/dev/null <<'EOF'
+{
+  local_certs
+}
+
+novitabox.local {
+  tls internal
+  reverse_proxy 127.0.0.1:8080
+}
+
+*.novitabox.local {
+  tls internal
+  reverse_proxy 127.0.0.1:8082
+}
+EOF
+sudo systemctl restart caddy
 ```
 
-
-## SDK
-
-#### Install the Novita Sandbox SDK:
+#### Build a Template
 
 ```bash
-pip install novita-sandbox
+/data/novitabox/boxctl \
+  --api http://127.0.0.1:8080 \
+  template build my-template \
+  --from-image ubuntu:22.04 \
+  --run 'apt-get update' \
+  --run 'apt-get install -y curl'
 ```
 
 #### Launch a sandbox
 
-see 
-
-
-#### 
-
 ```bash
-export NOVITA_API_URL=http://localhost:8080
-export NOVITA_API_KEY=$LOCAL_API_KEY
+TEMPLATE_ID=tpl-xxxxxxxxxxxxxxxxxxxx
+
+/data/novitabox/boxctl \
+  --api http://127.0.0.1:8080 \
+  sandbox create "$TEMPLATE_ID"
+
+SANDBOX_ID=sbx-xxxxxxxxxxxxxxxxxxxx
+
+/data/novitabox/boxctl \
+  --proxy http://127.0.0.1:8082 \
+  exec -it "$SANDBOX_ID" /bin/sh
 ```
-
-#### Run code or command in sandbox
-
-```python
-import os
-from novita_sandbox import Sandbox
-
-# point the SDK at your local NovitaBox instance
-os.environ["NOVITA_SANDBOX_URL"] = "http://localhost:8080" os.environ["NOVITA_API_KEY"] = "NovitaBox_local_development"  # any non-empty string for local use
-
-# spawn a sandbox
-print("Spawning a secure sandbox locally...")
-sbx = Sandbox(template="base")
-
-# run a command
-result = sbx.commands.run("echo 'Hello from NovitaBox!'")
-print(result.stdout)  # → Hello from NovitaBox!
-
-# clean up
-sbx.close()
-```
-
-
-The same code runs against Novita Sandbox Cloud by removing the NOVITA_SANDBOX_URL override — no other changes needed.
 
 ---
 
-## 🔄 Supported API Matrix
-
-| Feature / Method | Status | Description |
-|---|---|---|
-| `Sandbox.create()` | ✅ | Spawns a local MicroVM instance in milliseconds |
-| `Sandbox.pause()` | ✅ | Suspends the instance with a memory snapshot, freeing host CPU |
-| `Sandbox.resume()` | ✅ | Instantly resumes execution from the saved snapshot |
-| `Sandbox.close()` | ✅ | Destroys the instance and cleans up network/storage |
-| `Template.build()` | ✅ | Compiles custom sandbox templates from local Dockerfiles or RootFS |
-| `commands.run()` | ✅ | Executes shell commands inside the sandbox |
-| `filesystem.read/write/list/remove` | ✅ | Filesystem operations inside the sandbox |
-
-> Replace ✅/⚠️/🚧 placeholders with the actual implementation status before publishing.
-
----
 
 ## 🏗️ Architecture
 
-NovitaBox runs as a single process on the host and routes Novita Sandbox SDK calls to MicroVM instances managed locally:
+NovitaBox runs as a set of small host services and routes Novita Sandbox SDK calls to MicroVM instances managed locally:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -222,13 +176,89 @@ NovitaBox runs as a single process on the host and routes Novita Sandbox SDK cal
 └─────────────────────────────────────────────────────────────┘
 ```
 
-> Detailed architecture and design rationale: see `docs/overview.md`.
+#### Multi-Runtime Sandbox Platform
+
+NovitaBox is built around a runtime abstraction instead of being tied to one backend.
+
+Currently supported runtimes:
+
+- Firecracker
+- Cloud Hypervisor
+
+Runtime behavior is capability-driven. If a runtime does not support a feature, such as pause/resume with GPU
+passthrough, NovitaBox can degrade the API behavior explicitly instead of failing unpredictably.
+
+#### Fixed Guest IP Networking
+
+Every sandbox can see the same internal guest IP:
+
+```text
+guest_ip:   169.254.0.21
+gateway_ip: 169.254.0.22
+```
+
+The guest IP is not used as the global network identity. NovitaBox routes traffic by sandbox identity:
+
+```text
+sandbox_id -> host_access_ip -> guest_ip
+```
+
+This allows templates, pause state, and resumed sandboxes to keep stable guest networking without rewriting network
+configuration inside the sandbox.
+
+#### Per-Sandbox Shim
+
+Each sandbox has a dedicated `boxshim` process.
+
+`boxshim` is the parent process of the runtime and owns the actual runtime state. If NovitaBox restarts or upgrades,
+running sandboxes can survive because their runtime process is owned by the shim, not by the API server.
+
+Recovery flow:
+
+```text
+novitabox restart
+  -> scan sandbox shim sockets
+  -> reconnect to boxshim
+  -> query runtime state
+  -> reconcile persisted state
+```
+
+#### Clear Image, Template, and Snapshot State Flow
+
+NovitaBox keeps the public artifact model focused on three practical states:
+
+- Image: portable rootfs-only artifact
+- Template: fast-start artifact with rootfs, memory, and VM state
+- Snapshot: state files created after a Sandbox is paused
+
+The state flow is intentionally simple:
+
+```text
+docker image + start_cmd -> Template
+
+Template - memfile - snapfile -> Image
+Image -> sandbox -> Template
+
+Template -> Sandbox
+Sandbox -> Snapshot
+```
+
+This makes it clear which artifacts are portable, which artifacts are optimized for fast startup, and which state
+belongs to a running sandbox.
+
+> Detailed architecture and design rationale: see [`docs/architecture/overview.md`](docs/architecture/overview.md).
 
 
 ---
-## Documentation
 
+## 📄 Documentation
 
+- **Quick start:** [Install](docs/quick-start/install.md), [boxctl](docs/quick-start/boxctl.md), [SDK](docs/quick-start/sdk.md), [CLI](docs/quick-start/cli.md), [Proxy](docs/quick-start/proxy.md), [DNS](docs/quick-start/dns.md)
+- **API:** [HTTP API](docs/api/http.md), [Internal RPC](docs/api/RPC.md)
+- **Architecture:** [Overview](docs/architecture/overview.md), [Components](docs/architecture/components.md), [RuntimeSpec](docs/architecture/runtime.md), [Artifact Model](docs/architecture/artifact.md), [Network](docs/architecture/network.md), [Sandbox Lifecycle](docs/architecture/lifecycle.md), [File Layout](docs/architecture/file-layout.md), [Security Model](docs/architecture/security.md)
+- **CLI reference:** [Template](docs/cli/template.md), [Sandbox](docs/cli/sandbox.md), [Image](docs/cli/image.md), [Runtime and snapshot](docs/cli/others.md)
+- **Changelog:** [v0.0.1](docs/changelog/v0.0.1.md)
+- **Chinese docs:** [使用手册](docs/zh/usage.md), [Architecture overview](docs/zh/architecture/overview.md), [v0.0.1 changelog](docs/zh/changelog/v0.0.1.md)
 
 ---
 
@@ -246,7 +276,7 @@ See `CONTRIBUTING.md` for development setup and coding conventions.
 
 ---
 
-## 📄 License
+## 🧾 License
 
 Distributed under the **Apache 2.0 License**. See [`LICENSE`](LICENSE) for the full text.
 
@@ -254,6 +284,8 @@ Distributed under the **Apache 2.0 License**. See [`LICENSE`](LICENSE) for the f
 
 ## 🔗 Related
 
-- **[Novita Sandbox SDK](https://github.com/novitalabs/novita-sandbox-sdk)** — The unified SDK for both NovitaBox and Novita Cloud
+- **[Novita Sandbox SDK](https://github.com/novitalabs/novita-sandbox-sdk)** — The unified SDK for both NovitaBox and
+  Novita Cloud
 - **[Novita Sandbox Cloud](https://novita.ai/sandbox)** — Production-grade managed sandbox service
-- **[ComputeSDK Provider](https://github.com/computesdk/computesdk)** — Use NovitaBox / Novita Cloud through ComputeSDK's unified provider interface
+- **[ComputeSDK Provider](https://github.com/computesdk/computesdk)** — Use NovitaBox / Novita Cloud through
+  ComputeSDK's unified provider interface

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -1,6 +1,161 @@
 ## API Overview
 
-### E2B-Compatible API
+NovitaBox exposes compatibility routes and local native routes. The default local API endpoint is:
+
+```text
+http://127.0.0.1:8080
+```
+
+When Caddy is enabled:
+
+```text
+https://novitabox.local
+```
+
+## Health
+
+```bash
+curl http://127.0.0.1:8080/health
+curl http://127.0.0.1:8080/healthz
+```
+
+## Templates
+
+Create a template record:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/v3/templates \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"my-template"}'
+```
+
+Start a build:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/v2/templates/tpl-xxxxxxxxxxxxxxxxxxxx/builds/<build_id> \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "fromImage": "ubuntu:22.04",
+    "steps": [
+      {"type": "RUN", "args": ["echo hello from novitabox"]}
+    ]
+  }'
+```
+
+Get build status:
+
+```bash
+curl -sS http://127.0.0.1:8080/v2/templates/tpl-xxxxxxxxxxxxxxxxxxxx/builds/<build_id>/status
+```
+
+List templates:
+
+```bash
+curl -sS http://127.0.0.1:8080/templates
+```
+
+Get a template:
+
+```bash
+curl -sS http://127.0.0.1:8080/templates/tpl-xxxxxxxxxxxxxxxxxxxx
+```
+
+Delete a template:
+
+```bash
+curl -i -X DELETE http://127.0.0.1:8080/templates/tpl-xxxxxxxxxxxxxxxxxxxx
+```
+
+## Sandboxes
+
+Create a sandbox from a template:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes \
+  -H 'Content-Type: application/json' \
+  -d '{"templateID":"tpl-xxxxxxxxxxxxxxxxxxxx"}'
+```
+
+Create from an image:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes \
+  -H 'Content-Type: application/json' \
+  -d '{"imageID":"img-xxxxxxxxxxxxxxxxxxxx"}'
+```
+
+List sandboxes:
+
+```bash
+curl -sS http://127.0.0.1:8080/v1/sandboxes
+```
+
+Get sandbox info:
+
+```bash
+curl -sS http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+Pause and resume:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx/pause
+curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx/resume
+```
+
+Power lifecycle:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx/poweroff
+curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx/poweron
+curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx/reboot
+```
+
+Delete:
+
+```bash
+curl -i -X DELETE http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+## Images
+
+Create an image from a template:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/v1/images \
+  -H 'Content-Type: application/json' \
+  -d '{"templateID":"tpl-xxxxxxxxxxxxxxxxxxxx","imageID":"img-xxxxxxxxxxxxxxxxxxxx"}'
+```
+
+List images:
+
+```bash
+curl -sS http://127.0.0.1:8080/v1/images
+```
+
+Get an image:
+
+```bash
+curl -sS http://127.0.0.1:8080/v1/images/img-xxxxxxxxxxxxxxxxxxxx
+```
+
+Delete an image:
+
+```bash
+curl -i -X DELETE http://127.0.0.1:8080/v1/images/img-xxxxxxxxxxxxxxxxxxxx
+```
+
+## Runtimes
+
+```bash
+curl -sS http://127.0.0.1:8080/v1/runtimes
+curl -sS http://127.0.0.1:8080/v1/runtimes/firecracker
+curl -sS http://127.0.0.1:8080/v1/runtimes/firecracker/capabilities
+```
+
+## Route Summary
+
+### Compatible API
 
 ```http
 POST   /v1/sandboxes
@@ -20,7 +175,7 @@ GET    /v1/templates/{template_id}
 DELETE /v1/templates/{template_id}
 ```
 
-### Novita Native API
+### Native API
 
 ```http
 POST   /v1/sandboxes/{sandbox_id}/poweroff

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -1,8 +1,8 @@
 ## Components
 
-### novitabox api
+### boxapi
 
-The API layer is the global control entrypoint.
+`boxapi` is the HTTP control plane entrypoint.
 
 Responsibilities:
 
@@ -54,9 +54,9 @@ Responsibilities:
 - handle file operations
 - expose health and metrics endpoints
 
-### proxy
+### boxproxy
 
-`proxy` is the data plane entrypoint.
+`boxproxy` is the data plane entrypoint.
 
 Responsibilities:
 
@@ -64,4 +64,3 @@ Responsibilities:
 - proxy user services running inside sandboxes
 - upgrade shell sessions to WebSocket
 - resolve sandbox routes through sandbox identity
-- 

--- a/docs/architecture/file-layout.md
+++ b/docs/architecture/file-layout.md
@@ -1,26 +1,41 @@
 ## File Layout
 
-`$ROOT` defaults to `/var/lib`.
+`$ROOT` defaults to `/data/novitabox` in the installer.
 
 ```text
-$ROOT/novitabox/images/<image_id>/
+$ROOT/db/
+  novitabox.db
+
+$ROOT/images/<image_id>/
   rootfs.ext4
   metadata
 
-$ROOT/novitabox/templates/<template_id>/
+$ROOT/templates/<template_id>/
   rootfs.ext4
   memfile
   snapfile
   metadata
 
-$ROOT/novitabox/sandboxes/<sandbox_id>/
+$ROOT/sandboxes/<sandbox_id>/
   shim.sock
   shim.pid
   fc.sock
+  firecracker.log
+  kernel -> $ROOT/vmlinux.bin
+  snapshot/
 
-$ROOT/novitabox/sandboxes/<sandbox_id>/snapshot/
+$ROOT/sandboxes/<sandbox_id>/snapshot/
   rootfs.ext4
   memfile
   snapfile
   metadata
+
+$ROOT/boxapi
+$ROOT/boxctl
+$ROOT/boxd
+$ROOT/boxlet
+$ROOT/boxproxy
+$ROOT/boxshim
+$ROOT/firecracker
+$ROOT/vmlinux.bin
 ```

--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -9,8 +9,6 @@ Supported sandbox operations:
 - list
 - exec
 - shell
-- commit
-- clone
 
 Extended maintenance operations:
 

--- a/docs/architecture/network.md
+++ b/docs/architecture/network.md
@@ -14,13 +14,13 @@ Example:
 ```text
 Sandbox A:
   sandbox_id     = sbx-a
-  host_access_ip = 100.96.0.10
-  guest_ip       = 10.88.0.2
+  host_access_ip = 10.11.0.1
+  guest_ip       = 169.254.0.21
 
 Sandbox B:
   sandbox_id     = sbx-b
-  host_access_ip = 100.96.0.11
-  guest_ip       = 10.88.0.2
+  host_access_ip = 10.11.0.2
+  guest_ip       = 169.254.0.21
 ```
 
 Network layout:
@@ -28,24 +28,33 @@ Network layout:
 ```text
 Host root netns
   |
-  | route 100.96.0.10/32 -> veth-sbx-a-host -> ns-sbx-a
-  | route 100.96.0.11/32 -> veth-sbx-b-host -> ns-sbx-b
+  | route 10.11.0.1/32 -> veth-sbx-a-host -> ns-sbx-a
+  | route 10.11.0.2/32 -> veth-sbx-b-host -> ns-sbx-b
   |
   +-----------------------------+       +-----------------------------+
   | ns-sbx-a                    |       | ns-sbx-b                    |
   |                             |       |                             |
   | veth-sbx-a-ns               |       | veth-sbx-b-ns               |
-  | 169.254.100.2/30            |       | 169.254.101.2/30            |
+  | 10.12.0.3/31                |       | 10.12.0.5/31                |
   |                             |       |                             |
   | DNAT                        |       | DNAT                        |
-  | 100.96.0.10 -> 10.88.0.2    |       | 100.96.0.11 -> 10.88.0.2    |
+  | 10.11.0.1 -> 169.254.0.21   |       | 10.11.0.2 -> 169.254.0.21   |
   |                             |       |                             |
   | tap0                        |       | tap0                        |
-  | 10.88.0.1/30                |       | 10.88.0.1/30                |
+  | 169.254.0.22/30             |       | 169.254.0.22/30             |
   |     |                       |       |     |                       |
   |     v                       |       |     v                       |
-  | VM-A eth0 10.88.0.2         |       | VM-B eth0 10.88.0.2         |
+  | VM-A eth0 169.254.0.21      |       | VM-B eth0 169.254.0.21      |
   +-----------------------------+       +-----------------------------+
 ```
 
-The host never needs to access `10.88.0.2` directly. It accesses the unique `host_access_ip`, and the sandbox namespace translates traffic into the fixed guest IP.
+The host never needs to access `169.254.0.21` directly. It accesses the unique `host_access_ip`, and the sandbox namespace translates traffic into the fixed guest IP.
+
+Default CIDRs:
+
+```text
+host_access_cidr = 10.11.0.0/16
+veth_cidr        = 10.12.0.0/16
+guest_ip         = 169.254.0.21
+gateway_ip       = 169.254.0.22
+```

--- a/docs/changelog/v0.0.1.md
+++ b/docs/changelog/v0.0.1.md
@@ -1,5 +1,24 @@
 ---
-title: v0.0.1 — 2026.06.17
+title: v0.0.1 — 2026.06.30
 ---
 
-## 2026.06.17 Release v0.0.1
+## 2026.06.30 Release v0.0.1
+
+Initial NovitaBox local sandbox release.
+
+### Added
+
+- `boxapi` HTTP API for templates, sandboxes, images, runtimes, health checks, and compatibility routes.
+- `boxlet` node agent for local artifact management, template build, sandbox lifecycle, and networking.
+- `boxshim` runtime supervisor for Firecracker process management.
+- `boxd` guest agent for health checks, exec, interactive shell, PTY, and process APIs.
+- `boxproxy` data plane proxy for sandbox exec/shell and SDK connect-style traffic.
+- `boxctl` CLI for template, sandbox, image, runtime, and exec workflows.
+- Reflink-based artifact copies for rootfs, memory files, and snapshot files.
+- Btrfs-based one-command installer with systemd services.
+- Default fixed guest IP networking with per-sandbox host access IPs.
+- Local DNS and Caddy reverse proxy documentation for SDK compatibility.
+
+### Notes
+
+- Firecracker full snapshot support depends on host KVM behavior. Some nested KVM environments fail snapshot creation with `Failed to get KVM vcpu msr: 0x3a`.

--- a/docs/cli/image.md
+++ b/docs/cli/image.md
@@ -1,6 +1,59 @@
+# Image CLI
 
-save
-image change to template, rootfs -> rootfs + snapfile + memfile
+Images are rootfs-only artifacts. They are more portable than templates because they do not include Firecracker memory state.
 
-delete
-delete an image
+```bash
+boxctl image [command]
+```
+
+## Create
+
+Create an image from a template:
+
+```bash
+boxctl image create tpl-xxxxxxxxxxxxxxxxxxxx
+```
+
+Choose an image id:
+
+```bash
+boxctl image create tpl-xxxxxxxxxxxxxxxxxxxx \
+  --image img-xxxxxxxxxxxxxxxxxxxx
+```
+
+Add labels:
+
+```bash
+boxctl image create tpl-xxxxxxxxxxxxxxxxxxxx \
+  --label env=dev \
+  --label owner=agent
+```
+
+## List
+
+```bash
+boxctl image list
+boxctl image ls
+```
+
+## Get
+
+```bash
+boxctl image get img-xxxxxxxxxxxxxxxxxxxx
+```
+
+## Delete
+
+```bash
+boxctl image delete img-xxxxxxxxxxxxxxxxxxxx
+boxctl image rm img-xxxxxxxxxxxxxxxxxxxx
+```
+
+## Template Conversion
+
+The template command also exposes conversion:
+
+```bash
+boxctl template convert tpl-xxxxxxxxxxxxxxxxxxxx \
+  --image img-xxxxxxxxxxxxxxxxxxxx
+```

--- a/docs/cli/others.md
+++ b/docs/cli/others.md
@@ -12,3 +12,48 @@ show runtime capabilities
 
 show
 show sandbox snapshot info
+# Runtime CLI
+
+Runtime commands show what the local runtime backend can do.
+
+```bash
+boxctl runtime [command]
+```
+
+## List
+
+```bash
+boxctl runtime list
+```
+
+## Show
+
+```bash
+boxctl runtime show firecracker
+```
+
+## Capabilities
+
+```bash
+boxctl runtime capabilities firecracker
+```
+
+Capability fields describe whether the runtime supports:
+
+- start from image
+- start from template
+- start from snapshot
+- pause and resume
+- full snapshots
+- networking
+
+## Global Flags
+
+All `boxctl` commands support:
+
+```bash
+--api http://127.0.0.1:8080
+--proxy http://127.0.0.1:8082
+```
+
+Use `--api` for lifecycle and artifact APIs. Use `--proxy` for process, shell, and sandbox traffic.

--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -1,35 +1,135 @@
-create
-create a sandbox from a template or a snapshot, or image + start_cmd
+# Sandbox CLI
 
-pause
-create a sandbox-bound snapshot and release runtime resources when possible
+Sandbox commands manage running MicroVM sandboxes.
 
-resume
-create runtime again and resume from sandbox-bound snapshot
+```bash
+boxctl sandbox [command]
+```
 
-kill
-terminate sandbox lifecycle and remove sandbox-bound snapshots
+## Create
 
-list
-list all sandboxes
+Create from a template:
 
-exec
-exec a command in a sandbox
+```bash
+boxctl sandbox create tpl-xxxxxxxxxxxxxxxxxxxx
+```
 
-shell
-launch a shell
+Equivalent form:
 
-commit
-create a template from sandbox, need to pause sandbox
+```bash
+boxctl sandbox create --template tpl-xxxxxxxxxxxxxxxxxxxx
+```
 
-* poweroff(stop)
-  safety shutdown, save all state to rootfs
+Create from an image:
 
-* poweron(start)
-  start a sandbox from rootfs
+```bash
+boxctl sandbox create --image img-xxxxxxxxxxxxxxxxxxxx
+```
 
-* reboot(restart)
-  gracefully shut down and restart
+Create from a snapshot:
 
-clone
-clone a new sandbox from given sandbox
+```bash
+boxctl sandbox create --snapshot snap-xxxxxxxxxxxxxxxxxxxx
+```
+
+Options:
+
+- `--template <template_id>`: template id.
+- `--image <image_id>`: image id.
+- `--snapshot <snapshot_id>`: snapshot id.
+- `--runtime <runtime_type>`: runtime type, usually `firecracker`.
+
+## List and Get
+
+```bash
+boxctl sandbox list
+boxctl sandbox ls
+boxctl sandbox get sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+## Exec
+
+Run a command:
+
+```bash
+boxctl sandbox exec sbx-xxxxxxxxxxxxxxxxxxxx /bin/sh -c 'pwd && ls -alh'
+```
+
+Run with a working directory:
+
+```bash
+boxctl sandbox exec --cwd /root sbx-xxxxxxxxxxxxxxxxxxxx /bin/sh -c 'pwd'
+```
+
+Open an interactive terminal:
+
+```bash
+boxctl sandbox exec -it sbx-xxxxxxxxxxxxxxxxxxxx /bin/sh
+```
+
+There is also a top-level alias:
+
+```bash
+boxctl exec -it sbx-xxxxxxxxxxxxxxxxxxxx /bin/sh
+```
+
+## Shell
+
+```bash
+boxctl sandbox shell sbx-xxxxxxxxxxxxxxxxxxxx
+boxctl sandbox shell --shell /bin/bash sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+If `/bin/bash` is not present in the rootfs, use `/bin/sh`.
+
+## Pause and Resume
+
+Pause creates sandbox-bound snapshot state and releases runtime resources when possible:
+
+```bash
+boxctl sandbox pause sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+Resume starts the runtime again from the sandbox snapshot:
+
+```bash
+boxctl sandbox resume sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+## Power Lifecycle
+
+Gracefully power off:
+
+```bash
+boxctl sandbox poweroff sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+Power on from rootfs/snapshot files:
+
+```bash
+boxctl sandbox poweron sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+Reboot:
+
+```bash
+boxctl sandbox reboot sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+Hidden compatibility aliases are available:
+
+```bash
+boxctl sandbox stop sbx-xxxxxxxxxxxxxxxxxxxx
+boxctl sandbox start sbx-xxxxxxxxxxxxxxxxxxxx
+boxctl sandbox restart sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+## Delete
+
+Terminate a sandbox and remove sandbox-bound snapshots:
+
+```bash
+boxctl sandbox delete sbx-xxxxxxxxxxxxxxxxxxxx
+boxctl sandbox rm sbx-xxxxxxxxxxxxxxxxxxxx
+boxctl sandbox kill sbx-xxxxxxxxxxxxxxxxxxxx
+```

--- a/docs/cli/template.md
+++ b/docs/cli/template.md
@@ -1,11 +1,101 @@
-build
-build template from docker image, docker image -> template
+# Template CLI
 
-list
-list all templates
+Template commands manage fast-start sandbox templates.
 
-delete
-delete a template
+```bash
+boxctl template [command]
+```
 
-convert
-template change to image，drop memfile and snapfile
+## Create
+
+Create a template record and build id without running the build:
+
+```bash
+boxctl template create my-template
+```
+
+Options:
+
+- `--template <template_id>`: choose a template id.
+- `--cpu <count>`: template CPU count.
+- `--memory <mb>`: template memory in MB.
+
+## Build
+
+Create and build a template in one command:
+
+```bash
+boxctl template build my-template \
+  --from-image ubuntu:22.04 \
+  --run 'echo hello'
+```
+
+Sources:
+
+- `--from-image <image>`: build from a Docker image, for example `ubuntu:22.04`.
+- `--from-template <template_id>`: build from an existing template.
+
+Build commands:
+
+- `--run <command>`: run a shell command through `/bin/sh -c`.
+- `--exec <command>`: split the command by whitespace and execute it directly.
+- `--start-cmd <command>`: template start command.
+- `--ready-cmd <command>`: template ready command.
+
+Other options:
+
+- `--template <template_id>`: choose a template id.
+- `--cpu <count>`: template CPU count.
+- `--memory <mb>`: template memory in MB.
+
+Examples:
+
+```bash
+boxctl template build python-template \
+  --from-image ubuntu:22.04 \
+  --run 'apt-get update' \
+  --run 'apt-get install -y python3' \
+  --exec 'python3 --version'
+```
+
+## List
+
+```bash
+boxctl template list
+```
+
+Alias:
+
+```bash
+boxctl template ls
+```
+
+## Get
+
+```bash
+boxctl template get tpl-xxxxxxxxxxxxxxxxxxxx
+```
+
+## Build Status
+
+```bash
+boxctl template status tpl-xxxxxxxxxxxxxxxxxxxx <build_id>
+```
+
+## Delete
+
+```bash
+boxctl template delete tpl-xxxxxxxxxxxxxxxxxxxx
+boxctl template rm tpl-xxxxxxxxxxxxxxxxxxxx
+```
+
+## Convert to Image
+
+Convert a template to a rootfs-only image:
+
+```bash
+boxctl template convert tpl-xxxxxxxxxxxxxxxxxxxx \
+  --image img-xxxxxxxxxxxxxxxxxxxx
+```
+
+The image drops `memfile` and `snapfile`; it keeps only rootfs state.

--- a/docs/quick-start/boxctl.md
+++ b/docs/quick-start/boxctl.md
@@ -1,0 +1,179 @@
+# boxctl Quick Start
+
+`boxctl` is the native NovitaBox command line client. It talks to:
+
+- `boxapi` for lifecycle and artifact APIs, default `http://127.0.0.1:8080`
+- `boxproxy` for process and terminal traffic, default `http://127.0.0.1:8082`
+
+If NovitaBox is installed by `scripts/install.sh`, the binary is installed at:
+
+```bash
+/data/novitabox/boxctl
+```
+
+## Health Check
+
+```bash
+curl http://127.0.0.1:8080/health
+curl http://127.0.0.1:8082/healthz
+```
+
+## Build a Template
+
+Build from a Docker image:
+
+```bash
+/data/novitabox/boxctl \
+  --api http://127.0.0.1:8080 \
+  template build my-template \
+  --from-image ubuntu:22.04 \
+  --run 'echo hello from novitabox'
+```
+
+Build steps:
+
+- `--run` runs a shell command through `/bin/sh -c`; it can be repeated.
+- `--exec` splits the value by whitespace and executes it directly; it can be repeated.
+- `--start-cmd` and `--ready-cmd` are passed as template lifecycle commands.
+- `--template` can be used to choose a template id; otherwise one is generated.
+
+Example:
+
+```bash
+/data/novitabox/boxctl template build python-template \
+  --from-image ubuntu:22.04 \
+  --run 'apt-get update' \
+  --run 'apt-get install -y python3 python3-pip' \
+  --exec 'python3 --version'
+```
+
+The response includes `templateID` and `buildID`. Save the `templateID` for sandbox creation.
+
+## List and Inspect Templates
+
+```bash
+/data/novitabox/boxctl template list
+/data/novitabox/boxctl template get tpl-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl template status tpl-xxxxxxxxxxxxxxxxxxxx <build_id>
+```
+
+Delete a template:
+
+```bash
+/data/novitabox/boxctl template delete tpl-xxxxxxxxxxxxxxxxxxxx
+```
+
+## Create a Sandbox
+
+```bash
+/data/novitabox/boxctl \
+  --api http://127.0.0.1:8080 \
+  sandbox create tpl-xxxxxxxxxxxxxxxxxxxx
+```
+
+The response includes `sandboxID`.
+
+You can also create from an image:
+
+```bash
+/data/novitabox/boxctl sandbox create --image img-xxxxxxxxxxxxxxxxxxxx
+```
+
+## Execute Commands
+
+Run a one-shot command:
+
+```bash
+/data/novitabox/boxctl \
+  --proxy http://127.0.0.1:8082 \
+  exec sbx-xxxxxxxxxxxxxxxxxxxx /bin/sh -c 'pwd && ls -alh'
+```
+
+Open an interactive shell:
+
+```bash
+/data/novitabox/boxctl \
+  --proxy http://127.0.0.1:8082 \
+  exec -it sbx-xxxxxxxxxxxxxxxxxxxx /bin/sh
+```
+
+The sandbox subcommand exposes the same exec flow:
+
+```bash
+/data/novitabox/boxctl sandbox exec -it sbx-xxxxxxxxxxxxxxxxxxxx /bin/sh
+/data/novitabox/boxctl sandbox shell sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+## Sandbox Lifecycle
+
+```bash
+/data/novitabox/boxctl sandbox list
+/data/novitabox/boxctl sandbox get sbx-xxxxxxxxxxxxxxxxxxxx
+
+/data/novitabox/boxctl sandbox pause sbx-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl sandbox resume sbx-xxxxxxxxxxxxxxxxxxxx
+
+/data/novitabox/boxctl sandbox poweroff sbx-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl sandbox poweron sbx-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl sandbox reboot sbx-xxxxxxxxxxxxxxxxxxxx
+
+/data/novitabox/boxctl sandbox delete sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+`delete` also has aliases:
+
+```bash
+/data/novitabox/boxctl sandbox rm sbx-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl sandbox kill sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+## Images
+
+Create a rootfs-only image from a template:
+
+```bash
+/data/novitabox/boxctl image create tpl-xxxxxxxxxxxxxxxxxxxx \
+  --image img-xxxxxxxxxxxxxxxxxxxx \
+  --label env=dev
+```
+
+Manage images:
+
+```bash
+/data/novitabox/boxctl image list
+/data/novitabox/boxctl image get img-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl image delete img-xxxxxxxxxxxxxxxxxxxx
+```
+
+Convert a template to an image:
+
+```bash
+/data/novitabox/boxctl template convert tpl-xxxxxxxxxxxxxxxxxxxx \
+  --image img-xxxxxxxxxxxxxxxxxxxx
+```
+
+## Runtime Capabilities
+
+```bash
+/data/novitabox/boxctl runtime list
+/data/novitabox/boxctl runtime show firecracker
+/data/novitabox/boxctl runtime capabilities firecracker
+```
+
+## Troubleshooting
+
+Check service logs:
+
+```bash
+journalctl -u novitabox-boxapi -n 200 --no-pager
+journalctl -u novitabox-boxlet -n 200 --no-pager
+journalctl -u novitabox-boxproxy -n 200 --no-pager
+```
+
+If template build reaches `starting boxd` and then fails with:
+
+```text
+Failed to get KVM vcpu msr: 0x3a
+```
+
+the guest booted and the agent started, but Firecracker full snapshot creation is not supported by the current host KVM environment. This commonly happens on some nested KVM setups. Use a host with working Firecracker snapshot support or build from a rootfs/image flow that does not require full VM snapshots.

--- a/docs/quick-start/cli.md
+++ b/docs/quick-start/cli.md
@@ -1,0 +1,74 @@
+# Novita Sandbox CLI
+
+The Novita Sandbox CLI can talk to a local NovitaBox deployment through the same HTTP API surface used by the hosted service.
+
+## Install
+
+```bash
+npm install -g novita-sandbox-cli@2.0.5
+```
+
+## Local HTTPS Endpoint
+
+If you enabled Caddy in `scripts/install.sh`, the local API is available at:
+
+```text
+https://novitabox.local
+```
+
+The Caddy local CA is installed at:
+
+```text
+/usr/local/share/ca-certificates/caddy-local.crt
+```
+
+## Environment
+
+```bash
+export NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/caddy-local.crt
+export NO_PROXY=.novitabox.local,localhost,127.0.0.1,::1
+export NOVITA_DOMAIN=novitabox.local
+export NOVITA_API_KEY=dummy
+export NOVITA_ACCESS_TOKEN=dummy
+```
+
+If you skipped Caddy, use `boxctl` or curl against `http://127.0.0.1:8080` directly.
+
+## Build template
+
+```bash
+novita-sandbox-cli template build
+```
+
+Run this command from a directory containing a Novita Sandbox template project.
+
+For quick local smoke tests without a template project, use `boxctl` instead:
+
+```bash
+/data/novitabox/boxctl template build my-template \
+  --from-image ubuntu:22.04 \
+  --run 'echo hello from novitabox'
+```
+
+## Create Sandbox
+
+```bash
+novita-sandbox-cli sbx create tpl-xxxxxxxxxxxxxxxxxxxx
+```
+
+The CLI opens an interactive terminal after sandbox creation when the template is compatible with the current SDK version.
+
+## Common Commands
+
+```bash
+novita-sandbox-cli sbx create tpl-xxxxxxxxxxxxxxxxxxxx
+novita-sandbox-cli sbx list
+novita-sandbox-cli sbx kill sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+When debugging NovitaBox itself, prefer `boxctl` because it exposes local-only commands and can directly select `--api` and `--proxy`.
+ 
+```bash
+/data/novitabox/boxctl sandbox list
+/data/novitabox/boxctl exec -it sbx-xxxxxxxxxxxxxxxxxxxx /bin/sh
+```

--- a/docs/quick-start/dns.md
+++ b/docs/quick-start/dns.md
@@ -1,0 +1,51 @@
+# Local DNS
+
+NovitaBox SDK compatibility works best when all local requests resolve under one domain, for example:
+
+```text
+novitabox.local
+*.novitabox.local
+```
+
+The simple single-host setup maps the whole domain to loopback.
+
+```bash
+sudo apt-get install -y dnsmasq
+
+sudo tee /etc/dnsmasq.d/novitabox.conf >/dev/null <<'EOF'
+listen-address=127.0.0.1
+bind-interfaces
+no-resolv
+server=223.5.5.5
+server=202.96.209.133
+address=/.novitabox.local/127.0.0.1
+address=/.novitabox.local/::1
+EOF
+
+sudo systemctl restart dnsmasq
+```
+
+## systemd-resolved
+
+On systems using `systemd-resolved`, route only the NovitaBox domain to local dnsmasq:
+
+```bash
+sudo mkdir -p /etc/systemd/resolved.conf.d
+sudo tee /etc/systemd/resolved.conf.d/novitabox.conf >/dev/null <<'EOF'
+[Resolve]
+DNS=127.0.0.1
+Domains=~novitabox.local
+EOF
+
+sudo systemctl restart systemd-resolved
+```
+
+## Verify
+
+```bash
+getent hosts novitabox.local
+getent hosts api.novitabox.local
+getent hosts sbx-test.novitabox.local
+```
+
+All of them should resolve to `127.0.0.1` or `::1`.

--- a/docs/quick-start/install.md
+++ b/docs/quick-start/install.md
@@ -1,0 +1,165 @@
+# Installation
+
+This guide installs NovitaBox on one Linux host.
+
+## Requirements
+
+- Linux x86_64 or arm64
+- KVM available at `/dev/kvm`
+- TUN/TAP available at `/dev/net/tun`
+- Docker for building templates from Docker images
+- Btrfs or another reflink-capable filesystem for `$ROOT`
+
+The installer uses Btrfs by default.
+
+## One-Command Install
+
+From the repository root:
+
+```bash
+sudo -E scripts/install.sh
+```
+
+Default values:
+
+```text
+ROOT_DIR=/data/novitabox
+IMAGE_PATH=/data/novitabox.img
+IMAGE_SIZE=50G
+DOMAIN=novitabox.local
+ENABLE_DNS=1
+ENABLE_CADDY=1
+```
+
+Common overrides:
+
+```bash
+ROOT_DIR=/data/novitabox \
+IMAGE_PATH=/data/novitabox.img \
+IMAGE_SIZE=100G \
+DOMAIN=novitabox.local \
+sudo -E scripts/install.sh
+```
+
+Use already downloaded runtime assets:
+
+```bash
+FIRECRACKER_PATH=/root/novitabox/firecracker \
+KERNEL_PATH=/root/novitabox/vmlinux.bin \
+sudo -E scripts/install.sh
+```
+
+Skip Caddy:
+
+```bash
+ENABLE_CADDY=0 sudo -E scripts/install.sh
+```
+
+Skip DNS:
+
+```bash
+ENABLE_DNS=0 sudo -E scripts/install.sh
+```
+
+## What the Installer Does
+
+The installer:
+
+- installs system packages
+- installs Go when needed
+- creates a Btrfs image and mounts it at `$ROOT_DIR`
+- verifies reflink support
+- checks KVM and TUN/TAP
+- enables IPv4 forwarding
+- builds all NovitaBox components
+- installs binaries into `$ROOT_DIR`
+- installs Firecracker and guest kernel
+- writes systemd services
+- optionally configures dnsmasq
+- optionally configures Caddy with local TLS
+
+Installed binaries:
+
+```text
+$ROOT_DIR/boxapi
+$ROOT_DIR/boxctl
+$ROOT_DIR/boxd
+$ROOT_DIR/boxlet
+$ROOT_DIR/boxproxy
+$ROOT_DIR/boxshim
+$ROOT_DIR/firecracker
+$ROOT_DIR/vmlinux.bin
+```
+
+## Services
+
+```bash
+systemctl status novitabox-boxlet --no-pager
+systemctl status novitabox-boxapi --no-pager
+systemctl status novitabox-boxproxy --no-pager
+```
+
+Restart:
+
+```bash
+sudo systemctl restart novitabox-boxlet novitabox-boxapi novitabox-boxproxy
+```
+
+Logs:
+
+```bash
+journalctl -u novitabox-boxlet -f
+journalctl -u novitabox-boxapi -f
+journalctl -u novitabox-boxproxy -f
+```
+
+## Verify
+
+```bash
+curl http://127.0.0.1:8080/health
+curl http://127.0.0.1:8082/healthz
+```
+
+If Caddy is enabled:
+
+```bash
+curl -k https://novitabox.local/health
+```
+
+List sandboxes:
+
+```bash
+/data/novitabox/boxctl sandbox list
+```
+
+## Build from Source Manually
+
+```bash
+make build-linux-amd64
+# or
+make build-linux-arm64
+```
+
+Copy binaries:
+
+```bash
+sudo install -m 0755 bin/linux-amd64/* /data/novitabox/
+```
+
+Start services manually:
+
+```bash
+/data/novitabox/boxlet --root /data/novitabox --addr 127.0.0.1:8081
+/data/novitabox/boxapi --root /data/novitabox --addr 127.0.0.1:8080 --boxlet-addr 127.0.0.1:8081
+/data/novitabox/boxproxy --root /data/novitabox --addr 127.0.0.1:8082
+```
+
+## Notes
+
+The Firecracker full snapshot path depends on host KVM support. On some nested virtualization hosts, template snapshot creation can fail with:
+
+```text
+Failed to get KVM vcpu msr: 0x3a
+```
+
+That error is not a NovitaBox network issue. It means Firecracker could not save vCPU MSR state on the current host.

--- a/docs/quick-start/proxy.md
+++ b/docs/quick-start/proxy.md
@@ -1,0 +1,76 @@
+# Reverse Proxy
+
+NovitaBox has two local HTTP services:
+
+- `boxapi` on `127.0.0.1:8080`
+- `boxproxy` on `127.0.0.1:8082`
+
+SDKs expect one domain for the API and wildcard domains for sandbox traffic. The recommended local setup uses Caddy with an internal CA.
+
+## Caddy
+
+```bash
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+    | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+    | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+
+sudo chmod o+r /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+sudo chmod o+r /etc/apt/sources.list.d/caddy-stable.list
+
+sudo apt update
+sudo apt install -y caddy
+
+
+sudo tee /etc/caddy/Caddyfile >/dev/null <<'EOF'
+{
+  local_certs
+}
+
+api.novitabox.local {
+  tls internal
+  reverse_proxy 127.0.0.1:8080
+}
+
+*.novitabox.local {
+  tls internal
+  reverse_proxy 127.0.0.1:8082
+}
+EOF
+
+
+sudo systemctl restart caddy
+sudo systemctl status caddy --no-pager
+
+
+sudo cp /var/lib/caddy/.local/share/caddy/pki/authorities/local/root.crt /usr/local/share/ca-certificates/caddy-local.crt
+sudo update-ca-certificates
+```
+
+## Routing Model
+
+```text
+https://novitabox.local
+  -> 127.0.0.1:8080
+
+https://<sandbox-or-port>.novitabox.local
+  -> 127.0.0.1:8082
+```
+
+`boxproxy` resolves the sandbox id from the request host or headers, finds the sandbox network slot from the local database, and forwards traffic to the guest agent through the sandbox host access IP.
+
+## Health Checks
+
+```bash
+curl -k https://novitabox.local/health
+curl http://127.0.0.1:8082/healthz
+```
+
+If HTTPS clients fail certificate verification, make sure the Caddy local CA has been installed:
+
+```bash
+sudo cp /var/lib/caddy/.local/share/caddy/pki/authorities/local/root.crt \
+  /usr/local/share/ca-certificates/caddy-local.crt
+sudo update-ca-certificates
+```

--- a/docs/quick-start/sdk.md
+++ b/docs/quick-start/sdk.md
@@ -1,0 +1,57 @@
+# Novita Sandbox SDK
+
+The Novita Sandbox SDK can use NovitaBox as its local backend when DNS and the reverse proxy are configured.
+
+## Install
+
+```bash
+pip install novita-sandbox==2.0.5
+```
+
+## Environment
+
+For a Caddy-backed local deployment:
+
+```bash
+export NOVITA_DOMAIN=novitabox.local
+export NOVITA_API_KEY=dummy
+export NOVITA_ACCESS_TOKEN=dummy
+export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+export NO_PROXY=.novitabox.local,localhost,127.0.0.1,::1
+```
+
+If your Python HTTP stack does not use the system CA bundle, point it directly to Caddy's local CA:
+
+```bash
+export SSL_CERT_FILE=/usr/local/share/ca-certificates/caddy-local.crt
+```
+
+## Run a Command
+
+```python
+import os
+from novita_sandbox import Sandbox
+
+os.environ["NOVITA_DOMAIN"] = "novitabox.local"
+os.environ["NOVITA_API_KEY"] = "dummy"
+os.environ["NOVITA_ACCESS_TOKEN"] = "dummy"
+
+sbx = Sandbox(template="tpl-xxxxxxxxxxxxxxxxxxxx")
+
+result = sbx.commands.run("echo 'Hello from NovitaBox!'")
+print(result.stdout)
+
+sbx.close()
+```
+
+The same code runs in Novita production with your production API key and endpoint. No code changes required.
+
+## Verify with boxctl
+
+When SDK calls fail, first check the underlying local state:
+
+```bash
+/data/novitabox/boxctl sandbox list
+/data/novitabox/boxctl template list
+journalctl -u novitabox-boxapi -n 100 --no-pager
+```

--- a/internal/boxlet/server/artifact_test.go
+++ b/internal/boxlet/server/artifact_test.go
@@ -102,6 +102,40 @@ func TestCloneOrCopyFileCopiesContent(t *testing.T) {
 	assertFileContent(t, dest, "content")
 }
 
+func TestInternalSandboxNetworkSpecUsesLowestFreeSlot(t *testing.T) {
+	root := t.TempDir()
+	st, err := sqlite.Open(context.Background(), filepath.Join(root, "novitabox.db"))
+	if err != nil {
+		t.Fatalf("open sqlite store: %v", err)
+	}
+	defer st.Close()
+
+	if err := st.CreateSandbox(context.Background(), store.SandboxRecord{
+		ID:          "sbx-existing",
+		State:       "running",
+		RuntimeType: "firecracker",
+		TemplateID:  "tpl-existing",
+		NetworkSlot: 1,
+	}); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	svc := newArtifactService(cfg, log.NewNop(), st)
+
+	spec, err := svc.internalSandboxNetworkSpec(context.Background(), "template-build-tpl-test")
+	if err != nil {
+		t.Fatalf("internalSandboxNetworkSpec() error = %v", err)
+	}
+	if spec.GetSlot() != 2 {
+		t.Fatalf("slot = %d, want 2", spec.GetSlot())
+	}
+	if spec.GetHostAccessIp() != "10.11.0.2" {
+		t.Fatalf("host access ip = %q, want 10.11.0.2", spec.GetHostAccessIp())
+	}
+}
+
 func TestArtifactServiceCreateTemplateSnapshotRequiresKernel(t *testing.T) {
 	root := t.TempDir()
 	source := filepath.Join(root, "source-rootfs.ext4")

--- a/internal/boxlet/server/services.go
+++ b/internal/boxlet/server/services.go
@@ -1082,18 +1082,21 @@ func (s *artifactService) injectTemplateInit(ctx context.Context, rootfsPath str
 		return fmt.Errorf("write template init script: %w", err)
 	}
 
-	commands := []string{
-		"mkdir /novitabox",
-		"write " + debugfsQuote(initPath) + " /novitabox/init",
-		"sif /novitabox/init mode 0100755",
+	if err := runDebugfs(ctx, rootfsPath, "mkdir /novitabox"); err != nil && !strings.Contains(err.Error(), "File exists") {
+		return err
 	}
-	for _, command := range commands {
-		if err := runDebugfs(ctx, rootfsPath, command); err != nil {
-			if strings.HasPrefix(command, "mkdir ") && strings.Contains(err.Error(), "File exists") {
-				continue
-			}
-			return err
-		}
+	if err := runDebugfs(ctx, rootfsPath, "rm /novitabox/init"); err != nil && !strings.Contains(err.Error(), "File not found") {
+		return err
+	}
+	if err := runDebugfsScript(ctx, rootfsPath, []string{
+		"cd /novitabox",
+		"write " + debugfsQuote(initPath) + " init",
+		"sif init mode 0100755",
+	}); err != nil {
+		return err
+	}
+	if err := runDebugfs(ctx, rootfsPath, "stat /novitabox/init"); err != nil {
+		return err
 	}
 
 	return nil
@@ -1114,10 +1117,51 @@ exec ` + boxdPath + ` --addr ` + listenAddr + `
 
 func runDebugfs(ctx context.Context, rootfsPath string, command string) error {
 	cmd := exec.CommandContext(ctx, "debugfs", "-w", "-R", command, rootfsPath)
-	if output, err := cmd.CombinedOutput(); err != nil {
+	output, err := cmd.CombinedOutput()
+	if err != nil {
 		return fmt.Errorf("debugfs %q failed: %w: %s", command, err, strings.TrimSpace(string(output)))
 	}
+	if hasDebugfsCommandError(output) {
+		return fmt.Errorf("debugfs %q failed: %s", command, strings.TrimSpace(string(output)))
+	}
 	return nil
+}
+
+func runDebugfsScript(ctx context.Context, rootfsPath string, commands []string) error {
+	workDir := filepath.Dir(rootfsPath)
+	cmdFile, err := os.CreateTemp(workDir, ".debugfs-commands-*")
+	if err != nil {
+		return fmt.Errorf("create debugfs command file: %w", err)
+	}
+	cmdFilePath := cmdFile.Name()
+	defer os.Remove(cmdFilePath)
+
+	for _, command := range commands {
+		if _, err := fmt.Fprintln(cmdFile, command); err != nil {
+			_ = cmdFile.Close()
+			return fmt.Errorf("write debugfs command file: %w", err)
+		}
+	}
+	if err := cmdFile.Close(); err != nil {
+		return fmt.Errorf("close debugfs command file: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "debugfs", "-w", "-f", cmdFilePath, rootfsPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("debugfs script failed: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	if hasDebugfsCommandError(output) {
+		return fmt.Errorf("debugfs script failed: %s", strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func hasDebugfsCommandError(output []byte) bool {
+	text := string(output)
+	return strings.Contains(text, "File not found") ||
+		strings.Contains(text, "Ext2 directory already exists") ||
+		strings.Contains(text, "while creating directory")
 }
 
 func debugfsQuote(path string) string {
@@ -1250,7 +1294,7 @@ func (s *artifactService) internalSandboxNetworkSpec(ctx context.Context, sandbo
 			}
 		}
 	}
-	for slot := maxSlot; slot > 0; slot-- {
+	for slot := uint32(1); slot <= maxSlot; slot++ {
 		if _, ok := used[slot]; !ok {
 			return manager.SpecForSlot(sandboxID, slot)
 		}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,6 +19,7 @@ RELEASE_VERSION="${RELEASE_VERSION:-v0.0.1}"
 SOURCE_DIR="${SOURCE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 INSTALL_GO="${INSTALL_GO:-auto}"
 GO_VERSION="${GO_VERSION:-1.26.4}"
+GOPROXY="${GOPROXY:-https://goproxy.cn,direct}"
 ENABLE_DNS="${ENABLE_DNS:-1}"
 ENABLE_CADDY="${ENABLE_CADDY:-1}"
 REQUIRE_KVM="${REQUIRE_KVM:-1}"
@@ -53,9 +54,12 @@ need_root() {
 }
 
 need_no_spaces() {
-  case "$ROOT_DIR $IMAGE_PATH $SOURCE_DIR" in
-    *" "*) die "ROOT_DIR, IMAGE_PATH, and SOURCE_DIR must not contain spaces" ;;
-  esac
+  local path
+  for path in "$ROOT_DIR" "$IMAGE_PATH" "$SOURCE_DIR"; do
+    case "$path" in
+      *" "*) die "ROOT_DIR, IMAGE_PATH, and SOURCE_DIR must not contain spaces: $path" ;;
+    esac
+  done
 }
 
 command_exists() {
@@ -158,9 +162,9 @@ prepare_btrfs_root() {
   log "preparing btrfs root at ${ROOT_DIR}"
   mkdir -p "$(dirname "$IMAGE_PATH")" "$ROOT_DIR"
 
-  if findmnt -rn --target "$ROOT_DIR" >/dev/null 2>&1; then
+  if mountpoint -q "$ROOT_DIR"; then
     local fstype
-    fstype="$(findmnt -rn --target "$ROOT_DIR" -o FSTYPE)"
+    fstype="$(findmnt -rn --mountpoint "$ROOT_DIR" -o FSTYPE)"
     if [[ "$fstype" != "btrfs" ]]; then
       die "$ROOT_DIR is mounted as $fstype, but NovitaBox requires btrfs for this installer"
     fi
@@ -241,7 +245,7 @@ EOF
 build_components() {
   local arch="$1"
   log "building NovitaBox linux-${arch} components"
-  make -C "$SOURCE_DIR" "build-linux-${arch}"
+  GOPROXY="$GOPROXY" make -C "$SOURCE_DIR" "build-linux-${arch}"
 }
 
 install_components() {


### PR DESCRIPTION
- README: fill quick start with DNS, proxy, template build, sandbox, and exec examples
- docs: add install guide, boxctl workflow, SDK/CLI setup, proxy, DNS, and HTTP curl examples
- docs: expand CLI references for template, sandbox, image, runtime, and exec commands
- docs: add Chinese usage guide, architecture overview, and release notes
- docs: align architecture docs with current file layout, networking defaults, and lifecycle behavior