### PR TITLE
feat: add macOS Lima installer and host networking setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ NOVITABOX_GOMODCACHE := $(CURDIR)/.gomodcache
 NOVITABOX_BUF_CACHE_DIR := $(CURDIR)/.bufcache
 GOPROXY ?= https://goproxy.cn,direct
 
-.PHONY: build build-linux-amd64 build-linux-arm64 test fmt proto tools
+.PHONY: build build-linux-amd64 build-linux-arm64 build-darwin-arm64 build-darwin-amd64 test fmt proto tools clean
 
 COMMANDS := boxapi boxctl boxd boxlet boxproxy boxshim
 
@@ -25,6 +25,18 @@ build-linux-arm64:
 		GOOS=linux GOARCH=arm64 CGO_ENABLED=0 GOPROXY="$(GOPROXY)" GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go build -o "bin/linux-arm64/$$cmd" "./cmd/$$cmd"; \
 	done
 
+build-darwin-arm64:
+	mkdir -p bin/darwin-arm64
+	for cmd in $(COMMANDS); do \
+		GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 GOPROXY="$(GOPROXY)" GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go build -o "bin/darwin-arm64/$$cmd" "./cmd/$$cmd"; \
+	done
+
+build-darwin-amd64:
+	mkdir -p bin/darwin-amd64
+	for cmd in $(COMMANDS); do \
+		GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 GOPROXY="$(GOPROXY)" GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go build -o "bin/darwin-amd64/$$cmd" "./cmd/$$cmd"; \
+	done
+
 test:
 	GOPROXY="$(GOPROXY)" GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go test ./...
 
@@ -37,3 +49,6 @@ proto:
 tools:
 	mkdir -p .bin
 	cd tools && GOBIN="$(CURDIR)/.bin" GOPROXY="$(GOPROXY)" GOCACHE="$(NOVITABOX_GOCACHE)" GOMODCACHE="$(NOVITABOX_GOMODCACHE)" go install tool
+
+clean:
+	rm -rf bin .gocache .gomodcache .bufcache

