### PR TITLE
fix: harden release installer downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,51 @@ SDK** to write your agent code once, then run it locally with NovitaBox or in No
 
 ## 🚀 Quick Start
 
+### Recommended: One-Command Install
+
+Install the latest release components without building from source:
+
+**Linux**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | RELEASE_VERSION=v0.0.2 sudo -E bash
+```
+
+**macOS with Lima**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | RELEASE_VERSION=v0.0.2 bash
+```
+
+The release installer detects your operating system and CPU architecture, downloads the matching prebuilt components,
+and runs the platform installer. On macOS it downloads both Darwin binaries for the host and Linux binaries for the Lima
+VM. Firecracker and the guest kernel are kept on the stable `v0.0.1` runtime assets by default.
+
+Linux installs configure local DNS and HTTPS proxy by default. On macOS, enable host DNS and proxy explicitly:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | \
+  RELEASE_VERSION=v0.0.2 ENABLE_MAC_DNS=1 ENABLE_MAC_PROXY=1 bash
+```
+
+After installation:
+
+```bash
+curl http://127.0.0.1:8080/health
+curl http://127.0.0.1:8082/healthz
+```
+
+If DNS/proxy is enabled:
+
+```bash
+curl -k https://novitabox.localhost/health
+curl -k https://test.novitabox.localhost/healthz
+```
+
+> Full installation options: see [Installation](docs/quick-start/install.md).
+
+### Build from Source Manually
+
 #### Prepare the filesystem
 
 NovitaBox requires a filesystem that supports reflink copies, such as XFS or Btrfs, to store templates, snapshots, and related runtime data.

--- a/docs/quick-start/install.md
+++ b/docs/quick-start/install.md
@@ -1,6 +1,75 @@
 # Installation
 
-This guide installs NovitaBox on one Linux host.
+This guide covers one-command release installs and source-based installs.
+
+## Recommended: Release Install
+
+The release installer downloads prebuilt NovitaBox components for the current operating system and architecture.
+
+### Linux
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | RELEASE_VERSION=v0.0.2 sudo -E bash
+```
+
+Linux defaults:
+
+```text
+ROOT_DIR=/data/novitabox
+IMAGE_PATH=/data/novitabox.img
+IMAGE_SIZE=50G
+DOMAIN=novitabox.localhost
+ENABLE_DNS=1
+ENABLE_CADDY=1
+```
+
+### macOS with Lima
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | RELEASE_VERSION=v0.0.2 bash
+```
+
+On macOS, the installer downloads:
+
+```text
+novitabox-darwin-<arch>.tar.gz  # host boxctl and tools
+novitabox-linux-<arch>.tar.gz   # services installed inside the Lima VM
+```
+
+Homebrew and Lima are installed automatically when missing. macOS host DNS and proxy are disabled by default; enable them with:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | \
+  RELEASE_VERSION=v0.0.2 ENABLE_MAC_DNS=1 ENABLE_MAC_PROXY=1 bash
+```
+
+### Runtime Assets
+
+`firecracker` and `vmlinux.bin` are downloaded from the stable runtime asset release by default:
+
+```text
+RUNTIME_ASSET_VERSION=v0.0.1
+```
+
+Override only when publishing new runtime assets:
+
+```bash
+RELEASE_VERSION=v0.0.2 RUNTIME_ASSET_VERSION=v0.0.3 scripts/install-release.sh
+```
+
+### Uninstall
+
+Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/uninstall-linux.sh | sudo -E FORCE=1 bash
+```
+
+macOS with Lima:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/uninstall-macos-lima.sh | FORCE=1 bash
+```
 
 ## Requirements
 
@@ -12,7 +81,7 @@ This guide installs NovitaBox on one Linux host.
 
 The installer uses Btrfs by default.
 