--- a/internal/boxlet/server/network.go
+++ b/internal/boxlet/server/network.go
@@ -112,6 +112,7 @@ func (m sandboxNetworkManager) Ensure(ctx context.Context, spec *novitaboxv1.Net
 
 	hostVeth := hostVethName(spec.GetNamespaceName())
 	nsVeth := nsVethName(spec.GetNamespaceName())
+	nsPeerVeth := nsPeerVethName(spec.GetNamespaceName())
 	slot, err := networkSlotFromHostAccessIP(m.cfg.Network.HostAccessCIDR, spec.GetHostAccessIp())
 	if err != nil {
 		return err
@@ -125,12 +126,17 @@ func (m sandboxNetworkManager) Ensure(ctx context.Context, spec *novitaboxv1.Net
 		return fmt.Errorf("create netns %s: %w", spec.GetNamespaceName(), err)
 	}
 	_ = runCommand(ctx, "ip", "link", "del", hostVeth)
+	_ = runCommand(ctx, "ip", "link", "del", nsPeerVeth)
+	_ = runCommand(ctx, "ip", "netns", "exec", spec.GetNamespaceName(), "ip", "link", "del", nsVeth)
 
-	if err := runCommand(ctx, "ip", "link", "add", hostVeth, "type", "veth", "peer", "name", nsVeth); err != nil {
+	if err := runCommand(ctx, "ip", "link", "add", hostVeth, "type", "veth", "peer", "name", nsPeerVeth); err != nil {
 		return fmt.Errorf("create veth pair: %w", err)
 	}
-	if err := runCommand(ctx, "ip", "link", "set", nsVeth, "netns", spec.GetNamespaceName()); err != nil {
+	if err := runCommand(ctx, "ip", "link", "set", nsPeerVeth, "netns", spec.GetNamespaceName()); err != nil {
 		return fmt.Errorf("move veth to netns: %w", err)
+	}
+	if err := runCommand(ctx, "ip", "netns", "exec", spec.GetNamespaceName(), "ip", "link", "set", nsPeerVeth, "name", nsVeth); err != nil {
+		return fmt.Errorf("rename namespace veth: %w", err)
 	}
 	if err := runCommand(ctx, "ip", "addr", "replace", veth.hostCIDR(), "dev", hostVeth); err != nil {
 		return fmt.Errorf("configure host veth: %w", err)
@@ -325,6 +331,10 @@ func hostVethName(netns string) string {
 
 func nsVethName(netns string) string {
 	return "eth0"
+}
+
+func nsPeerVethName(netns string) string {
+	return shortName("vp-" + netns)
 }
 
 func shortName(name string) string {

--- a/internal/boxlet/server/network_test.go
+++ b/internal/boxlet/server/network_test.go
@@ -52,6 +52,16 @@ func TestVethAddrsUseSlotPair(t *testing.T) {
 	}
 }
 
+func TestNamespacePeerVethDoesNotUseFinalEth0Name(t *testing.T) {
+	netns := "nb-test"
+	if got := nsVethName(netns); got != "eth0" {
+		t.Fatalf("nsVethName() = %q, want eth0", got)
+	}
+	if got := nsPeerVethName(netns); got == "" || got == nsVethName(netns) {
+		t.Fatalf("nsPeerVethName() = %q, want a unique temporary name", got)
+	}
+}
+
 func TestSandboxNetworkCompletePreservesExplicitValues(t *testing.T) {
 	cfg := config.Default()
 	manager := newSandboxNetworkManager(cfg)

--- a/scripts/install-macos-lima.sh
+++ b/scripts/install-macos-lima.sh
@@ -1,0 +1,721 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# macOS Lima installer for NovitaBox.
+#
+# This script prepares a Lima Linux VM on macOS, builds Linux binaries
+# locally, uploads only the binaries and installer into the VM, then runs the
+# Linux installer inside the VM.
+#
+# Usage from repository root:
+#   scripts/install-macos-lima.sh
+#
+# Common overrides:
+#   LIMA_CPUS=4 LIMA_MEMORY=8GiB LIMA_DISK=80GiB scripts/install-macos-lima.sh
+#   LIMA_IMAGE_URL=https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-arm64.img scripts/install-macos-lima.sh
+#   LIMA_IMAGE_PATH=$HOME/.lima/_templates/ubuntu-24.04-server-cloudimg-arm64.img scripts/install-macos-lima.sh
+#   ENABLE_MAC_DNS=1 ENABLE_MAC_PROXY=1 scripts/install-macos-lima.sh
+#   ENABLE_VM_DNS=1 ENABLE_VM_CADDY=1 scripts/install-macos-lima.sh
+#   DOCKER_REGISTRY_MIRRORS=https://docker.m.daocloud.io,https://docker.1ms.run scripts/install-macos-lima.sh
+#   FIRECRACKER_URL=https://.../firecracker-arm64 KERNEL_URL=https://.../vmlinux.bin-arm64 scripts/install-macos-lima.sh
+
+VM_NAME="${VM_NAME:-novitabox}"
+LIMA_TEMPLATE_NAME="${LIMA_TEMPLATE_NAME:-ubuntu-24.04-novitabox}"
+LIMA_TEMPLATE_DIR="${LIMA_TEMPLATE_DIR:-${HOME}/.lima/_templates}"
+LIMA_TEMPLATE_PATH="${LIMA_TEMPLATE_PATH:-${LIMA_TEMPLATE_DIR}/${LIMA_TEMPLATE_NAME}.yaml}"
+LIMA_IMAGE_PATH="${LIMA_IMAGE_PATH:-}"
+LIMA_IMAGE_URL="${LIMA_IMAGE_URL:-}"
+LIMA_IMAGE_DIGEST="${LIMA_IMAGE_DIGEST:-}"
+RELEASE_VERSION="${RELEASE_VERSION:-v0.0.1}"
+BUILD_ARCH="${BUILD_ARCH:-}"
+DARWIN_ARCH="${DARWIN_ARCH:-}"
+ASSET_ARCH="${ASSET_ARCH:-}"
+FIRECRACKER_URL="${FIRECRACKER_URL:-}"
+KERNEL_URL="${KERNEL_URL:-}"
+FIRECRACKER_PATH="${FIRECRACKER_PATH:-}"
+KERNEL_PATH="${KERNEL_PATH:-}"
+
+LIMA_CPUS="${LIMA_CPUS:-2}"
+LIMA_MEMORY="${LIMA_MEMORY:-4GiB}"
+LIMA_DISK="${LIMA_DISK:-80GiB}"
+LIMA_USER="${LIMA_USER:-novitabox}"
+
+VM_INSTALL_DIR="${VM_INSTALL_DIR:-/home/${LIMA_USER}/novitabox-install}"
+ROOT_DIR="${ROOT_DIR:-/data/novitabox}"
+IMAGE_PATH="${IMAGE_PATH:-/data/novitabox.img}"
+IMAGE_SIZE="${IMAGE_SIZE:-50G}"
+DOMAIN="${DOMAIN:-novitabox.local}"
+ENABLE_MAC_DNS="${ENABLE_MAC_DNS:-${ENABLE_DNS:-0}}"
+ENABLE_MAC_PROXY="${ENABLE_MAC_PROXY:-${ENABLE_CADDY:-0}}"
+ENABLE_VM_DNS="${ENABLE_VM_DNS:-0}"
+ENABLE_VM_CADDY="${ENABLE_VM_CADDY:-0}"
+REQUIRE_KVM="${REQUIRE_KVM:-1}"
+GOPROXY="${GOPROXY:-https://goproxy.cn,direct}"
+DOCKER_REGISTRY_MIRRORS="${DOCKER_REGISTRY_MIRRORS:-https://docker.m.daocloud.io,https://docker.1ms.run}"
+
+SOURCE_DIR="${SOURCE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+ASSET_DIR="${ASSET_DIR:-${SOURCE_DIR}/assets}"
+BREW_BIN="${BREW_BIN:-}"
+BREW_PREFIX="${BREW_PREFIX:-}"
+MAC_DNSMASQ_MAIN_CONF="${MAC_DNSMASQ_MAIN_CONF:-}"
+MAC_DNSMASQ_CONF="${MAC_DNSMASQ_CONF:-}"
+MAC_RESOLVER_DIR="${MAC_RESOLVER_DIR:-/etc/resolver}"
+MAC_CADDYFILE="${MAC_CADDYFILE:-}"
+MAC_CADDY_CA_PATH="${MAC_CADDY_CA_PATH:-${SOURCE_DIR}/assets/caddy-local-root.crt}"
+
+log() {
+  printf '[novitabox-macos] %s\n' "$*"
+}
+
+warn() {
+  printf '[novitabox-macos] warning: %s\n' "$*" >&2
+}
+
+die() {
+  printf '[novitabox-macos] error: %s\n' "$*" >&2
+  exit 1
+}
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+trim_space() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "${value}"
+}
+
+docker_registry_mirrors_json_lines() {
+  local input="$1"
+  local mirror escaped i suffix
+  local mirrors=()
+
+  if [[ -z "${input}" || "${input}" == "none" || "${input}" == "0" ]]; then
+    return
+  fi
+
+  IFS=',' read -r -a raw_mirrors <<<"${input}"
+  for mirror in "${raw_mirrors[@]}"; do
+    mirror="$(trim_space "${mirror}")"
+    if [[ -n "${mirror}" ]]; then
+      mirrors+=("${mirror}")
+    fi
+  done
+
+  for ((i = 0; i < ${#mirrors[@]}; i++)); do
+    escaped="${mirrors[$i]}"
+    escaped="${escaped//\\/\\\\}"
+    escaped="${escaped//\"/\\\"}"
+    suffix=","
+    if (( i == ${#mirrors[@]} - 1 )); then
+      suffix=""
+    fi
+    printf "      '    \"%s\"%s' \\\\\n" "${escaped}" "${suffix}"
+  done
+}
+
+docker_registry_mirrors_provision_block() {
+  local json_lines
+  json_lines="$(docker_registry_mirrors_json_lines "$1")"
+  if [[ -z "${json_lines}" ]]; then
+    return
+  fi
+
+  cat <<EOF
+    mkdir -p /etc/docker
+    printf '%s\n' \\
+      '{' \\
+      '  "registry-mirrors": [' \\
+${json_lines}
+      '  ]' \\
+      '}' >/etc/docker/daemon.json
+EOF
+}
+
+sha256_file() {
+  local path="$1"
+  local output
+
+  if command_exists shasum; then
+    output="$(LC_ALL=C LANG=C shasum -a 256 "${path}")"
+    echo "${output%% *}"
+    return
+  fi
+
+  if command_exists sha256sum; then
+    output="$(LC_ALL=C LANG=C sha256sum "${path}")"
+    echo "${output%% *}"
+    return
+  fi
+
+  if command_exists openssl; then
+    output="$(LC_ALL=C LANG=C openssl dgst -sha256 -r "${path}")"
+    echo "${output%% *}"
+    return
+  fi
+
+  die "cannot calculate sha256: shasum, sha256sum, and openssl are all missing"
+}
+
+detect_host_lima_arch() {
+  local machine
+  machine="$(uname -m)"
+  case "${machine}" in
+    arm64 | aarch64) echo "aarch64" ;;
+    x86_64 | amd64) echo "x86_64" ;;
+    *) echo "aarch64" ;;
+  esac
+}
+
+need_macos() {
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    die "this installer must run on macOS"
+  fi
+}
+
+need_lima() {
+  if ! command_exists limactl; then
+    die "Lima is not installed. Install it with: brew install lima"
+  fi
+}
+
+need_brew() {
+  if ! command_exists brew; then
+    die "Homebrew is required for macOS DNS/proxy setup. Install it first or rerun with ENABLE_MAC_DNS=0 ENABLE_MAC_PROXY=0"
+  fi
+}
+
+need_build_tools() {
+  if ! command_exists go; then
+    die "Go is not installed. Install it with: brew install go"
+  fi
+
+  if ! command_exists make; then
+    die "make is not installed. Install Xcode Command Line Tools with: xcode-select --install"
+  fi
+
+  if ! command_exists curl; then
+    die "curl is not installed or not in PATH"
+  fi
+
+  if ! command_exists tar; then
+    die "tar is not installed or not in PATH"
+  fi
+}
+
+need_source_dir() {
+  if [[ ! -f "${SOURCE_DIR}/scripts/install.sh" ]]; then
+    die "SOURCE_DIR must point to the NovitaBox repository root: ${SOURCE_DIR}"
+  fi
+}
+
+resolve_macos_service_paths() {
+  if [[ "${ENABLE_MAC_DNS}" != "1" && "${ENABLE_MAC_PROXY}" != "1" ]]; then
+    return
+  fi
+  need_brew
+
+  if [[ -z "${BREW_PREFIX}" ]]; then
+    BREW_BIN="$(command -v brew)"
+    BREW_PREFIX="$("${BREW_BIN}" --prefix)"
+  elif [[ -z "${BREW_BIN}" ]]; then
+    BREW_BIN="$(command -v brew)"
+  fi
+  MAC_DNSMASQ_MAIN_CONF="${MAC_DNSMASQ_MAIN_CONF:-${BREW_PREFIX}/etc/dnsmasq.conf}"
+  MAC_DNSMASQ_CONF="${MAC_DNSMASQ_CONF:-${BREW_PREFIX}/etc/dnsmasq.d/novitabox.conf}"
+  MAC_CADDYFILE="${MAC_CADDYFILE:-${BREW_PREFIX}/etc/Caddyfile}"
+}
+
+normalize_lima_arch() {
+  case "$1" in
+    aarch64 | arm64) echo "aarch64" ;;
+    x86_64 | amd64) echo "x86_64" ;;
+    *) die "unsupported Lima architecture: $1" ;;
+  esac
+}
+
+go_arch_for_lima_arch() {
+  case "$1" in
+    aarch64) echo "arm64" ;;
+    x86_64) echo "amd64" ;;
+    *) die "unsupported Lima architecture: $1" ;;
+  esac
+}
+
+go_arch_for_darwin_host() {
+  case "$(uname -m)" in
+    arm64 | aarch64) echo "arm64" ;;
+    x86_64 | amd64) echo "amd64" ;;
+    *) die "unsupported Darwin architecture: $(uname -m)" ;;
+  esac
+}
+
+ubuntu_cloud_image_url_for_lima_arch() {
+  case "$1" in
+    aarch64) echo "https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-arm64.img" ;;
+    x86_64) echo "https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img" ;;
+    *) die "unsupported Lima architecture: $1" ;;
+  esac
+}
+
+ubuntu_cloud_image_name_for_lima_arch() {
+  case "$1" in
+    aarch64) echo "ubuntu-24.04-server-cloudimg-arm64.img" ;;
+    x86_64) echo "ubuntu-24.04-server-cloudimg-amd64.img" ;;
+    *) die "unsupported Lima architecture: $1" ;;
+  esac
+}
+
+resolve_arch_config() {
+  LIMA_ARCH="${LIMA_ARCH:-$(detect_host_lima_arch)}"
+  LIMA_ARCH="$(normalize_lima_arch "${LIMA_ARCH}")"
+  BUILD_ARCH="${BUILD_ARCH:-$(go_arch_for_lima_arch "${LIMA_ARCH}")}"
+  DARWIN_ARCH="${DARWIN_ARCH:-$(go_arch_for_darwin_host)}"
+  ASSET_ARCH="${ASSET_ARCH:-${BUILD_ARCH}}"
+  LIMA_IMAGE_URL="${LIMA_IMAGE_URL:-$(ubuntu_cloud_image_url_for_lima_arch "${LIMA_ARCH}")}"
+  LIMA_IMAGE_PATH="${LIMA_IMAGE_PATH:-${LIMA_TEMPLATE_DIR}/$(ubuntu_cloud_image_name_for_lima_arch "${LIMA_ARCH}")}"
+  FIRECRACKER_URL="${FIRECRACKER_URL:-https://github.com/novitalabs/NovitaBox/releases/download/${RELEASE_VERSION}/firecracker-${ASSET_ARCH}}"
+  KERNEL_URL="${KERNEL_URL:-https://github.com/novitalabs/NovitaBox/releases/download/${RELEASE_VERSION}/vmlinux.bin-${ASSET_ARCH}}"
+  FIRECRACKER_PATH="${FIRECRACKER_PATH:-${ASSET_DIR}/firecracker-${ASSET_ARCH}}"
+  KERNEL_PATH="${KERNEL_PATH:-${ASSET_DIR}/vmlinux.bin-${ASSET_ARCH}}"
+}
+
+size_to_mib() {
+  local value="$1"
+  local number unit
+
+  if [[ "$value" =~ ^([0-9]+)([KkMmGgTt]i?[Bb]?)?$ ]]; then
+    number="${BASH_REMATCH[1]}"
+    unit="${BASH_REMATCH[2]}"
+  else
+    die "invalid size ${value}; use values like 50G, 80GiB, or 51200MiB"
+  fi
+
+  case "${unit}" in
+    "" | [Mm] | [Mm][Bb] | [Mm]i | [Mm]i[Bb])
+      echo "$number"
+      ;;
+    [Kk] | [Kk][Bb] | [Kk]i | [Kk]i[Bb])
+      echo $(((number + 1023) / 1024))
+      ;;
+    [Gg] | [Gg][Bb] | [Gg]i | [Gg]i[Bb])
+      echo $((number * 1024))
+      ;;
+    [Tt] | [Tt][Bb] | [Tt]i | [Tt]i[Bb])
+      echo $((number * 1024 * 1024))
+      ;;
+    *)
+      die "unsupported size unit in ${value}"
+      ;;
+  esac
+}
+
+validate_disk_size() {
+  local disk_mib image_mib
+  disk_mib="$(size_to_mib "${LIMA_DISK}")"
+  image_mib="$(size_to_mib "${IMAGE_SIZE}")"
+
+  if (( disk_mib <= image_mib )); then
+    die "LIMA_DISK (${LIMA_DISK}) must be larger than IMAGE_SIZE (${IMAGE_SIZE})"
+  fi
+}
+
+print_config() {
+  cat <<EOF
+[novitabox-macos] Lima VM configuration:
+  VM_NAME             ${VM_NAME}
+  LIMA_TEMPLATE_NAME  ${LIMA_TEMPLATE_NAME}
+  LIMA_ARCH           ${LIMA_ARCH}
+  BUILD_ARCH          ${BUILD_ARCH}
+  DARWIN_ARCH         ${DARWIN_ARCH}
+  ASSET_ARCH          ${ASSET_ARCH}
+  LIMA_CPUS           ${LIMA_CPUS}
+  LIMA_MEMORY         ${LIMA_MEMORY}
+  LIMA_DISK           ${LIMA_DISK}
+  IMAGE_SIZE          ${IMAGE_SIZE}
+  ROOT_DIR            ${ROOT_DIR}
+  IMAGE_PATH          ${IMAGE_PATH}
+  LIMA_IMAGE_PATH     ${LIMA_IMAGE_PATH}
+  LIMA_IMAGE_URL      ${LIMA_IMAGE_URL}
+  FIRECRACKER_PATH    ${FIRECRACKER_PATH}
+  KERNEL_PATH         ${KERNEL_PATH}
+  DOCKER_MIRRORS      ${DOCKER_REGISTRY_MIRRORS}
+  ENABLE_MAC_DNS      ${ENABLE_MAC_DNS}
+  ENABLE_MAC_PROXY    ${ENABLE_MAC_PROXY}
+  MAC_DNSMASQ_MAIN    ${MAC_DNSMASQ_MAIN_CONF:-<disabled>}
+  MAC_DNSMASQ_CONF    ${MAC_DNSMASQ_CONF:-<disabled>}
+  MAC_RESOLVER_DIR    ${MAC_RESOLVER_DIR}
+  MAC_CADDYFILE       ${MAC_CADDYFILE:-<disabled>}
+  ENABLE_VM_DNS       ${ENABLE_VM_DNS}
+  ENABLE_VM_CADDY     ${ENABLE_VM_CADDY}
+
+Override example:
+  LIMA_CPUS=4 LIMA_MEMORY=8GiB LIMA_DISK=100GiB IMAGE_SIZE=80G scripts/install-macos-lima.sh
+
+EOF
+}
+
+build_local_binaries() {
+  log "building linux-${BUILD_ARCH} components locally"
+  make -C "${SOURCE_DIR}" "build-linux-${BUILD_ARCH}"
+  log "building darwin-${DARWIN_ARCH} components locally"
+  make -C "${SOURCE_DIR}" "build-darwin-${DARWIN_ARCH}"
+}
+
+prepare_template_dir() {
+  log "preparing Lima template directory ${LIMA_TEMPLATE_DIR}"
+  mkdir -p "${LIMA_TEMPLATE_DIR}"
+}
+
+download_asset_if_needed() {
+  local name="$1"
+  local path="$2"
+  local url="$3"
+  local mode="$4"
+
+  if [[ -s "${path}" ]]; then
+    log "using existing ${name} ${path}"
+    chmod "${mode}" "${path}"
+    return
+  fi
+  if [[ -z "${url}" ]]; then
+    die "${name} is missing at ${path} and no download URL was provided"
+  fi
+
+  log "downloading ${name} from ${url}"
+  mkdir -p "$(dirname "${path}")"
+  curl -fL "${url}" -o "${path}.tmp"
+  chmod "${mode}" "${path}.tmp"
+  mv -f "${path}.tmp" "${path}"
+}
+
+prepare_runtime_assets() {
+  mkdir -p "${ASSET_DIR}"
+  download_asset_if_needed "firecracker" "${FIRECRACKER_PATH}" "${FIRECRACKER_URL}" 0755
+  download_asset_if_needed "kernel" "${KERNEL_PATH}" "${KERNEL_URL}" 0644
+}
+
+prepare_lima_image() {
+  mkdir -p "$(dirname "${LIMA_IMAGE_PATH}")"
+
+  if [[ -f "${LIMA_IMAGE_PATH}" ]]; then
+    log "using existing Lima image ${LIMA_IMAGE_PATH}"
+  else
+    log "downloading Lima base image from ${LIMA_IMAGE_URL}"
+    curl -fL "${LIMA_IMAGE_URL}" -o "${LIMA_IMAGE_PATH}.tmp"
+    mv -f "${LIMA_IMAGE_PATH}.tmp" "${LIMA_IMAGE_PATH}"
+  fi
+
+  log "calculating Lima image sha256"
+  LIMA_IMAGE_DIGEST="sha256:$(sha256_file "${LIMA_IMAGE_PATH}")"
+}
+
+write_lima_template() {
+  local image_uri
+  local docker_mirror_block
+  image_uri="file://${LIMA_IMAGE_PATH}"
+  docker_mirror_block="$(docker_registry_mirrors_provision_block "${DOCKER_REGISTRY_MIRRORS}")"
+
+  log "writing Lima template ${LIMA_TEMPLATE_PATH}"
+  cat >"${LIMA_TEMPLATE_PATH}" <<EOF
+minimumLimaVersion: 2.0.0
+
+vmType: vz
+arch: ${LIMA_ARCH}
+cpus: ${LIMA_CPUS}
+memory: ${LIMA_MEMORY}
+disk: ${LIMA_DISK}
+
+images:
+- location: "${image_uri}"
+  arch: "${LIMA_ARCH}"
+  digest: "${LIMA_IMAGE_DIGEST}"
+
+containerd:
+  system: false
+  user: false
+
+user:
+  name: ${LIMA_USER}
+  home: /home/${LIMA_USER}
+  shell: /bin/bash
+
+provision:
+- mode: system
+  script: |
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y \
+      bash \
+      btrfs-progs \
+      ca-certificates \
+      coreutils \
+      curl \
+      docker.io \
+      findutils \
+      gcc \
+      git \
+      iproute2 \
+      iptables \
+      kmod \
+      libc6-dev \
+      make \
+      procps \
+      util-linux
+${docker_mirror_block}
+    systemctl daemon-reload
+    systemctl enable docker
+    systemctl restart docker
+    systemctl is-active --quiet docker
+    usermod -aG docker ${LIMA_USER}
+
+portForwards:
+- guestPort: 8080
+  hostPort: 8080
+  hostIP: "127.0.0.1"
+  proto: tcp
+- guestPort: 8082
+  hostPort: 8082
+  hostIP: "127.0.0.1"
+  proto: tcp
+
+nestedVirtualization: true
+EOF
+}
+
+start_lima_vm() {
+  if limactl list --format '{{.Name}}' | grep -Fxq "${VM_NAME}"; then
+    log "Lima VM ${VM_NAME} already exists"
+    limactl start "${VM_NAME}" >/dev/null || true
+    return
+  fi
+
+  log "starting Lima VM ${VM_NAME} from template:${LIMA_TEMPLATE_NAME}"
+  limactl start --name="${VM_NAME}" "template:${LIMA_TEMPLATE_NAME}"
+}
+
+wait_lima_vm() {
+  log "waiting for Lima VM ${VM_NAME}"
+  local deadline=$((SECONDS + 600))
+  until limactl shell "${VM_NAME}" -- uname -a >/dev/null 2>&1; do
+    if (( SECONDS >= deadline )); then
+      die "Lima VM ${VM_NAME} did not become ready"
+    fi
+    sleep 2
+  done
+}
+
+check_vm_kvm() {
+  log "checking KVM inside Lima VM"
+  if ! limactl shell "${VM_NAME}" -- test -e /dev/kvm; then
+    if [[ "${REQUIRE_KVM}" == "1" ]]; then
+      die "/dev/kvm is missing inside Lima VM. Firecracker requires nested virtualization."
+    fi
+    warn "/dev/kvm is missing inside Lima VM; Firecracker sandboxes will not start"
+  fi
+}
+
+configure_macos_entrypoints() {
+  if [[ "${ENABLE_MAC_DNS}" == "1" ]]; then
+    configure_macos_dns
+  fi
+  if [[ "${ENABLE_MAC_PROXY}" == "1" ]]; then
+    configure_macos_proxy
+  fi
+}
+
+brew_install_if_missing() {
+  local formula="$1"
+  if brew list --formula "${formula}" >/dev/null 2>&1; then
+    log "using existing Homebrew formula ${formula}"
+    return
+  fi
+  log "installing Homebrew formula ${formula}"
+  brew install "${formula}"
+}
+
+configure_macos_dns() {
+  log "configuring macOS dnsmasq for *.${DOMAIN}"
+  brew_install_if_missing dnsmasq
+
+  mkdir -p "$(dirname "${MAC_DNSMASQ_CONF}")"
+  touch "${MAC_DNSMASQ_MAIN_CONF}"
+  if ! grep -Fqs "conf-dir=$(dirname "${MAC_DNSMASQ_CONF}")" "${MAC_DNSMASQ_MAIN_CONF}"; then
+    {
+      printf '\n# Managed by NovitaBox.\n'
+      printf 'conf-dir=%s,*.conf\n' "$(dirname "${MAC_DNSMASQ_CONF}")"
+    } >>"${MAC_DNSMASQ_MAIN_CONF}"
+  fi
+
+  cat >"${MAC_DNSMASQ_CONF}" <<EOF
+# Managed by NovitaBox.
+address=/${DOMAIN}/127.0.0.1
+address=/.${DOMAIN}/127.0.0.1
+address=/${DOMAIN}/::1
+address=/.${DOMAIN}/::1
+EOF
+
+  sudo mkdir -p "${MAC_RESOLVER_DIR}"
+  printf 'nameserver 127.0.0.1\n' | sudo tee "${MAC_RESOLVER_DIR}/${DOMAIN}" >/dev/null
+
+  sudo "${BREW_BIN}" services restart dnsmasq
+  dscacheutil -flushcache >/dev/null 2>&1 || true
+}
+
+configure_macos_proxy() {
+  log "configuring macOS Caddy reverse proxy for ${DOMAIN}"
+  brew_install_if_missing caddy
+
+  mkdir -p "$(dirname "${MAC_CADDYFILE}")" "$(dirname "${MAC_CADDY_CA_PATH}")"
+  cat >"${MAC_CADDYFILE}" <<EOF
+# Managed by NovitaBox.
+{
+	admin off
+}
+
+${DOMAIN} {
+	tls internal
+	reverse_proxy 127.0.0.1:8080
+}
+
+*.${DOMAIN} {
+	tls internal
+	reverse_proxy 127.0.0.1:8082
+}
+EOF
+
+  sudo "${BREW_BIN}" services restart caddy
+
+  local root_ca=""
+  root_ca="$(find "${HOME}/Library/Application Support/Caddy" "${BREW_PREFIX}/var/lib/caddy" -path '*/pki/authorities/local/root.crt' -print -quit 2>/dev/null || true)"
+  if [[ -n "${root_ca}" ]]; then
+    cp "${root_ca}" "${MAC_CADDY_CA_PATH}"
+    log "Caddy local CA copied to ${MAC_CADDY_CA_PATH}"
+    warn "trust the Caddy local CA in macOS Keychain if HTTPS clients do not trust https://${DOMAIN}"
+  else
+    warn "Caddy local CA was not found; run 'caddy trust' or trust Caddy's local CA manually if HTTPS clients fail"
+  fi
+}
+
+sync_install_payload_to_vm() {
+  local payload_dir
+  payload_dir="$(mktemp -d "${TMPDIR:-/tmp}/novitabox-lima-payload.XXXXXX")"
+
+  mkdir -p "${payload_dir}/bin/linux-${BUILD_ARCH}" "${payload_dir}/scripts" "${payload_dir}/assets"
+  cp "${SOURCE_DIR}/scripts/install.sh" "${payload_dir}/scripts/install.sh"
+  cp "${SOURCE_DIR}/scripts/uninstall.sh" "${payload_dir}/scripts/uninstall.sh"
+  chmod +x "${payload_dir}/scripts/install.sh"
+  chmod +x "${payload_dir}/scripts/uninstall.sh"
+  cp "${FIRECRACKER_PATH}" "${payload_dir}/assets/firecracker"
+  cp "${KERNEL_PATH}" "${payload_dir}/assets/vmlinux.bin"
+  chmod 0755 "${payload_dir}/assets/firecracker"
+  chmod 0644 "${payload_dir}/assets/vmlinux.bin"
+
+  local cmd
+  for cmd in boxapi boxctl boxd boxlet boxproxy boxshim; do
+    if [[ ! -x "${SOURCE_DIR}/bin/linux-${BUILD_ARCH}/${cmd}" ]]; then
+      die "missing linux-${BUILD_ARCH} binary: ${SOURCE_DIR}/bin/linux-${BUILD_ARCH}/${cmd}"
+    fi
+    cp "${SOURCE_DIR}/bin/linux-${BUILD_ARCH}/${cmd}" "${payload_dir}/bin/linux-${BUILD_ARCH}/${cmd}"
+  done
+
+  log "uploading prebuilt components to ${VM_NAME}:${VM_INSTALL_DIR}"
+  limactl shell "${VM_NAME}" -- rm -rf "${VM_INSTALL_DIR}"
+  limactl shell "${VM_NAME}" -- mkdir -p "${VM_INSTALL_DIR}"
+
+  tar \
+    -C "${payload_dir}" \
+    -cf - . | limactl shell "${VM_NAME}" -- tar -C "${VM_INSTALL_DIR}" -xf -
+
+  rm -rf "${payload_dir}"
+}
+
+run_linux_installer() {
+  log "running Linux installer inside Lima VM"
+  limactl shell "${VM_NAME}" -- bash -lc "
+    cd '${VM_INSTALL_DIR}' &&
+    sudo env \
+      ROOT_DIR='${ROOT_DIR}' \
+      IMAGE_PATH='${IMAGE_PATH}' \
+      IMAGE_SIZE='${IMAGE_SIZE}' \
+      DOMAIN='${DOMAIN}' \
+      ENABLE_DNS='${ENABLE_VM_DNS}' \
+      ENABLE_CADDY='${ENABLE_VM_CADDY}' \
+      REQUIRE_KVM='${REQUIRE_KVM}' \
+      GOPROXY='${GOPROXY}' \
+      FIRECRACKER_PATH='${VM_INSTALL_DIR}/assets/firecracker' \
+      KERNEL_PATH='${VM_INSTALL_DIR}/assets/vmlinux.bin' \
+      SKIP_BUILD=1 \
+      SOURCE_DIR='${VM_INSTALL_DIR}' \
+      bash scripts/install.sh
+  "
+}
+
+print_summary() {
+  cat <<EOF
+
+NovitaBox Lima VM is ready.
+
+boxctl:
+  ${SOURCE_DIR}/bin/darwin-${DARWIN_ARCH}/boxctl --api http://127.0.0.1:8080 template build my-template --from-image ubuntu:22.04 --run 'echo hello from novitabox'
+  ${SOURCE_DIR}/bin/darwin-${DARWIN_ARCH}/boxctl --api http://127.0.0.1:8080 sandbox create <template-id>
+  ${SOURCE_DIR}/bin/darwin-${DARWIN_ARCH}/boxctl --api http://127.0.0.1:8080 sandbox ls
+  ${SOURCE_DIR}/bin/darwin-${DARWIN_ARCH}/boxctl --proxy http://127.0.0.1:8082 exec -it <sandbox-id> bash
+
+novita-sandbox-cli:
+  export NOVITA_DOMAIN=${DOMAIN}
+  export NOVITA_API_KEY=dummy
+  export NOVITA_ACCESS_TOKEN=dummy
+  export NO_PROXY=.${DOMAIN},localhost,127.0.0.1,::1
+  export NODE_EXTRA_CA_CERTS=${MAC_CADDY_CA_PATH}
+  novita-sandbox-cli sbx create <template-id>
+
+Health:
+  curl http://127.0.0.1:8080/health
+  curl http://127.0.0.1:8082/healthz
+
+Forwarded ports:
+  boxapi:   127.0.0.1:8080 -> VM 8080
+  boxproxy: 127.0.0.1:8082 -> VM 8082
+
+DNS/proxy:
+  macOS DNS:   ENABLE_MAC_DNS=${ENABLE_MAC_DNS}
+  macOS proxy: ENABLE_MAC_PROXY=${ENABLE_MAC_PROXY}
+  domain:      ${DOMAIN}
+  Caddy CA:    ${MAC_CADDY_CA_PATH}
+  VM-side DNS/Caddy are disabled by default and controlled only by ENABLE_VM_DNS / ENABLE_VM_CADDY.
+
+Template file:
+  ${LIMA_TEMPLATE_PATH}
+
+EOF
+}
+
+main() {
+  need_macos
+  need_lima
+  need_build_tools
+  need_source_dir
+  resolve_arch_config
+  resolve_macos_service_paths
+  validate_disk_size
+  print_config
+  prepare_template_dir
+  prepare_lima_image
+  prepare_runtime_assets
+  write_lima_template
+  start_lima_vm
+  wait_lima_vm
+  check_vm_kvm
+  build_local_binaries
+  sync_install_payload_to_vm
+  run_linux_installer
+  configure_macos_entrypoints
+  print_summary
+}
+
+main "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,8 +8,9 @@ set -Eeuo pipefail
 #
 # Common overrides:
 #   ROOT_DIR=/data/novitabox IMAGE_SIZE=100G DOMAIN=novitabox.local sudo -E scripts/install.sh