-## One-Command Install
+## Source Install
 
 From the repository root:
 

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -36,6 +36,7 @@ FIRECRACKER_URL="${FIRECRACKER_URL:-}"
 KERNEL_URL="${KERNEL_URL:-}"
 FIRECRACKER_PATH="${FIRECRACKER_PATH:-}"
 KERNEL_PATH="${KERNEL_PATH:-}"
+CURL_PROXY="${CURL_PROXY:-${https_proxy:-${HTTPS_PROXY:-${http_proxy:-${HTTP_PROXY:-}}}}}"
 
 COMMANDS=(boxapi boxctl boxd boxlet boxproxy boxshim)
 
@@ -69,6 +70,26 @@ need_no_spaces() {
 
 command_exists() {
   command -v "$1" >/dev/null 2>&1
+}
+
+curl_retry_all_errors_args=()
+if curl --help all 2>/dev/null | grep -q -- '--retry-all-errors'; then
+  curl_retry_all_errors_args=(--retry-all-errors)
+fi
+curl_proxy_args=()
+if [[ -n "${CURL_PROXY}" ]]; then
+  curl_proxy_args=(--proxy "${CURL_PROXY}")
+fi
+
+download_to_tmp() {
+  local url="$1"
+  local tmp="$2"
+
+  rm -f "${tmp}"
+  if ! curl -fL --http1.1 --retry 5 "${curl_retry_all_errors_args[@]}" "${curl_proxy_args[@]}" --retry-delay 2 -o "${tmp}" "${url}"; then
+    rm -f "${tmp}"
+    return 1
+  fi
 }
 
 trim_space() {
@@ -377,7 +398,9 @@ install_asset() {
   fi
 
   log "downloading ${name} from ${url}"
-  curl -fL "$url" -o "${dest}.tmp"
+  if ! download_to_tmp "$url" "${dest}.tmp"; then
+    die "download ${name} failed"
+  fi
   chmod "$mode" "${dest}.tmp"
   mv -f "${dest}.tmp" "$dest"
 }

--- a/scripts/install-macos-lima.sh
+++ b/scripts/install-macos-lima.sh
@@ -65,6 +65,7 @@ MAC_DNSMASQ_CONF="${MAC_DNSMASQ_CONF:-}"
 MAC_RESOLVER_DIR="${MAC_RESOLVER_DIR:-/etc/resolver}"
 MAC_CADDYFILE="${MAC_CADDYFILE:-}"
 MAC_CADDY_CA_PATH="${MAC_CADDY_CA_PATH:-${SOURCE_DIR}/assets/caddy-local-root.crt}"
+CURL_PROXY="${CURL_PROXY:-${https_proxy:-${HTTPS_PROXY:-${http_proxy:-${HTTP_PROXY:-}}}}}"
 
 log() {
   printf '[novitabox-macos] %s\n' "$*"
@@ -81,6 +82,26 @@ die() {
 
 command_exists() {
   command -v "$1" >/dev/null 2>&1
+}
+
+curl_retry_all_errors_args=()
+if curl --help all 2>/dev/null | grep -q -- '--retry-all-errors'; then
+  curl_retry_all_errors_args=(--retry-all-errors)
+fi
+curl_proxy_args=()
+if [[ -n "${CURL_PROXY}" ]]; then
+  curl_proxy_args=(--proxy "${CURL_PROXY}")
+fi
+
+download_to_tmp() {
+  local url="$1"
+  local tmp="$2"
+
+  rm -f "${tmp}"
+  if ! curl -fL --http1.1 --retry 5 "${curl_retry_all_errors_args[@]}" "${curl_proxy_args[@]}" --retry-delay 2 -o "${tmp}" "${url}"; then
+    rm -f "${tmp}"
+    return 1
+  fi
 }
 
 trim_space() {
@@ -408,7 +429,9 @@ download_asset_if_needed() {
 
   log "downloading ${name} from ${url}"
   mkdir -p "$(dirname "${path}")"
-  curl -fL "${url}" -o "${path}.tmp"
+  if ! download_to_tmp "${url}" "${path}.tmp"; then
+    die "download ${name} failed"
+  fi
   chmod "${mode}" "${path}.tmp"
   mv -f "${path}.tmp" "${path}"
 }
@@ -426,7 +449,9 @@ prepare_lima_image() {
     log "using existing Lima image ${LIMA_IMAGE_PATH}"
   else
     log "downloading Lima base image from ${LIMA_IMAGE_URL}"
-    curl -fL "${LIMA_IMAGE_URL}" -o "${LIMA_IMAGE_PATH}.tmp"
+    if ! download_to_tmp "${LIMA_IMAGE_URL}" "${LIMA_IMAGE_PATH}.tmp"; then
+      die "download Lima base image failed"
+    fi
     mv -f "${LIMA_IMAGE_PATH}.tmp" "${LIMA_IMAGE_PATH}"
   fi
 

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -40,6 +40,7 @@ fi
 FORCE_DOWNLOAD="${FORCE_DOWNLOAD:-0}"
 INSTALL_HOMEBREW="${INSTALL_HOMEBREW:-1}"
 INSTALL_LIMA="${INSTALL_LIMA:-1}"
+CURL_PROXY="${CURL_PROXY:-${https_proxy:-${HTTPS_PROXY:-${http_proxy:-${HTTP_PROXY:-}}}}}"
 
 COMMANDS=(boxapi boxctl boxd boxlet boxproxy boxshim)
 
@@ -90,13 +91,37 @@ need_tools() {
   fi
 }
 
+curl_retry_all_errors_args=()
+if curl --help all 2>/dev/null | grep -q -- '--retry-all-errors'; then
+  curl_retry_all_errors_args=(--retry-all-errors)
+fi
+curl_proxy_args=()
+if [[ -n "${CURL_PROXY}" ]]; then
+  curl_proxy_args=(--proxy "${CURL_PROXY}")
+fi
+
+download_to_tmp() {
+  local url="$1"
+  local tmp="$2"
+
+  rm -f "${tmp}"
+  if ! curl -fL --http1.1 --retry 5 "${curl_retry_all_errors_args[@]}" "${curl_proxy_args[@]}" --retry-delay 2 -o "${tmp}" "${url}"; then
+    rm -f "${tmp}"
+    return 1
+  fi
+}
+
 download_source_script() {
   local name="$1"
   local path="${SOURCE_DIR}/scripts/${name}"
   local url="${SOURCE_BASE_URL}/scripts/${name}"
+  local tmp="${path}.tmp"
 
   log "downloading ${url}"
-  curl -fL --retry 3 --retry-delay 2 -o "${path}" "${url}"
+  if ! download_to_tmp "${url}" "${tmp}"; then
+    die "download ${name} failed"
+  fi
+  mv -f "${tmp}" "${path}"
   chmod 0755 "${path}"
 }
 
@@ -191,8 +216,9 @@ download_archive() {
 
   log "downloading ${url}"
   tmp="${path}.tmp"
-  rm -f "${tmp}"
-  curl -fL --retry 3 --retry-delay 2 -o "${tmp}" "${url}"
+  if ! download_to_tmp "${url}" "${tmp}"; then
+    die "download ${name} failed"
+  fi
   mv "${tmp}" "${path}"
   printf '%s\n' "${path}"
 }
@@ -274,6 +300,9 @@ install_macos_lima() {
 main() {
   log "starting NovitaBox release installer ${RELEASE_VERSION}"
   log "runtime assets version ${RUNTIME_ASSET_VERSION}"
+  if [[ -n "${CURL_PROXY}" ]]; then
+    log "using curl proxy ${CURL_PROXY}"
+  fi
   need_tools
   ensure_source_layout
 


### PR DESCRIPTION
- install: add proxy-aware curl downloads with retries
- install: avoid using partial files after failed downloads
- docs: surface one-command install and uninstall commands