-#   FIRECRACKER_URL=https://.../firecracker KERNEL_URL=https://.../vmlinux.bin sudo -E scripts/install.sh
+#   FIRECRACKER_URL=https://.../firecracker-amd64 KERNEL_URL=https://.../vmlinux.bin-amd64 sudo -E scripts/install.sh
 #   FIRECRACKER_PATH=/path/to/firecracker KERNEL_PATH=/path/to/vmlinux.bin sudo -E scripts/install.sh
+#   SKIP_BUILD=1 SOURCE_DIR=/path/to/prebuilt-layout sudo -E scripts/install.sh
 
 ROOT_DIR="${ROOT_DIR:-/data/novitabox}"
 IMAGE_PATH="${IMAGE_PATH:-/data/novitabox.img}"
@@ -20,6 +21,8 @@ SOURCE_DIR="${SOURCE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 INSTALL_GO="${INSTALL_GO:-auto}"
 GO_VERSION="${GO_VERSION:-1.26.4}"
 GOPROXY="${GOPROXY:-https://goproxy.cn,direct}"
+DOCKER_REGISTRY_MIRRORS="${DOCKER_REGISTRY_MIRRORS:-https://docker.m.daocloud.io,https://docker.1ms.run}"
+SKIP_BUILD="${SKIP_BUILD:-0}"
 ENABLE_DNS="${ENABLE_DNS:-1}"
 ENABLE_CADDY="${ENABLE_CADDY:-1}"
 REQUIRE_KVM="${REQUIRE_KVM:-1}"
@@ -27,8 +30,8 @@ BOXAPI_ADDR="${BOXAPI_ADDR:-127.0.0.1:8080}"
 BOXLET_ADDR="${BOXLET_ADDR:-127.0.0.1:8081}"
 BOXPROXY_ADDR="${BOXPROXY_ADDR:-127.0.0.1:8082}"
 
-FIRECRACKER_URL="${FIRECRACKER_URL:-https://github.com/novitalabs/NovitaBox/releases/download/${RELEASE_VERSION}/firecracker}"
-KERNEL_URL="${KERNEL_URL:-https://github.com/novitalabs/NovitaBox/releases/download/${RELEASE_VERSION}/vmlinux.bin}"
+FIRECRACKER_URL="${FIRECRACKER_URL:-}"
+KERNEL_URL="${KERNEL_URL:-}"
 FIRECRACKER_PATH="${FIRECRACKER_PATH:-}"
 KERNEL_PATH="${KERNEL_PATH:-}"
 
@@ -66,12 +69,58 @@ command_exists() {
   command -v "$1" >/dev/null 2>&1
 }
 
+trim_space() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "${value}"
+}
+
+docker_registry_mirrors_json_lines() {
+  local input="$1"
+  local mirror escaped i suffix
+  local mirrors=()
+
+  if [[ -z "${input}" || "${input}" == "none" || "${input}" == "0" ]]; then
+    return
+  fi
+
+  IFS=',' read -r -a raw_mirrors <<<"${input}"
+  for mirror in "${raw_mirrors[@]}"; do
+    mirror="$(trim_space "${mirror}")"
+    if [[ -n "${mirror}" ]]; then
+      mirrors+=("${mirror}")
+    fi
+  done
+
+  for ((i = 0; i < ${#mirrors[@]}; i++)); do
+    escaped="${mirrors[$i]}"
+    escaped="${escaped//\\/\\\\}"
+    escaped="${escaped//\"/\\\"}"
+    suffix=","
+    if (( i == ${#mirrors[@]} - 1 )); then
+      suffix=""
+    fi
+    printf '    "%s"%s\n' "${escaped}" "${suffix}"
+  done
+}
+
 detect_arch() {
   case "$(uname -m)" in
     x86_64 | amd64) echo "amd64" ;;
     aarch64 | arm64) echo "arm64" ;;
     *) die "unsupported architecture: $(uname -m)" ;;
   esac
+}
+
+default_firecracker_url() {
+  local arch="$1"
+  echo "https://github.com/novitalabs/NovitaBox/releases/download/${RELEASE_VERSION}/firecracker-${arch}"
+}
+
+default_kernel_url() {
+  local arch="$1"
+  echo "https://github.com/novitalabs/NovitaBox/releases/download/${RELEASE_VERSION}/vmlinux.bin-${arch}"
 }
 
 install_packages() {
@@ -119,6 +168,36 @@ install_packages() {
   fi
 
   die "unsupported package manager; install dependencies manually and rerun"
+}
+
+configure_docker() {
+  if [[ -z "${DOCKER_REGISTRY_MIRRORS}" || "${DOCKER_REGISTRY_MIRRORS}" == "none" || "${DOCKER_REGISTRY_MIRRORS}" == "0" ]]; then
+    log "skipping Docker registry mirror configuration"
+    return
+  fi
+  if ! command_exists docker && ! systemctl list-unit-files docker.service >/dev/null 2>&1; then
+    log "Docker is not installed; skipping Docker registry mirror configuration"
+    return
+  fi
+
+  log "configuring Docker registry mirrors: ${DOCKER_REGISTRY_MIRRORS}"
+  mkdir -p /etc/docker
+  {
+    printf '{\n'
+    printf '  "registry-mirrors": [\n'
+    docker_registry_mirrors_json_lines "${DOCKER_REGISTRY_MIRRORS}"
+    printf '  ]\n'
+    printf '}\n'
+  } >/etc/docker/daemon.json
+
+  if command_exists systemctl && systemctl list-unit-files docker.service >/dev/null 2>&1; then
+    systemctl daemon-reload
+    systemctl enable docker >/dev/null 2>&1 || true
+    systemctl restart docker
+    systemctl is-active --quiet docker || die "docker did not become active after restart"
+  else
+    warn "systemctl docker.service not found; restart Docker manually to apply /etc/docker/daemon.json"
+  fi
 }
 
 version_ge() {
@@ -244,6 +323,16 @@ EOF
 
 build_components() {
   local arch="$1"
+  if [[ "$SKIP_BUILD" == "1" ]]; then
+    log "skipping build; using prebuilt components from ${SOURCE_DIR}/bin/linux-${arch}"
+    for cmd in "${COMMANDS[@]}"; do
+      if [[ ! -x "${SOURCE_DIR}/bin/linux-${arch}/${cmd}" ]]; then
+        die "missing prebuilt component: ${SOURCE_DIR}/bin/linux-${arch}/${cmd}"
+      fi
+    done
+    return
+  fi
+
   log "building NovitaBox linux-${arch} components"
   GOPROXY="$GOPROXY" make -C "$SOURCE_DIR" "build-linux-${arch}"
 }
@@ -255,6 +344,9 @@ install_components() {
   for cmd in "${COMMANDS[@]}"; do
     install -m 0755 "${SOURCE_DIR}/bin/linux-${arch}/${cmd}" "${ROOT_DIR}/${cmd}"
   done
+  if [[ -f "${SOURCE_DIR}/scripts/uninstall.sh" ]]; then
+    install -m 0755 "${SOURCE_DIR}/scripts/uninstall.sh" "${ROOT_DIR}/uninstall.sh"
+  fi
 }
 
 install_asset() {
@@ -283,8 +375,12 @@ install_asset() {
 }
 
 install_runtime_assets() {
-  install_asset "firecracker" "$FIRECRACKER_PATH" "$FIRECRACKER_URL" "${ROOT_DIR}/firecracker" 0755
-  install_asset "kernel" "$KERNEL_PATH" "$KERNEL_URL" "${ROOT_DIR}/vmlinux.bin" 0644
+  local arch="$1"
+  local firecracker_url="${FIRECRACKER_URL:-$(default_firecracker_url "$arch")}"
+  local kernel_url="${KERNEL_URL:-$(default_kernel_url "$arch")}"
+
+  install_asset "firecracker" "$FIRECRACKER_PATH" "$firecracker_url" "${ROOT_DIR}/firecracker" 0755
+  install_asset "kernel" "$KERNEL_PATH" "$kernel_url" "${ROOT_DIR}/vmlinux.bin" 0644
 }
 
 write_systemd_units() {
@@ -484,14 +580,17 @@ main() {
   arch="$(detect_arch)"
 
   install_packages
-  ensure_go "$arch"
+  configure_docker
+  if [[ "$SKIP_BUILD" != "1" ]]; then
+    ensure_go "$arch"
+  fi
   prepare_btrfs_root
   verify_reflink
   prepare_kernel_modules
   configure_sysctl
   build_components "$arch"
   install_components "$arch"
-  install_runtime_assets
+  install_runtime_assets "$arch"
   write_systemd_units
   configure_dnsmasq
   configure_caddy

--- a/scripts/uninstall-macos-lima.sh
+++ b/scripts/uninstall-macos-lima.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Remove a macOS Lima-based NovitaBox installation.
+#
+# Default usage:
+#   scripts/uninstall-macos-lima.sh
+#
+# Common overrides:
+#   KEEP_VM=1 scripts/uninstall-macos-lima.sh
+#   KEEP_LIMA_IMAGE=1 KEEP_ASSETS=1 scripts/uninstall-macos-lima.sh
+#   FORCE=1 scripts/uninstall-macos-lima.sh
+
+VM_NAME="${VM_NAME:-novitabox}"
+LIMA_TEMPLATE_NAME="${LIMA_TEMPLATE_NAME:-ubuntu-24.04-novitabox}"
+LIMA_TEMPLATE_DIR="${LIMA_TEMPLATE_DIR:-${HOME}/.lima/_templates}"
+LIMA_TEMPLATE_PATH="${LIMA_TEMPLATE_PATH:-${LIMA_TEMPLATE_DIR}/${LIMA_TEMPLATE_NAME}.yaml}"
+LIMA_IMAGE_PATH="${LIMA_IMAGE_PATH:-}"
+SOURCE_DIR="${SOURCE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+ASSET_DIR="${ASSET_DIR:-${SOURCE_DIR}/assets}"
+BREW_BIN="${BREW_BIN:-}"
+BREW_PREFIX="${BREW_PREFIX:-}"
+MAC_DNSMASQ_MAIN_CONF="${MAC_DNSMASQ_MAIN_CONF:-}"
+MAC_DNSMASQ_CONF="${MAC_DNSMASQ_CONF:-}"
+MAC_RESOLVER_DIR="${MAC_RESOLVER_DIR:-/etc/resolver}"
+MAC_CADDYFILE="${MAC_CADDYFILE:-}"
+MAC_CADDY_CA_PATH="${MAC_CADDY_CA_PATH:-${SOURCE_DIR}/assets/caddy-local-root.crt}"
+LIMA_USER="${LIMA_USER:-novitabox}"
+VM_INSTALL_DIR="${VM_INSTALL_DIR:-/home/${LIMA_USER}/novitabox-install}"
+ROOT_DIR="${ROOT_DIR:-/data/novitabox}"
+IMAGE_PATH="${IMAGE_PATH:-/data/novitabox.img}"
+DOMAIN="${DOMAIN:-novitabox.local}"
+
+KEEP_VM="${KEEP_VM:-0}"
+KEEP_TEMPLATE="${KEEP_TEMPLATE:-0}"
+KEEP_LIMA_IMAGE="${KEEP_LIMA_IMAGE:-0}"
+KEEP_ASSETS="${KEEP_ASSETS:-0}"
+FORCE="${FORCE:-0}"
+
+log() {
+  printf '[novitabox-macos-uninstall] %s\n' "$*"
+}
+
+warn() {
+  printf '[novitabox-macos-uninstall] warning: %s\n' "$*" >&2
+}
+
+die() {
+  printf '[novitabox-macos-uninstall] error: %s\n' "$*" >&2
+  exit 1
+}
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+need_macos() {
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    die "this uninstaller must run on macOS"
+  fi
+}
+
+need_lima() {
+  if ! command_exists limactl; then
+    die "Lima is not installed; nothing to remove through limactl"
+  fi
+}
+
+resolve_macos_service_paths() {
+  if command_exists brew; then
+    BREW_BIN="${BREW_BIN:-$(command -v brew)}"
+  fi
+  if [[ -z "${BREW_PREFIX}" ]] && [[ -n "${BREW_BIN}" ]]; then
+    BREW_PREFIX="$("${BREW_BIN}" --prefix)"
+  fi
+  if [[ -n "${BREW_PREFIX}" ]]; then
+    MAC_DNSMASQ_MAIN_CONF="${MAC_DNSMASQ_MAIN_CONF:-${BREW_PREFIX}/etc/dnsmasq.conf}"
+    MAC_DNSMASQ_CONF="${MAC_DNSMASQ_CONF:-${BREW_PREFIX}/etc/dnsmasq.d/novitabox.conf}"
+    MAC_CADDYFILE="${MAC_CADDYFILE:-${BREW_PREFIX}/etc/Caddyfile}"
+  else
+    MAC_DNSMASQ_MAIN_CONF="${MAC_DNSMASQ_MAIN_CONF:-}"
+    MAC_DNSMASQ_CONF="${MAC_DNSMASQ_CONF:-}"
+    MAC_CADDYFILE="${MAC_CADDYFILE:-}"
+  fi
+}
+
+detect_host_lima_arch() {
+  local machine
+  machine="$(uname -m)"
+  case "${machine}" in
+    arm64 | aarch64) echo "aarch64" ;;
+    x86_64 | amd64) echo "x86_64" ;;
+    *) echo "aarch64" ;;
+  esac
+}
+
+default_lima_image_name() {
+  case "$(detect_host_lima_arch)" in
+    aarch64) echo "ubuntu-24.04-server-cloudimg-arm64.img" ;;
+    x86_64) echo "ubuntu-24.04-server-cloudimg-amd64.img" ;;
+  esac
+}
+
+resolve_paths() {
+  LIMA_IMAGE_PATH="${LIMA_IMAGE_PATH:-${LIMA_TEMPLATE_DIR}/$(default_lima_image_name)}"
+}
+
+confirm_destructive() {
+  if [[ "${FORCE}" == "1" ]]; then
+    return
+  fi
+
+  cat <<EOF
+This will uninstall the Lima-based NovitaBox environment.
+
+It will remove:
+  Lima VM:       ${VM_NAME}
+  template:      ${LIMA_TEMPLATE_PATH}
+  Lima image:    ${LIMA_IMAGE_PATH}
+  asset cache:   ${ASSET_DIR}
+  resolver:      ${MAC_RESOLVER_DIR}/${DOMAIN}
+  dnsmasq main:  ${MAC_DNSMASQ_MAIN_CONF:-<unknown; brew not found>}
+  dnsmasq conf:  ${MAC_DNSMASQ_CONF:-<unknown; brew not found>}
+  Caddyfile:     ${MAC_CADDYFILE:-<unknown; brew not found>}
+  Caddy CA copy: ${MAC_CADDY_CA_PATH}
+
+It will first try to run the Linux uninstaller inside the VM.
+
+Set KEEP_VM=1, KEEP_TEMPLATE=1, KEEP_LIMA_IMAGE=1, or KEEP_ASSETS=1 to keep those files.
+Set FORCE=1 to skip this prompt.
+
+EOF
+
+  read -r -p "Continue? [y/N] " answer
+  case "${answer}" in
+    y | Y | yes | YES) ;;
+    *) die "aborted" ;;
+  esac
+}
+
+vm_exists() {
+  limactl list --format '{{.Name}}' 2>/dev/null | grep -Fxq "${VM_NAME}"
+}
+
+run_linux_uninstaller_in_vm() {
+  if ! vm_exists; then
+    log "Lima VM ${VM_NAME} does not exist; skipping in-VM cleanup"
+    return
+  fi
+
+  log "starting ${VM_NAME} for in-VM cleanup"
+  limactl start "${VM_NAME}" >/dev/null 2>&1 || true
+
+  if ! limactl shell "${VM_NAME}" -- test -f "${VM_INSTALL_DIR}/scripts/uninstall.sh" >/dev/null 2>&1; then
+    warn "in-VM uninstaller not found at ${VM_INSTALL_DIR}/scripts/uninstall.sh; removing VM directly"
+    return
+  fi
+
+  log "running Linux uninstaller inside ${VM_NAME}"
+  limactl shell "${VM_NAME}" -- bash -lc "
+    sudo env \
+      ROOT_DIR='${ROOT_DIR}' \
+      IMAGE_PATH='${IMAGE_PATH}' \
+      DOMAIN='${DOMAIN}' \
+      FORCE=1 \
+      bash '${VM_INSTALL_DIR}/scripts/uninstall.sh'
+  " || warn "in-VM uninstaller failed; continuing with Lima cleanup"
+}
+
+remove_vm() {
+  if [[ "${KEEP_VM}" == "1" ]]; then
+    log "KEEP_VM=1; keeping Lima VM ${VM_NAME}"
+    return
+  fi
+
+  if vm_exists; then
+    log "removing Lima VM ${VM_NAME}"
+    limactl stop "${VM_NAME}" --force >/dev/null 2>&1 || true
+    limactl delete "${VM_NAME}" --force
+  else
+    log "Lima VM ${VM_NAME} is already absent"
+  fi
+}
+
+remove_template() {
+  if [[ "${KEEP_TEMPLATE}" == "1" ]]; then
+    log "KEEP_TEMPLATE=1; keeping ${LIMA_TEMPLATE_PATH}"
+    return
+  fi
+
+  log "removing Lima template ${LIMA_TEMPLATE_PATH}"
+  rm -f "${LIMA_TEMPLATE_PATH}"
+}
+
+remove_lima_image() {
+  if [[ "${KEEP_LIMA_IMAGE}" == "1" ]]; then
+    log "KEEP_LIMA_IMAGE=1; keeping ${LIMA_IMAGE_PATH}"
+    return
+  fi
+
+  log "removing Lima base image ${LIMA_IMAGE_PATH}"
+  rm -f "${LIMA_IMAGE_PATH}" "${LIMA_IMAGE_PATH}.tmp"
+}
+
+remove_assets() {
+  if [[ "${KEEP_ASSETS}" == "1" ]]; then
+    log "KEEP_ASSETS=1; keeping ${ASSET_DIR}"
+    return
+  fi
+
+  log "removing runtime asset cache ${ASSET_DIR}"
+  rm -rf "${ASSET_DIR}"
+}
+
+remove_macos_entrypoints() {
+  log "removing macOS DNS/proxy configuration"
+
+  if [[ -f "${MAC_RESOLVER_DIR}/${DOMAIN}" ]]; then
+    sudo rm -f "${MAC_RESOLVER_DIR}/${DOMAIN}"
+    sudo rmdir "${MAC_RESOLVER_DIR}" >/dev/null 2>&1 || true
+  fi
+
+  if [[ -n "${MAC_DNSMASQ_CONF}" ]]; then
+    rm -f "${MAC_DNSMASQ_CONF}"
+    rmdir "$(dirname "${MAC_DNSMASQ_CONF}")" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${MAC_DNSMASQ_MAIN_CONF}" ]] && [[ -f "${MAC_DNSMASQ_MAIN_CONF}" ]]; then
+    sed -i.bak '/# Managed by NovitaBox\./,+1d' "${MAC_DNSMASQ_MAIN_CONF}" || true
+    rm -f "${MAC_DNSMASQ_MAIN_CONF}.bak"
+  fi
+  if [[ -n "${BREW_BIN}" ]] && "${BREW_BIN}" list --formula dnsmasq >/dev/null 2>&1; then
+    sudo "${BREW_BIN}" services restart dnsmasq >/dev/null 2>&1 || true
+  fi
+
+  if [[ -n "${MAC_CADDYFILE}" ]] && [[ -f "${MAC_CADDYFILE}" ]]; then
+    if grep -q "Managed by NovitaBox" "${MAC_CADDYFILE}" || grep -q "reverse_proxy 127.0.0.1:8080" "${MAC_CADDYFILE}"; then
+      rm -f "${MAC_CADDYFILE}"
+    else
+      warn "leaving ${MAC_CADDYFILE} in place because it does not look installer-owned"
+    fi
+  fi
+  if [[ -n "${BREW_BIN}" ]] && "${BREW_BIN}" list --formula caddy >/dev/null 2>&1; then
+    sudo "${BREW_BIN}" services restart caddy >/dev/null 2>&1 || true
+  fi
+
+  rm -f "${MAC_CADDY_CA_PATH}"
+  dscacheutil -flushcache >/dev/null 2>&1 || true
+}
+
+print_summary() {
+  cat <<EOF
+
+NovitaBox Lima environment has been uninstalled.
+
+State:
+  KEEP_VM          ${KEEP_VM}
+  KEEP_TEMPLATE    ${KEEP_TEMPLATE}
+  KEEP_LIMA_IMAGE  ${KEEP_LIMA_IMAGE}
+  KEEP_ASSETS      ${KEEP_ASSETS}
+
+EOF
+}
+
+main() {
+  need_macos
+  need_lima
+  resolve_paths
+  resolve_macos_service_paths
+  confirm_destructive
+  run_linux_uninstaller_in_vm
+  remove_vm
+  remove_template
+  remove_lima_image
+  remove_assets
+  remove_macos_entrypoints
+  print_summary
+}
+
+main "$@"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Remove a Linux NovitaBox installation.
+#
+# Default usage:
+#   sudo scripts/uninstall.sh
+#
+# Common overrides:
+#   ROOT_DIR=/data/novitabox IMAGE_PATH=/data/novitabox.img sudo -E scripts/uninstall.sh
+#   KEEP_DATA=1 sudo -E scripts/uninstall.sh
+
+ROOT_DIR="${ROOT_DIR:-/data/novitabox}"
+IMAGE_PATH="${IMAGE_PATH:-/data/novitabox.img}"
+DOMAIN="${DOMAIN:-novitabox.local}"
+KEEP_DATA="${KEEP_DATA:-0}"
+KEEP_PACKAGES="${KEEP_PACKAGES:-1}"
+FORCE="${FORCE:-0}"
+
+SERVICES=(novitabox-boxapi.service novitabox-boxproxy.service novitabox-boxlet.service)
+COMMANDS=(boxapi boxctl boxd boxlet boxproxy boxshim firecracker vmlinux.bin)
+
+log() {
+  printf '[novitabox-uninstall] %s\n' "$*"
+}
+
+warn() {
+  printf '[novitabox-uninstall] warning: %s\n' "$*" >&2
+}
+
+die() {
+  printf '[novitabox-uninstall] error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_root() {
+  if [[ "${EUID}" -ne 0 ]]; then
+    die "run as root, for example: sudo -E scripts/uninstall.sh"
+  fi
+}
+
+confirm_destructive() {
+  if [[ "${FORCE}" == "1" ]]; then
+    return
+  fi
+
+  cat <<EOF
+This will uninstall NovitaBox from this host.
+
+It will remove:
+  services:      ${SERVICES[*]}
+  root:          ${ROOT_DIR}
+  image:         ${IMAGE_PATH}
+  sysctl:        /etc/sysctl.d/99-novitabox.conf
+  dnsmasq:       /etc/dnsmasq.d/novitabox.conf
+  resolved:      /etc/systemd/resolved.conf.d/novitabox.conf
+  Caddy CA:      /usr/local/share/ca-certificates/caddy-local.crt
+
+Set KEEP_DATA=1 to keep ${ROOT_DIR} and ${IMAGE_PATH}.
+Set FORCE=1 to skip this prompt.
+
+EOF
+
+  read -r -p "Continue? [y/N] " answer
+  case "${answer}" in
+    y | Y | yes | YES) ;;
+    *) die "aborted" ;;
+  esac
+}
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+stop_services() {
+  log "stopping NovitaBox services"
+  if ! command_exists systemctl; then
+    warn "systemctl not found; skipping service cleanup"
+    return
+  fi
+
+  systemctl stop "${SERVICES[@]}" >/dev/null 2>&1 || true
+  systemctl disable "${SERVICES[@]}" >/dev/null 2>&1 || true
+
+  local service
+  for service in "${SERVICES[@]}"; do
+    rm -f "/etc/systemd/system/${service}"
+  done
+
+  systemctl daemon-reload || true
+  systemctl reset-failed "${SERVICES[@]}" >/dev/null 2>&1 || true
+}
+
+kill_leftover_processes() {
+  log "stopping leftover NovitaBox processes"
+  pkill -TERM -f "${ROOT_DIR}/boxapi" >/dev/null 2>&1 || true
+  pkill -TERM -f "${ROOT_DIR}/boxproxy" >/dev/null 2>&1 || true
+  pkill -TERM -f "${ROOT_DIR}/boxlet" >/dev/null 2>&1 || true
+  pkill -TERM -f "${ROOT_DIR}/boxshim" >/dev/null 2>&1 || true
+  pkill -TERM -f "${ROOT_DIR}/firecracker" >/dev/null 2>&1 || true
+  sleep 1
+  pkill -KILL -f "${ROOT_DIR}/boxapi" >/dev/null 2>&1 || true
+  pkill -KILL -f "${ROOT_DIR}/boxproxy" >/dev/null 2>&1 || true
+  pkill -KILL -f "${ROOT_DIR}/boxlet" >/dev/null 2>&1 || true
+  pkill -KILL -f "${ROOT_DIR}/boxshim" >/dev/null 2>&1 || true
+  pkill -KILL -f "${ROOT_DIR}/firecracker" >/dev/null 2>&1 || true
+}
+
+cleanup_network() {
+  if ! command_exists ip; then
+    warn "ip command not found; skipping network namespace cleanup"
+    return
+  fi
+
+  log "removing NovitaBox network namespaces and veth links"
+  local ns
+  while read -r ns; do
+    [[ -n "${ns}" ]] || continue
+    ip netns pids "${ns}" 2>/dev/null | xargs -r kill -TERM >/dev/null 2>&1 || true
+    sleep 0.1
+    ip netns pids "${ns}" 2>/dev/null | xargs -r kill -KILL >/dev/null 2>&1 || true
+    ip netns del "${ns}" >/dev/null 2>&1 || true
+  done < <(ip netns list 2>/dev/null | awk '{print $1}' | grep '^nb-' || true)
+
+  local link
+  while read -r link; do
+    [[ -n "${link}" ]] || continue
+    ip link del "${link}" >/dev/null 2>&1 || true
+  done < <(ip -o link show 2>/dev/null | awk -F': ' '{print $2}' | cut -d@ -f1 | grep '^vh-' || true)
+}
+
+cleanup_sysctl() {
+  log "removing sysctl configuration"
+  rm -f /etc/sysctl.d/99-novitabox.conf
+  if command_exists sysctl; then
+    sysctl --system >/dev/null 2>&1 || true
+  fi
+}
+
+cleanup_dnsmasq() {
+  log "removing dnsmasq configuration"
+  rm -f /etc/dnsmasq.d/novitabox.conf
+  if command_exists systemctl && systemctl list-unit-files dnsmasq.service >/dev/null 2>&1; then
+    systemctl restart dnsmasq >/dev/null 2>&1 || true
+  fi
+}
+
+cleanup_resolved() {
+  log "removing systemd-resolved configuration"
+  rm -f /etc/systemd/resolved.conf.d/novitabox.conf
+  rmdir /etc/systemd/resolved.conf.d >/dev/null 2>&1 || true
+  if command_exists systemctl && systemctl list-unit-files systemd-resolved.service >/dev/null 2>&1; then
+    systemctl restart systemd-resolved >/dev/null 2>&1 || true
+  fi
+}
+
+cleanup_caddy() {
+  log "removing Caddy configuration written by installer"
+  if [[ -f /etc/caddy/Caddyfile ]] && grep -q "reverse_proxy .*8080" /etc/caddy/Caddyfile && grep -q "reverse_proxy .*8082" /etc/caddy/Caddyfile; then
+    rm -f /etc/caddy/Caddyfile
+  else
+    warn "leaving /etc/caddy/Caddyfile in place because it does not look installer-owned"
+  fi
+
+  rm -f /usr/local/share/ca-certificates/caddy-local.crt
+  if command_exists update-ca-certificates; then
+    update-ca-certificates >/dev/null 2>&1 || true
+  fi
+  if command_exists systemctl && systemctl list-unit-files caddy.service >/dev/null 2>&1; then
+    systemctl restart caddy >/dev/null 2>&1 || true
+  fi
+}
+
+remove_fstab_entry() {
+  if [[ ! -f /etc/fstab ]]; then
+    return
+  fi
+
+  log "removing fstab entry"
+  local tmp
+  tmp="$(mktemp)"
+  awk -v image="${IMAGE_PATH}" -v root="${ROOT_DIR}" '
+    !($1 == image && $2 == root && $3 == "btrfs") { print }
+  ' /etc/fstab >"${tmp}"
+  cat "${tmp}" >/etc/fstab
+  rm -f "${tmp}"
+}
+
+unmount_root() {
+  if mountpoint -q "${ROOT_DIR}"; then
+    log "unmounting ${ROOT_DIR}"
+    umount "${ROOT_DIR}" || {
+      warn "normal unmount failed; trying lazy unmount"
+      umount -l "${ROOT_DIR}" || warn "failed to unmount ${ROOT_DIR}"
+    }
+  fi
+}
+
+remove_data() {
+  if [[ "${KEEP_DATA}" == "1" ]]; then
+    log "KEEP_DATA=1; keeping ${ROOT_DIR} and ${IMAGE_PATH}"
+    return
+  fi
+
+  remove_fstab_entry
+  unmount_root
+
+  log "removing NovitaBox data"
+  rm -rf "${ROOT_DIR}"
+  rm -f "${IMAGE_PATH}"
+
+  local image_dir
+  image_dir="$(dirname "${IMAGE_PATH}")"
+  if [[ "${image_dir}" != "/" && "${image_dir}" != "." ]]; then
+    rmdir "${image_dir}" >/dev/null 2>&1 || true
+  fi
+}
+
+remove_packages_hint() {
+  if [[ "${KEEP_PACKAGES}" == "1" ]]; then
+    return
+  fi
+
+  log "KEEP_PACKAGES=0 requested; package removal is intentionally conservative"
+  if command_exists apt-get; then
+    apt-get remove -y dnsmasq caddy btrfs-progs >/dev/null 2>&1 || true
+  elif command_exists dnf; then
+    dnf remove -y dnsmasq caddy btrfs-progs >/dev/null 2>&1 || true
+  elif command_exists yum; then
+    yum remove -y dnsmasq caddy btrfs-progs >/dev/null 2>&1 || true
+  fi
+}
+
+print_summary() {
+  cat <<EOF
+
+NovitaBox has been uninstalled.
+
+Removed:
+  services and systemd units
+  network namespaces named nb-*
+  veth links named vh-*
+  sysctl/dnsmasq/resolved/Caddy installer config
+
+Data:
+  KEEP_DATA=${KEEP_DATA}
+  root:  ${ROOT_DIR}
+  image: ${IMAGE_PATH}
+
+EOF
+}
+
+main() {
+  need_root
+  confirm_destructive
+  stop_services
+  kill_leftover_processes
+  cleanup_network
+  cleanup_sysctl
+  cleanup_dnsmasq
+  cleanup_resolved
+  cleanup_caddy
+  remove_data
+  remove_packages_hint
+  print_summary
+}
+
+main "$@"


### PR DESCRIPTION
- scripts: add Lima-based macOS install and uninstall flows
- scripts: build Linux VM binaries and Darwin host binaries during macOS install
- scripts: download Ubuntu cloud image and runtime assets on macOS before VM setup
- scripts: configure Docker mirrors and restart Docker after daemon.json updates
- scripts: support macOS dnsmasq and Caddy setup for host-side DNS/proxy
- scripts: add cleanup for Lima VM, images, assets, resolver, dnsmasq, and Caddy config
- boxlet: avoid host eth0 veth conflicts by renaming namespace peer after netns move
- make: add darwin amd64 build target