### PR TITLE
feat: add gVisor runtime support with GPU CDI integration

### DIFF
--- a/cmd/boxctl/main.go
+++ b/cmd/boxctl/main.go
@@ -77,6 +77,7 @@ func newSandboxCommand(apiAddr *string, proxyAddr *string) *cobra.Command {
 	var createImageID string
 	var createSnapshotID string
 	var createRuntimeType string
+	var createGPUCount uint32
 	createCmd := &cobra.Command{
 		Use:   "create [template_id]",
 		Short: "Create a sandbox",
@@ -98,6 +99,9 @@ func newSandboxCommand(apiAddr *string, proxyAddr *string) *cobra.Command {
 			if createSnapshotID != "" {
 				body["snapshot_id"] = createSnapshotID
 			}
+			if createGPUCount > 0 {
+				body["gpu"] = createGPUCount
+			}
 			if createRuntimeType != "" {
 				body["runtime_type"] = createRuntimeType
 			}
@@ -105,9 +109,10 @@ func newSandboxCommand(apiAddr *string, proxyAddr *string) *cobra.Command {
 		},
 	}
 	createCmd.Flags().StringVar(&createTemplateID, "template", "", "template id")
+	createCmd.Flags().StringVar(&createRuntimeType, "runtime", "", "runtime type")
 	createCmd.Flags().StringVar(&createImageID, "image", "", "image id")
 	createCmd.Flags().StringVar(&createSnapshotID, "snapshot", "", "snapshot id")
-	createCmd.Flags().StringVar(&createRuntimeType, "runtime", "", "runtime type")
+	createCmd.Flags().Uint32Var(&createGPUCount, "gpu", 0, "GPU count")
 
 	cmd.AddCommand(createCmd)
 	cmd.AddCommand(listAPICommand(apiAddr, "list", "List sandboxes", "/v1/sandboxes"))

--- a/cmd/boxlet/main.go
+++ b/cmd/boxlet/main.go
@@ -20,6 +20,7 @@ func main() {
 		RootDir:               defaults.RootDir,
 		Addr:                  defaults.Boxlet.Addr,
 		RuntimeDriver:         defaults.Boxshim.RuntimeDriver,
+		RunscBinaryPath:       defaults.GVisor.RunscBinaryPath,
 		TemplateSnapshotWait:  defaults.Template.SnapshotWaitSecs,
 		TemplateAgentWait:     defaults.Template.AgentWaitSecs,
 		TemplateBoxdGuestPath: defaults.Template.BoxdGuestPath,
@@ -49,6 +50,7 @@ func main() {
 	cmd.Flags().IntVar(&opts.Port, "port", 0, "boxlet listen port, overrides the port in --addr")
 	cmd.Flags().StringVar(&opts.DBPath, "db-path", opts.DBPath, "SQLite database path, defaults to $root/db/novitabox.db")
 	cmd.Flags().StringVar(&opts.RuntimeDriver, "runtime-driver", opts.RuntimeDriver, "runtime driver passed to boxshim, defaults to firecracker")
+	cmd.Flags().StringVar(&opts.RunscBinaryPath, "runsc-bin", opts.RunscBinaryPath, "runsc binary path used by the gVisor runtime, defaults to $root/runsc")
 	cmd.Flags().StringVar(&opts.TemplateKernelPath, "template-kernel", opts.TemplateKernelPath, "kernel image used when building template snapshots, defaults to $root/vmlinux.bin")
 	cmd.Flags().Uint32Var(&opts.TemplateSnapshotWait, "template-snapshot-wait", opts.TemplateSnapshotWait, "seconds to wait before exporting template snapshot")
 	cmd.Flags().StringVar(&opts.TemplateAgentHealth, "template-agent-health", opts.TemplateAgentHealth, "boxd health URL used before exporting template snapshot")

--- a/cmd/boxshim/main.go
+++ b/cmd/boxshim/main.go
@@ -17,9 +17,10 @@ import (
 func main() {
 	defaults := config.Default()
 	opts := config.BoxshimOptions{
-		RootDir:       defaults.RootDir,
-		SocketPath:    defaults.Boxshim.SocketPath,
-		RuntimeDriver: defaults.Boxshim.RuntimeDriver,
+		RootDir:         defaults.RootDir,
+		SocketPath:      defaults.Boxshim.SocketPath,
+		RuntimeDriver:   defaults.Boxshim.RuntimeDriver,
+		RunscBinaryPath: defaults.GVisor.RunscBinaryPath,
 	}
 
 	cmd := &cobra.Command{
@@ -31,8 +32,9 @@ func main() {
 	}
 	cmd.Flags().StringVar(&opts.RootDir, "root", opts.RootDir, "NovitaBox root directory")
 	cmd.Flags().StringVar(&opts.SocketPath, "socket", opts.SocketPath, "boxshim Unix socket path")
-	cmd.Flags().StringVar(&opts.RuntimeDriver, "runtime-driver", opts.RuntimeDriver, "runtime driver: stub or firecracker")
+	cmd.Flags().StringVar(&opts.RuntimeDriver, "runtime-driver", opts.RuntimeDriver, "runtime driver: stub, firecracker, or gvisor")
 	cmd.Flags().StringVar(&opts.FirecrackerBinaryPath, "firecracker-bin", opts.FirecrackerBinaryPath, "Firecracker binary path, defaults to $root/firecracker")
+	cmd.Flags().StringVar(&opts.RunscBinaryPath, "runsc-bin", opts.RunscBinaryPath, "runsc binary path used by the gVisor runtime, defaults to $root/runsc")
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "boxshim: %v\n", err)

--- a/internal/boxapi/handler/runtime.go
+++ b/internal/boxapi/handler/runtime.go
@@ -42,6 +42,7 @@ func (h *Handler) ListRuntimes(c *gin.Context) {
 	response.JSON(c, http.StatusOK, listRuntimesResponse{
 		Runtimes: []runtimeSummaryResponse{
 			{RuntimeType: "firecracker", Capabilities: firecrackerRuntimeCapabilities()},
+			{RuntimeType: "gvisor", Capabilities: gvisorRuntimeCapabilities()},
 			{RuntimeType: "cloud-hypervisor", Capabilities: cloudHypervisorRuntimeCapabilities()},
 		},
 	})
@@ -76,6 +77,8 @@ func runtimeCapabilities(runtimeType string) (runtimeCapabilitiesResponse, bool)
 		return firecrackerRuntimeCapabilities(), true
 	case "cloud-hypervisor":
 		return cloudHypervisorRuntimeCapabilities(), true
+	case "gvisor":
+		return gvisorRuntimeCapabilities(), true
 	default:
 		return runtimeCapabilitiesResponse{}, false
 	}
@@ -87,8 +90,8 @@ func normalizeRuntimeName(runtimeType string) string {
 		return "firecracker"
 	case "runtime-type-cloud-hypervisor", "cloud-hypervisor":
 		return "cloud-hypervisor"
-	case "runtime-type-container", "container":
-		return "container"
+	case "runtime-type-container", "container", "gvisor":
+		return "gvisor"
 	default:
 		return ""
 	}
@@ -118,4 +121,22 @@ func cloudHypervisorRuntimeCapabilities() runtimeCapabilitiesResponse {
 	caps.HotplugDisk = true
 	caps.HotplugNetwork = true
 	return caps
+}
+
+func gvisorRuntimeCapabilities() runtimeCapabilitiesResponse {
+	return runtimeCapabilitiesResponse{
+		StartFromImage:    true,
+		StartFromTemplate: true,
+		StartFromSnapshot: false,
+		Pause:             false,
+		Resume:            false,
+		FullSnapshot:      false,
+		DiffSnapshot:      false,
+		GPU:               true,
+		Vsock:             false,
+		TapNetwork:        false,
+		GracefulShutdown:  true,
+		SerialConsole:     false,
+		Jailer:            false,
+	}
 }

--- a/internal/boxapi/handler/sandbox.go
+++ b/internal/boxapi/handler/sandbox.go
@@ -30,6 +30,7 @@ type createSandboxRequest struct {
 	MCP                 map[string]any    `json:"mcp,omitempty"`
 	Metadata            map[string]string `json:"metadata,omitempty"`
 	Network             map[string]any    `json:"network,omitempty"`
+	GPU                 *uint32           `json:"gpu,omitempty"`
 	Secure              *bool             `json:"secure,omitempty"`
 	TemplateID          string            `json:"templateID"`
 	Timeout             *int32            `json:"timeout,omitempty"`
@@ -140,6 +141,12 @@ func (h *Handler) CreateSandbox(c *gin.Context) {
 			RuntimeSpec: &novitaboxv1.RuntimeSpec{
 				SandboxId:   sandboxID,
 				RuntimeType: runtimeTypeToProto(runtimeType),
+				Machine: func() *novitaboxv1.MachineSpec {
+					if req.GPU == nil {
+						return nil
+					}
+					return &novitaboxv1.MachineSpec{Gpu: *req.GPU}
+				}(),
 			},
 		})
 		if err != nil {
@@ -519,7 +526,7 @@ func runtimeTypeToProto(runtimeType string) novitaboxv1.RuntimeType {
 	switch strings.ToLower(runtimeType) {
 	case "cloud-hypervisor", "cloud_hypervisor":
 		return novitaboxv1.RuntimeType_RUNTIME_TYPE_CLOUD_HYPERVISOR
-	case "container":
+	case "container", "gvisor":
 		return novitaboxv1.RuntimeType_RUNTIME_TYPE_CONTAINER
 	default:
 		return novitaboxv1.RuntimeType_RUNTIME_TYPE_FIRECRACKER
@@ -856,8 +863,8 @@ func normalizeRuntimeType(runtimeType string) string {
 	switch strings.ToLower(runtimeType) {
 	case "runtime_type_cloud_hypervisor", "cloud-hypervisor", "cloud_hypervisor":
 		return "cloud-hypervisor"
-	case "runtime_type_container", "container":
-		return "container"
+	case "runtime_type_container", "container", "gvisor":
+		return "gvisor"
 	default:
 		return "firecracker"
 	}
@@ -868,7 +875,7 @@ func protoRuntimeType(runtimeType novitaboxv1.RuntimeType) string {
 	case novitaboxv1.RuntimeType_RUNTIME_TYPE_CLOUD_HYPERVISOR:
 		return "cloud-hypervisor"
 	case novitaboxv1.RuntimeType_RUNTIME_TYPE_CONTAINER:
-		return "container"
+		return "gvisor"
 	default:
 		return "firecracker"
 	}

--- a/internal/boxapi/handler/sandbox_test.go
+++ b/internal/boxapi/handler/sandbox_test.go
@@ -1,0 +1,104 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/novitalabs/NovitaBox/internal/config"
+	"github.com/novitalabs/NovitaBox/internal/log"
+	novitaboxv1 "github.com/novitalabs/NovitaBox/internal/pb/novitabox/v1"
+	"github.com/novitalabs/NovitaBox/internal/storage/store/sqlite"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func TestCreateSandboxForwardsGPUCount(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+
+	root := t.TempDir()
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.Storage.DBPath = filepath.Join(root, "db", "novitabox.db")
+
+	st, err := sqlite.Open(context.Background(), cfg.Storage.DBPath)
+	if err != nil {
+		t.Fatalf("open sqlite store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := st.Close(); err != nil {
+			t.Fatalf("close sqlite store: %v", err)
+		}
+	})
+
+	client := &fakeSandboxClient{}
+	h := New(cfg, log.NewNop(), st, client, nil)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPost, "/v1/sandboxes", strings.NewReader(`{"templateID":"tpl-test","runtime_type":"gvisor","gpu":2}`))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	h.CreateSandbox(c)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	if client.createReq == nil {
+		t.Fatal("expected CreateSandbox to be called")
+	}
+	if got := client.createReq.GetRuntimeSpec().GetMachine().GetGpu(); got != 2 {
+		t.Fatalf("runtimeSpec.machine.gpu = %d, want 2", got)
+	}
+}
+
+type fakeSandboxClient struct {
+	createReq *novitaboxv1.CreateSandboxRequest
+}
+
+func (f *fakeSandboxClient) CreateSandbox(_ context.Context, in *novitaboxv1.CreateSandboxRequest, _ ...grpc.CallOption) (*novitaboxv1.SandboxInfo, error) {
+	f.createReq = in
+	return &novitaboxv1.SandboxInfo{
+		SandboxId:   in.GetSandboxId(),
+		TemplateId:  in.GetTemplateId(),
+		RuntimeType: in.GetRuntimeType(),
+	}, nil
+}
+
+func (f *fakeSandboxClient) PauseSandbox(context.Context, *novitaboxv1.PauseSandboxRequest, ...grpc.CallOption) (*novitaboxv1.SnapshotInfo, error) {
+	return nil, nil
+}
+
+func (f *fakeSandboxClient) ResumeSandbox(context.Context, *novitaboxv1.ResumeSandboxRequest, ...grpc.CallOption) (*novitaboxv1.SandboxInfo, error) {
+	return nil, nil
+}
+
+func (f *fakeSandboxClient) KillSandbox(context.Context, *novitaboxv1.KillSandboxRequest, ...grpc.CallOption) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (f *fakeSandboxClient) StartSandbox(context.Context, *novitaboxv1.StartSandboxRequest, ...grpc.CallOption) (*novitaboxv1.SandboxInfo, error) {
+	return nil, nil
+}
+
+func (f *fakeSandboxClient) StopSandbox(context.Context, *novitaboxv1.StopSandboxRequest, ...grpc.CallOption) (*novitaboxv1.SandboxInfo, error) {
+	return nil, nil
+}
+
+func (f *fakeSandboxClient) RebootSandbox(context.Context, *novitaboxv1.RebootSandboxRequest, ...grpc.CallOption) (*novitaboxv1.SandboxInfo, error) {
+	return nil, nil
+}
+
+func (f *fakeSandboxClient) GetSandbox(context.Context, *novitaboxv1.GetSandboxRequest, ...grpc.CallOption) (*novitaboxv1.SandboxInfo, error) {
+	return nil, nil
+}
+
+func (f *fakeSandboxClient) ListSandboxes(context.Context, *novitaboxv1.ListSandboxesRequest, ...grpc.CallOption) (*novitaboxv1.ListSandboxesResponse, error) {
+	return nil, nil
+}

--- a/internal/boxapi/handler/template.go
+++ b/internal/boxapi/handler/template.go
@@ -22,14 +22,15 @@ import (
 )
 
 type createTemplateV3Request struct {
-	Alias      *string           `json:"alias,omitempty"`
-	CPUCount   *int32            `json:"cpuCount,omitempty"`
-	MemoryMB   *int32            `json:"memoryMB,omitempty"`
-	Metadata   map[string]string `json:"metadata,omitempty"`
-	Name       *string           `json:"name,omitempty"`
-	Tags       *[]string         `json:"tags,omitempty"`
-	TeamID     *string           `json:"teamID,omitempty"`
-	TemplateID *string           `json:"templateID,omitempty"`
+	Alias       *string           `json:"alias,omitempty"`
+	CPUCount    *int32            `json:"cpuCount,omitempty"`
+	MemoryMB    *int32            `json:"memoryMB,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+	Name        *string           `json:"name,omitempty"`
+	Tags        *[]string         `json:"tags,omitempty"`
+	TeamID      *string           `json:"teamID,omitempty"`
+	TemplateID  *string           `json:"templateID,omitempty"`
+	RuntimeType *string           `json:"runtimeType,omitempty"`
 }
 
 type startTemplateBuildV2Request struct {
@@ -174,6 +175,10 @@ func (h *Handler) CreateTemplateV3(c *gin.Context) {
 
 	name, tags := splitTemplateName(input)
 	tags = append(tags, derefStringSlice(req.Tags)...)
+	runtimeType := normalizeRuntimeType(derefString(req.RuntimeType))
+	if runtimeType == "" {
+		runtimeType = "firecracker"
+	}
 
 	templateID := strings.TrimSpace(derefString(req.TemplateID))
 	if templateID == "" {
@@ -189,10 +194,14 @@ func (h *Handler) CreateTemplateV3(c *gin.Context) {
 		return
 	}
 
-	record := newTemplateRecord(h.cfg.RootDir, templateID)
+	record := newTemplateRecord(h.cfg.RootDir, templateID, runtimeType)
 	record.Aliases = []string{name}
 	record.Names = []string{name}
 	record.Metadata = req.Metadata
+	if record.Metadata == nil {
+		record.Metadata = map[string]string{}
+	}
+	record.Metadata["runtimeType"] = runtimeType
 	record.CPUCount = defaultTemplateCPUCount
 	if req.CPUCount != nil && *req.CPUCount > 0 {
 		record.CPUCount = *req.CPUCount
@@ -225,7 +234,7 @@ func (h *Handler) CreateTemplateV3(c *gin.Context) {
 	response.JSON(c, http.StatusAccepted, templateV3Response{
 		Aliases:    []string{name},
 		BuildID:    buildID,
-		Metadata:   req.Metadata,
+		Metadata:   record.Metadata,
 		Names:      []string{name},
 		Public:     false,
 		Tags:       deduplicateStrings(tags),
@@ -252,7 +261,8 @@ func (h *Handler) StartTemplateBuildV2(c *gin.Context) {
 		return
 	}
 
-	if _, err := h.store.GetTemplateBuild(c.Request.Context(), templateID, buildID); err != nil {
+	record, err := h.store.GetTemplateBuild(c.Request.Context(), templateID, buildID)
+	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			response.Error(c, response.ErrNotFound("template build not found"))
 			return
@@ -261,18 +271,22 @@ func (h *Handler) StartTemplateBuildV2(c *gin.Context) {
 		response.Error(c, response.ErrInternal("load template build failed"))
 		return
 	}
-
+	switch record.Status {
+	case store.TemplateBuildStatusWaiting:
+		// no-op, initial state
+	case store.TemplateBuildStatusError:
+		// retryable state, handled below
+	default:
+		response.Error(c, response.ErrBadRequest("build is not retryable"))
+		return
+	}
 	if err := h.store.UpdateTemplateBuildStatus(
 		c.Request.Context(),
 		templateID,
 		buildID,
-		store.TemplateBuildStatusWaiting,
+		record.Status,
 		store.TemplateBuildStatusBuilding,
 	); err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			response.Error(c, response.ErrBadRequest("build is not in waiting state"))
-			return
-		}
 		h.logger.Error("start template build failed", "template_id", templateID, "build_id", buildID, "error", err)
 		response.Error(c, response.ErrInternal("start template build failed"))
 		return
@@ -882,8 +896,15 @@ func deduplicateStrings(values []string) []string {
 	return result
 }
 
-func newTemplateRecord(rootDir string, templateID string) store.TemplateRecord {
+func newTemplateRecord(rootDir string, templateID string, runtimeType string) store.TemplateRecord {
 	dir := layout.New(rootDir).TemplateDir(templateID)
+
+	if strings.EqualFold(runtimeType, "gvisor") || strings.EqualFold(runtimeType, "container") {
+		return store.TemplateRecord{
+			ID:         templateID,
+			RootfsPath: filepath.Join(dir, "rootfs"),
+		}
+	}
 
 	return store.TemplateRecord{
 		ID:           templateID,

--- a/internal/boxapi/server/router_test.go
+++ b/internal/boxapi/server/router_test.go
@@ -58,8 +58,8 @@ func TestRouterListRuntimes(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if len(got.Runtimes) == 0 || got.Runtimes[0].RuntimeType != "firecracker" {
-		t.Fatalf("runtimes = %#v, want firecracker first", got.Runtimes)
+	if len(got.Runtimes) < 3 || got.Runtimes[0].RuntimeType != "firecracker" || got.Runtimes[1].RuntimeType != "gvisor" {
+		t.Fatalf("runtimes = %#v, want firecracker first and gvisor second", got.Runtimes)
 	}
 }
 
@@ -574,6 +574,42 @@ func TestRouterStartTemplateBuildV2(t *testing.T) {
 	}
 	if statusGot.LogEntries == nil || statusGot.Logs == nil {
 		t.Fatalf("status response should include empty logEntries/logs arrays: %#v", statusGot)
+	}
+
+	if err := s.store.UpdateTemplateBuildStatus(t.Context(), created.TemplateID, created.BuildID, store.TemplateBuildStatusReady, store.TemplateBuildStatusError); err != nil {
+		t.Fatalf("mark build error: %v", err)
+	}
+
+	retryReq := httptest.NewRequest(
+		http.MethodPost,
+		"/v2/templates/"+created.TemplateID+"/builds/"+created.BuildID,
+		bytes.NewBufferString(`{"fromImage":"ubuntu:22.04"}`),
+	)
+	retryReq.Header.Set("Content-Type", "application/json")
+	retryRec := httptest.NewRecorder()
+	s.router().ServeHTTP(retryRec, retryReq)
+	if retryRec.Code != http.StatusAccepted {
+		t.Fatalf("retry expected status %d, got %d body=%s", http.StatusAccepted, retryRec.Code, retryRec.Body.String())
+	}
+
+	retryStatusReq := httptest.NewRequest(
+		http.MethodGet,
+		"/templates/"+created.TemplateID+"/builds/"+created.BuildID+"/status?logsOffset=0&limit=100",
+		nil,
+	)
+	retryStatusRec := httptest.NewRecorder()
+	s.router().ServeHTTP(retryStatusRec, retryStatusReq)
+	if retryStatusRec.Code != http.StatusOK {
+		t.Fatalf("retry status expected status %d, got %d body=%s", http.StatusOK, retryStatusRec.Code, retryStatusRec.Body.String())
+	}
+	var retryStatusGot struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(retryStatusRec.Body.Bytes(), &retryStatusGot); err != nil {
+		t.Fatalf("decode retry status response: %v", err)
+	}
+	if retryStatusGot.Status != "ready" {
+		t.Fatalf("retry build status = %q, want ready", retryStatusGot.Status)
 	}
 }
 

--- a/internal/boxlet/server/artifact_test.go
+++ b/internal/boxlet/server/artifact_test.go
@@ -102,6 +102,137 @@ func TestCloneOrCopyFileCopiesContent(t *testing.T) {
 	assertFileContent(t, dest, "content")
 }
 
+func TestCopyFilePreservesMode(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	dest := filepath.Join(root, "nested", "dest")
+	if err := os.WriteFile(source, []byte("content"), 0o755); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.Chmod(source, 0o755); err != nil {
+		t.Fatalf("chmod source: %v", err)
+	}
+
+	if err := copyFile(source, dest); err != nil {
+		t.Fatalf("copyFile() error = %v", err)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat dest: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Fatalf("dest mode = %o, want 755", got)
+	}
+}
+
+func TestCopyDirPreservesMode(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	dest := filepath.Join(root, "nested", "dest")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.Chmod(source, 0o1777); err != nil {
+		t.Fatalf("chmod source: %v", err)
+	}
+
+	if err := copyDir(source, dest); err != nil {
+		t.Fatalf("copyDir() error = %v", err)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat dest: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o777 {
+		t.Fatalf("dest mode = %o, want 777", got)
+	}
+}
+
+func TestInjectDomesticAptSourcesRewritesUpstreamMirrors(t *testing.T) {
+	root := t.TempDir()
+	aptDir := filepath.Join(root, "etc", "apt")
+	if err := os.MkdirAll(filepath.Join(aptDir, "sources.list.d"), 0o755); err != nil {
+		t.Fatalf("mkdir apt dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(aptDir, "sources.list"), []byte("deb http://archive.ubuntu.com/ubuntu jammy main restricted\n"), 0o644); err != nil {
+		t.Fatalf("write sources.list: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(aptDir, "sources.list.d", "security.list"), []byte("deb http://security.ubuntu.com/ubuntu jammy-security main restricted\n"), 0o644); err != nil {
+		t.Fatalf("write security.list: %v", err)
+	}
+
+	if err := injectDomesticAptSources(root); err != nil {
+		t.Fatalf("injectDomesticAptSources() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(aptDir, "sources.list"))
+	if err != nil {
+		t.Fatalf("read sources.list: %v", err)
+	}
+	if got := string(data); !strings.Contains(got, "http://mirrors.aliyun.com/ubuntu") {
+		t.Fatalf("rewritten sources.list = %q, want aliyun mirror", got)
+	}
+	if strings.Contains(string(data), "archive.ubuntu.com") {
+		t.Fatalf("rewritten sources.list still contains upstream mirror: %q", string(data))
+	}
+
+	data, err = os.ReadFile(filepath.Join(aptDir, "sources.list.d", "security.list"))
+	if err != nil {
+		t.Fatalf("read security.list: %v", err)
+	}
+	if got := string(data); !strings.Contains(got, "http://mirrors.aliyun.com/ubuntu") {
+		t.Fatalf("rewritten security.list = %q, want aliyun mirror", got)
+	}
+}
+
+func TestTemplateHostsContentIncludesMirrorEntries(t *testing.T) {
+	content := templateHostsContentWithResolver(func(host string) string {
+		switch host {
+		case "mirrors.aliyun.com":
+			return "198.18.0.16"
+		case "archive.ubuntu.com":
+			return "198.18.0.34"
+		case "security.ubuntu.com":
+			return "198.18.0.15"
+		default:
+			return ""
+		}
+	})
+	for _, want := range []string{
+		"127.0.0.1 localhost",
+		"198.18.0.16 mirrors.aliyun.com",
+		"198.18.0.34 archive.ubuntu.com",
+		"198.18.0.15 security.ubuntu.com",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("template hosts content missing %q: %s", want, content)
+		}
+	}
+}
+
+func TestCloneOrCopyFilePreservesMode(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	dest := filepath.Join(root, "nested", "dest")
+	if err := os.WriteFile(source, []byte("content"), 0o755); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.Chmod(source, 0o755); err != nil {
+		t.Fatalf("chmod source: %v", err)
+	}
+
+	if err := cloneOrCopyFile(source, dest); err != nil {
+		t.Fatalf("cloneOrCopyFile() error = %v", err)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat dest: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Fatalf("dest mode = %o, want 755", got)
+	}
+}
+
 func TestInternalSandboxNetworkSpecUsesLowestFreeSlot(t *testing.T) {
 	root := t.TempDir()
 	st, err := sqlite.Open(context.Background(), filepath.Join(root, "novitabox.db"))
@@ -133,6 +264,63 @@ func TestInternalSandboxNetworkSpecUsesLowestFreeSlot(t *testing.T) {
 	}
 	if spec.GetHostAccessIp() != "10.11.0.2" {
 		t.Fatalf("host access ip = %q, want 10.11.0.2", spec.GetHostAccessIp())
+	}
+}
+
+func TestMarkUsedNetworkSlotsFromRouteOutput(t *testing.T) {
+	used := map[uint32]struct{}{3: {}}
+	markUsedNetworkSlotsFromRouteOutput("10.11.0.0/16", `
+default via 192.168.70.1 dev ens18
+10.11.0.1 via 10.12.0.3 dev vh-nb-aaaa
+10.11.0.2/32 via 10.12.0.5 dev vh-nb-bbbb
+10.12.0.2/31 dev vh-nb-aaaa proto kernel scope link src 10.12.0.2
+`, used)
+
+	for _, slot := range []uint32{1, 2, 3} {
+		if _, ok := used[slot]; !ok {
+			t.Fatalf("slot %d was not marked used", slot)
+		}
+	}
+	if _, ok := used[4]; ok {
+		t.Fatalf("slot 4 was unexpectedly marked used")
+	}
+}
+
+func TestTemplateBuildAgentURLUsesRuntimeNetworkHost(t *testing.T) {
+	cfg := config.Default()
+	networkSpec, err := newSandboxNetworkManager(cfg).SpecForSlot("template-build-tpl-test", 1)
+	if err != nil {
+		t.Fatalf("SpecForSlot() error = %v", err)
+	}
+
+	firecrackerURL, err := templateBuildAgentURL(cfg, "template-build-tpl-test", networkSpec, "firecracker")
+	if err != nil {
+		t.Fatalf("templateBuildAgentURL(firecracker) error = %v", err)
+	}
+	if !strings.Contains(firecrackerURL.health, "10.11.0.1:49983") {
+		t.Fatalf("firecracker health URL = %q, want host access ip", firecrackerURL.health)
+	}
+
+	gvisorURL, err := templateBuildAgentURL(cfg, "template-build-tpl-test", networkSpec, "gvisor")
+	if err != nil {
+		t.Fatalf("templateBuildAgentURL(gvisor) error = %v", err)
+	}
+	if !strings.Contains(gvisorURL.health, "10.11.0.1:49983") {
+		t.Fatalf("gvisor health URL = %q, want host access ip", gvisorURL.health)
+	}
+}
+
+func TestTemplateBuildAgentURLFallsBackToLocalhostWithoutNetworkSpec(t *testing.T) {
+	cfg := config.Default()
+	urls, err := templateBuildAgentURL(cfg, "template-build-tpl-test", nil, "gvisor")
+	if err != nil {
+		t.Fatalf("templateBuildAgentURL() error = %v", err)
+	}
+	if urls.health != "http://127.0.0.1:49983/healthz" {
+		t.Fatalf("health URL = %q, want localhost fallback", urls.health)
+	}
+	if urls.exec != "http://127.0.0.1:49983/exec" {
+		t.Fatalf("exec URL = %q, want localhost fallback", urls.exec)
 	}
 }
 
@@ -207,6 +395,44 @@ func TestArtifactServiceTemplateCRUD(t *testing.T) {
 		t.Fatalf("DeleteTemplate() error = %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(root, "templates", "tpl-crud")); !os.IsNotExist(err) {
+		t.Fatalf("template dir stat error = %v, want not exist", err)
+	}
+}
+
+func TestArtifactServiceDeleteTemplateRemovesDirectoryRootfsTemplateDir(t *testing.T) {
+	root := t.TempDir()
+
+	st, err := sqlite.Open(context.Background(), filepath.Join(root, "novitabox.db"))
+	if err != nil {
+		t.Fatalf("open sqlite store: %v", err)
+	}
+	defer st.Close()
+
+	templateDir := filepath.Join(root, "templates", "tpl-gvisor")
+	rootfsDir := filepath.Join(templateDir, "rootfs")
+	if err := os.MkdirAll(rootfsDir, 0o755); err != nil {
+		t.Fatalf("create rootfs dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootfsDir, "marker"), []byte("ok"), 0o644); err != nil {
+		t.Fatalf("write rootfs marker: %v", err)
+	}
+	if err := st.CreateTemplate(context.Background(), store.TemplateRecord{
+		ID:         "tpl-gvisor",
+		RootfsPath: rootfsDir,
+		Metadata: map[string]string{
+			"runtimeType": "gvisor",
+		},
+	}); err != nil {
+		t.Fatalf("create template record: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	svc := newArtifactService(cfg, log.NewNop(), st)
+	if _, err := svc.DeleteTemplate(context.Background(), &novitaboxv1.DeleteTemplateRequest{TemplateId: "tpl-gvisor"}); err != nil {
+		t.Fatalf("DeleteTemplate() error = %v", err)
+	}
+	if _, err := os.Stat(templateDir); !os.IsNotExist(err) {
 		t.Fatalf("template dir stat error = %v, want not exist", err)
 	}
 }
@@ -378,6 +604,32 @@ func TestWithWritableTemplateRootfsRestoresOriginalAndExportsWorkCopy(t *testing
 	}
 	if string(exported) != "flushed" {
 		t.Fatalf("exported rootfs = %q, want flushed", string(exported))
+	}
+}
+
+func TestCloneOrCopyPathPreservesSymlink(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	dst := filepath.Join(root, "dst")
+	if err := os.MkdirAll(filepath.Join(src, "usr", "bin"), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "usr", "bin", "sh"), []byte("shell"), 0o755); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.Symlink("usr/bin", filepath.Join(src, "bin")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	if err := cloneOrCopyPath(src, dst); err != nil {
+		t.Fatalf("cloneOrCopyPath() error = %v", err)
+	}
+	target, err := os.Readlink(filepath.Join(dst, "bin"))
+	if err != nil {
+		t.Fatalf("read copied symlink: %v", err)
+	}
+	if target != "usr/bin" {
+		t.Fatalf("symlink target = %q, want usr/bin", target)
 	}
 }
 
@@ -570,6 +822,36 @@ func TestTemplateBoxdInitScript(t *testing.T) {
 	}
 	if strings.Contains(script, "exec /sbin/init") || strings.Contains(script, "exec /bin/sh") {
 		t.Fatalf("init script should keep boxd as PID 1: %s", script)
+	}
+}
+
+func TestHasUsableNameserver(t *testing.T) {
+	if hasUsableNameserver([]byte("nameserver 127.0.0.53\noptions edns0 trust-ad\n")) {
+		t.Fatalf("stub resolv.conf should not be treated as usable")
+	}
+	if !hasUsableNameserver([]byte("nameserver 10.0.0.1\nsearch local\n")) {
+		t.Fatalf("real resolv.conf should be treated as usable")
+	}
+}
+
+func TestWriteTemplateResolvConfUsesFixedResolver(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "etc", "resolv.conf")
+
+	if err := writeTemplateResolvConf(path, true); err != nil {
+		t.Fatalf("writeTemplateResolvConf() error = %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read resolv.conf: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "nameserver 114.114.114.114") {
+		t.Fatalf("resolv.conf = %q, want fixed resolver", got)
+	}
+	if strings.Contains(got, "1.1.1.1") || strings.Contains(got, "8.8.8.8") {
+		t.Fatalf("resolv.conf = %q, want no fallback resolvers", got)
 	}
 }
 

--- a/internal/boxlet/server/network.go
+++ b/internal/boxlet/server/network.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"os/exec"
@@ -105,7 +106,7 @@ func (m sandboxNetworkManager) MaxSlots() (uint32, error) {
 	return vethSlots, nil
 }
 
-func (m sandboxNetworkManager) Ensure(ctx context.Context, spec *novitaboxv1.NetworkSpec) error {
+func (m sandboxNetworkManager) Prepare(ctx context.Context, runtimeType novitaboxv1.RuntimeType, spec *novitaboxv1.NetworkSpec) error {
 	if spec == nil || spec.GetNamespaceName() == "" {
 		return nil
 	}
@@ -128,7 +129,7 @@ func (m sandboxNetworkManager) Ensure(ctx context.Context, spec *novitaboxv1.Net
 	_ = runCommand(ctx, "ip", "link", "del", hostVeth)
 	_ = runCommand(ctx, "ip", "link", "del", nsPeerVeth)
 	_ = runCommand(ctx, "ip", "netns", "exec", spec.GetNamespaceName(), "ip", "link", "del", nsVeth)
-
+	_ = runCommand(ctx, "ip", "netns", "exec", spec.GetNamespaceName(), "ip", "link", "del", spec.GetTapName())
 	if err := runCommand(ctx, "ip", "link", "add", hostVeth, "type", "veth", "peer", "name", nsPeerVeth); err != nil {
 		return fmt.Errorf("create veth pair: %w", err)
 	}
@@ -157,24 +158,24 @@ func (m sandboxNetworkManager) Ensure(ctx context.Context, spec *novitaboxv1.Net
 		return fmt.Errorf("enable namespace ip forwarding: %w", err)
 	}
 
-	if err := runCommand(ctx, "ip", "netns", "exec", spec.GetNamespaceName(), "ip", "tuntap", "add", "dev", spec.GetTapName(), "mode", "tap"); err != nil && !commandOutputContains(err, "File exists") {
-		return fmt.Errorf("create tap %s: %w", spec.GetTapName(), err)
-	}
-	gatewayCIDR := spec.GetGatewayIp() + "/30"
-	if err := runCommand(ctx, "ip", "netns", "exec", spec.GetNamespaceName(), "ip", "addr", "replace", gatewayCIDR, "dev", spec.GetTapName()); err != nil {
-		return fmt.Errorf("configure tap gateway: %w", err)
-	}
-	if err := runCommand(ctx, "ip", "netns", "exec", spec.GetNamespaceName(), "ip", "link", "set", spec.GetTapName(), "up"); err != nil {
-		return fmt.Errorf("set tap up: %w", err)
-	}
 	if err := runCommand(ctx, "ip", "netns", "exec", spec.GetNamespaceName(), "ip", "route", "replace", "default", "via", veth.hostIP); err != nil {
 		return fmt.Errorf("configure namespace default route: %w", err)
 	}
-
 	if err := runCommand(ctx, "ip", "route", "replace", spec.GetHostAccessIp()+"/32", "via", veth.peerIP, "dev", hostVeth); err != nil {
 		return fmt.Errorf("configure host access route: %w", err)
 	}
-	if err := ensureNAT(ctx, spec); err != nil {
+
+	switch runtimeType {
+	case novitaboxv1.RuntimeType_RUNTIME_TYPE_CONTAINER:
+		if err := m.prepareGVisorNamespace(ctx, spec); err != nil {
+			return err
+		}
+	default:
+		if err := m.prepareFirecrackerNamespace(ctx, spec); err != nil {
+			return err
+		}
+	}
+	if err := m.prepareHostInternetNAT(ctx); err != nil {
 		return err
 	}
 
@@ -186,30 +187,117 @@ func (m sandboxNetworkManager) Cleanup(ctx context.Context, sandboxID string, sl
 	if err != nil || spec == nil {
 		return err
 	}
-	_ = removeNAT(ctx, spec)
+	_ = m.removeHostInternetNAT(ctx)
+	_ = m.removeNAT(ctx, spec)
 	_ = runCommand(ctx, "ip", "route", "del", spec.GetHostAccessIp()+"/32")
 	_ = runCommand(ctx, "ip", "link", "del", hostVethName(spec.GetNamespaceName()))
 	_ = runCommand(ctx, "ip", "netns", "del", spec.GetNamespaceName())
 	return nil
 }
 
-func ensureNAT(ctx context.Context, spec *novitaboxv1.NetworkSpec) error {
+func (m sandboxNetworkManager) ensureNAT(ctx context.Context, spec *novitaboxv1.NetworkSpec) error {
 	if err := ensureIPTablesRule(ctx, spec.GetNamespaceName(), "nat", "PREROUTING", dnatRuleArgs(spec)); err != nil {
 		return fmt.Errorf("configure sandbox DNAT: %w", err)
 	}
 	if err := ensureIPTablesRule(ctx, spec.GetNamespaceName(), "nat", "POSTROUTING", snatRuleArgs(spec)); err != nil {
 		return fmt.Errorf("configure sandbox SNAT: %w", err)
 	}
+	if err := ensureIPTablesRule(ctx, spec.GetNamespaceName(), "nat", "POSTROUTING", vethSnatRuleArgs(m.cfg.Network.VethCIDR, spec)); err != nil {
+		return fmt.Errorf("configure sandbox veth SNAT: %w", err)
+	}
 	return nil
 }
 
-func removeNAT(ctx context.Context, spec *novitaboxv1.NetworkSpec) error {
+func (m sandboxNetworkManager) prepareFirecrackerNamespace(ctx context.Context, spec *novitaboxv1.NetworkSpec) error {
+	// Firecracker keeps the guest IP inside the VM, so the netns needs tap0
+	// plus the fixed guest-facing /30.
+	if err := runCommand(ctx, "ip", "netns", "exec", spec.GetNamespaceName(), "ip", "tuntap", "add", "dev", spec.GetTapName(), "mode", "tap"); err != nil && !commandOutputContains(err, "File exists") {
+		return fmt.Errorf("create tap %s: %w", spec.GetTapName(), err)
+	}
+	gatewayCIDR := spec.GetGatewayIp() + "/30"
+	if err := runCommand(ctx, "ip", "netns", "exec", spec.GetNamespaceName(), "ip", "addr", "replace", gatewayCIDR, "dev", spec.GetTapName()); err != nil {
+		return fmt.Errorf("configure tap gateway: %w", err)
+	}
+	if err := runCommand(ctx, "ip", "netns", "exec", spec.GetNamespaceName(), "ip", "link", "set", spec.GetTapName(), "up"); err != nil {
+		return fmt.Errorf("set tap up: %w", err)
+	}
+	if err := m.ensureNAT(ctx, spec); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m sandboxNetworkManager) prepareGVisorNamespace(ctx context.Context, spec *novitaboxv1.NetworkSpec) error {
+	// gVisor runs the agent as a process inside the namespace, so we expose the
+	// agent IP directly on eth0 so the host access route can hit the process
+	// without an extra DNAT hop.
+	if err := runCommand(ctx, "ip", "netns", "exec", spec.GetNamespaceName(), "ip", "addr", "replace", spec.GetHostAccessIp()+"/32", "dev", nsVethName(spec.GetNamespaceName())); err != nil {
+		return fmt.Errorf("configure gvisor host access address: %w", err)
+	}
+	if err := runCommand(ctx, "ip", "netns", "exec", spec.GetNamespaceName(), "ip", "addr", "replace", spec.GetGuestIp()+"/30", "dev", "lo"); err != nil {
+		return fmt.Errorf("configure gvisor agent address: %w", err)
+	}
+	if err := runCommand(ctx, "ip", "netns", "exec", spec.GetNamespaceName(), "ip", "link", "set", "lo", "up"); err != nil {
+		return fmt.Errorf("set namespace loopback up: %w", err)
+	}
+	if err := m.ensureNAT(ctx, spec); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m sandboxNetworkManager) removeNAT(ctx context.Context, spec *novitaboxv1.NetworkSpec) error {
 	dnatErr := deleteIPTablesRule(ctx, spec.GetNamespaceName(), "nat", "PREROUTING", dnatRuleArgs(spec))
 	snatErr := deleteIPTablesRule(ctx, spec.GetNamespaceName(), "nat", "POSTROUTING", snatRuleArgs(spec))
+	vethSnatErr := deleteIPTablesRule(ctx, spec.GetNamespaceName(), "nat", "POSTROUTING", vethSnatRuleArgs(m.cfg.Network.VethCIDR, spec))
 	if dnatErr != nil {
 		return dnatErr
 	}
+	if vethSnatErr != nil {
+		return vethSnatErr
+	}
 	return snatErr
+}
+
+func (m sandboxNetworkManager) prepareHostInternetNAT(ctx context.Context) error {
+	dev, err := hostDefaultRouteDev(ctx)
+	if err != nil {
+		return err
+	}
+	if err := runCommand(ctx, "sysctl", "-w", "net.ipv4.ip_forward=1"); err != nil {
+		return fmt.Errorf("enable host ip forwarding: %w", err)
+	}
+	for _, cidr := range []string{m.cfg.Network.VethCIDR, m.cfg.Network.HostAccessCIDR} {
+		if cidr == "" {
+			continue
+		}
+		if err := ensureHostIPTablesRule(ctx, "nat", "POSTROUTING", []string{"-s", cidr, "-o", dev, "-j", "MASQUERADE"}); err != nil {
+			return fmt.Errorf("configure host masquerade for %s: %w", cidr, err)
+		}
+		if err := ensureHostIPTablesRule(ctx, "filter", "FORWARD", []string{"-s", cidr, "-o", dev, "-j", "ACCEPT"}); err != nil {
+			return fmt.Errorf("configure host forward outbound for %s: %w", cidr, err)
+		}
+		if err := ensureHostIPTablesRule(ctx, "filter", "FORWARD", []string{"-d", cidr, "-i", dev, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"}); err != nil {
+			return fmt.Errorf("configure host forward inbound for %s: %w", cidr, err)
+		}
+	}
+	return nil
+}
+
+func (m sandboxNetworkManager) removeHostInternetNAT(ctx context.Context) error {
+	dev, err := hostDefaultRouteDev(ctx)
+	if err != nil {
+		return err
+	}
+	for _, cidr := range []string{m.cfg.Network.HostAccessCIDR, m.cfg.Network.VethCIDR} {
+		if cidr == "" {
+			continue
+		}
+		_ = deleteHostIPTablesRule(ctx, "filter", "FORWARD", []string{"-d", cidr, "-i", dev, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"})
+		_ = deleteHostIPTablesRule(ctx, "filter", "FORWARD", []string{"-s", cidr, "-o", dev, "-j", "ACCEPT"})
+		_ = deleteHostIPTablesRule(ctx, "nat", "POSTROUTING", []string{"-s", cidr, "-o", dev, "-j", "MASQUERADE"})
+	}
+	return nil
 }
 
 func ensureIPTablesRule(ctx context.Context, netns string, table string, chain string, args []string) error {
@@ -226,12 +314,34 @@ func deleteIPTablesRule(ctx context.Context, netns string, table string, chain s
 	return runCommand(ctx, "ip", append([]string{"netns", "exec", netns, "iptables"}, del...)...)
 }
 
+func ensureHostIPTablesRule(ctx context.Context, table string, chain string, args []string) error {
+	check := append([]string{"-t", table, "-C", chain}, args...)
+	if err := runCommand(ctx, "iptables", check...); err == nil {
+		return nil
+	}
+	add := append([]string{"-t", table, "-A", chain}, args...)
+	return runCommand(ctx, "iptables", add...)
+}
+
+func deleteHostIPTablesRule(ctx context.Context, table string, chain string, args []string) error {
+	del := append([]string{"-t", table, "-D", chain}, args...)
+	return runCommand(ctx, "iptables", del...)
+}
+
 func dnatRuleArgs(spec *novitaboxv1.NetworkSpec) []string {
 	return []string{"-i", nsVethName(spec.GetNamespaceName()), "-d", spec.GetHostAccessIp() + "/32", "-j", "DNAT", "--to-destination", spec.GetGuestIp()}
 }
 
 func snatRuleArgs(spec *novitaboxv1.NetworkSpec) []string {
 	return []string{"-o", nsVethName(spec.GetNamespaceName()), "-s", spec.GetGuestIp(), "-j", "SNAT", "--to-source", spec.GetHostAccessIp()}
+}
+
+func vethSnatRuleArgs(cidr string, spec *novitaboxv1.NetworkSpec) []string {
+	addrs, err := vethAddrsForSlot(cidr, spec.GetSlot())
+	if err != nil {
+		return []string{"-j", "RETURN"}
+	}
+	return []string{"-o", nsVethName(spec.GetNamespaceName()), "-s", addrs.peerIP, "-j", "SNAT", "--to-source", spec.GetHostAccessIp()}
 }
 
 type sandboxVethAddrs struct {
@@ -322,11 +432,11 @@ func indexedIP(cidr string, index uint32) (string, error) {
 }
 
 func sandboxNetNSName(sandboxID string) string {
-	return shortName("nb-" + sandboxID)
+	return hashName("nb-", sandboxID)
 }
 
 func hostVethName(netns string) string {
-	return shortName("vh-" + netns)
+	return hashName("vh-", netns)
 }
 
 func nsVethName(netns string) string {
@@ -334,7 +444,17 @@ func nsVethName(netns string) string {
 }
 
 func nsPeerVethName(netns string) string {
-	return shortName("vp-" + netns)
+	return hashName("vp-", netns)
+}
+
+func hashName(prefix string, values ...string) string {
+	h := sha1.New()
+	for _, value := range values {
+		_, _ = h.Write([]byte(value))
+		_, _ = h.Write([]byte{0})
+	}
+	sum := h.Sum(nil)
+	return prefix + hex.EncodeToString(sum[:5])
 }
 
 func shortName(name string) string {
@@ -378,4 +498,21 @@ func commandOutputContains(err error, needle string) bool {
 		return false
 	}
 	return strings.Contains(err.Error(), needle)
+}
+
+func hostDefaultRouteDev(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "ip", "route", "show", "default")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("show host default route: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		for i := 0; i < len(fields)-1; i++ {
+			if fields[i] == "dev" && fields[i+1] != "" {
+				return fields[i+1], nil
+			}
+		}
+	}
+	return "", fmt.Errorf("host default route device not found in %q", strings.TrimSpace(string(out)))
 }

--- a/internal/boxlet/server/server_test.go
+++ b/internal/boxlet/server/server_test.go
@@ -63,8 +63,8 @@ func TestNodeService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list runtimes: %v", err)
 	}
-	if len(runtimes.GetRuntimes()) != 2 {
-		t.Fatalf("expected 2 runtimes, got %d", len(runtimes.GetRuntimes()))
+	if len(runtimes.GetRuntimes()) != 3 {
+		t.Fatalf("expected 3 runtimes, got %d", len(runtimes.GetRuntimes()))
 	}
 }
 
@@ -86,6 +86,32 @@ func TestSandboxRuntimeSpecUsesBoxdInit(t *testing.T) {
 	}
 }
 
+func TestSandboxRuntimeSpecUsesGVisorRootfsDir(t *testing.T) {
+	cfg := config.Default()
+	cfg.RootDir = t.TempDir()
+	svc := newSandboxService(cfg, log.NewNop(), nil)
+
+	spec := svc.runtimeSpecForSandbox(store.SandboxRecord{
+		ID:          "sbx-test",
+		State:       sandbox.StateRunning,
+		RuntimeType: "gvisor",
+		TemplateID:  "tpl-test",
+	})
+
+	if spec.GetRootfs().GetFormat() != "dir" {
+		t.Fatalf("rootfs format = %q, want dir", spec.GetRootfs().GetFormat())
+	}
+	if !strings.HasSuffix(spec.GetRootfs().GetPath(), filepath.Join("sandboxes", "sbx-test", "rootfs")) {
+		t.Fatalf("rootfs path = %q, want sandbox rootfs dir", spec.GetRootfs().GetPath())
+	}
+	if spec.GetKernel() != nil {
+		t.Fatalf("kernel spec = %#v, want nil", spec.GetKernel())
+	}
+	if spec.GetSnapshot() != nil {
+		t.Fatalf("snapshot spec = %#v, want nil", spec.GetSnapshot())
+	}
+}
+
 func TestCompleteRuntimeSpecFillsBoxdInit(t *testing.T) {
 	cfg := config.Default()
 	cfg.RootDir = t.TempDir()
@@ -104,6 +130,65 @@ func TestCompleteRuntimeSpecFillsBoxdInit(t *testing.T) {
 	args := strings.Join(spec.GetKernel().GetKernelArgs(), " ")
 	if !strings.Contains(args, "init=/novitabox/init") {
 		t.Fatalf("kernel args = %q, want init=/novitabox/init", args)
+	}
+}
+
+func TestCompleteRuntimeSpecPreservesGPUCountAndDefaultsMachine(t *testing.T) {
+	cfg := config.Default()
+	cfg.RootDir = t.TempDir()
+	svc := newSandboxService(cfg, log.NewNop(), nil)
+
+	spec := svc.completeRuntimeSpec(store.SandboxRecord{
+		ID:          "sbx-test",
+		State:       sandbox.StateRunning,
+		RuntimeType: "gvisor",
+		TemplateID:  "tpl-test",
+	}, &novitaboxv1.RuntimeSpec{
+		SandboxId:   "sbx-test",
+		RuntimeType: novitaboxv1.RuntimeType_RUNTIME_TYPE_CONTAINER,
+		Machine: &novitaboxv1.MachineSpec{
+			Gpu: 2,
+		},
+	})
+
+	if spec.GetMachine().GetGpu() != 2 {
+		t.Fatalf("gpu = %d, want 2", spec.GetMachine().GetGpu())
+	}
+	if spec.GetMachine().GetVcpu() != cfg.Template.VCPU {
+		t.Fatalf("vcpu = %d, want %d", spec.GetMachine().GetVcpu(), cfg.Template.VCPU)
+	}
+	if spec.GetMachine().GetMemoryMb() != cfg.Template.MemoryMB {
+		t.Fatalf("memory = %d, want %d", spec.GetMachine().GetMemoryMb(), cfg.Template.MemoryMB)
+	}
+}
+
+func TestTemplateRuntimeDriverUsesMetadata(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.Default()
+	cfg.RootDir = t.TempDir()
+	st, err := sqlite.Open(ctx, filepath.Join(cfg.RootDir, "db", "novitabox.db"))
+	if err != nil {
+		t.Fatalf("open sqlite store: %v", err)
+	}
+	defer st.Close()
+
+	if err := st.CreateTemplate(ctx, store.TemplateRecord{
+		ID:         "tpl-gvisor",
+		RootfsPath: filepath.Join(cfg.RootDir, "templates", "tpl-gvisor", "rootfs"),
+		Metadata: map[string]string{
+			"runtimeType": "gvisor",
+		},
+	}); err != nil {
+		t.Fatalf("create template: %v", err)
+	}
+
+	svc := newArtifactService(cfg, log.NewNop(), st)
+	got, err := svc.templateRuntimeDriver(ctx, "tpl-gvisor")
+	if err != nil {
+		t.Fatalf("template runtime driver: %v", err)
+	}
+	if got != "gvisor" {
+		t.Fatalf("runtime driver = %q, want gvisor", got)
 	}
 }
 

--- a/internal/boxlet/server/services.go
+++ b/internal/boxlet/server/services.go
@@ -20,6 +20,7 @@ import (
 	"syscall"
 	"time"
 
+	shimruntime "github.com/novitalabs/NovitaBox/internal/boxshim/runtime"
 	"github.com/novitalabs/NovitaBox/internal/config"
 	"github.com/novitalabs/NovitaBox/internal/log"
 	novitaboxv1 "github.com/novitalabs/NovitaBox/internal/pb/novitabox/v1"
@@ -92,14 +93,14 @@ func (s *sandboxService) CreateSandbox(ctx context.Context, req *novitaboxv1.Cre
 		_ = s.releaseSandboxNetwork(ctx, record)
 		return nil, err
 	}
-	if err := newSandboxNetworkManager(s.cfg).Ensure(ctx, spec.GetNetwork()); err != nil {
+	if err := newSandboxNetworkManager(s.cfg).Prepare(ctx, spec.GetRuntimeType(), spec.GetNetwork()); err != nil {
 		_ = s.store.UpdateSandboxState(ctx, sandboxID, sandbox.StateCreating, sandbox.StateFailed, "create")
 		_ = s.releaseSandboxNetwork(ctx, record)
 		return nil, err
 	}
 
 	shimSocket := filepath.Join(sandboxDir, "shim.sock")
-	if err := ensureShim(ctx, s.cfg, shimSocket); err != nil {
+	if err := ensureShim(ctx, s.cfg, shimSocket, runtimeDriverFromRuntimeType(runtimeType)); err != nil {
 		_ = s.store.UpdateSandboxState(ctx, sandboxID, sandbox.StateCreating, sandbox.StateFailed, "create")
 		_ = s.releaseSandboxNetwork(ctx, record)
 		return nil, err
@@ -243,7 +244,7 @@ func (s *sandboxService) ResumeSandbox(ctx context.Context, req *novitaboxv1.Res
 		_ = s.releaseSandboxNetwork(ctx, *record)
 		return nil, err
 	}
-	if err := newSandboxNetworkManager(s.cfg).Ensure(ctx, spec.GetNetwork()); err != nil {
+	if err := newSandboxNetworkManager(s.cfg).Prepare(ctx, spec.GetRuntimeType(), spec.GetNetwork()); err != nil {
 		_ = s.setSandboxState(ctx, record.ID, sandbox.StateFailed, "resume")
 		_ = s.releaseSandboxNetwork(ctx, *record)
 		return nil, err
@@ -299,7 +300,7 @@ func (s *sandboxService) KillSandbox(ctx context.Context, req *novitaboxv1.KillS
 	if err := s.store.DeleteSandbox(ctx, record.ID); err != nil {
 		return nil, err
 	}
-	if err := os.RemoveAll(sandboxDir); err != nil {
+	if err := removeSandboxDirectory(sandboxDir); err != nil {
 		return nil, fmt.Errorf("remove sandbox directory: %w", err)
 	}
 	if err := s.releaseSandboxNetwork(ctx, *record); err != nil {
@@ -362,7 +363,7 @@ func (s *sandboxService) StartSandbox(ctx context.Context, req *novitaboxv1.Star
 		_ = s.releaseSandboxNetwork(ctx, *record)
 		return nil, err
 	}
-	if err := newSandboxNetworkManager(s.cfg).Ensure(ctx, spec.GetNetwork()); err != nil {
+	if err := newSandboxNetworkManager(s.cfg).Prepare(ctx, spec.GetRuntimeType(), spec.GetNetwork()); err != nil {
 		_ = s.setSandboxState(ctx, record.ID, sandbox.StateFailed, "start")
 		_ = s.releaseSandboxNetwork(ctx, *record)
 		return nil, err
@@ -606,27 +607,44 @@ func (s *sandboxService) runtimeSpecForSandbox(record store.SandboxRecord) *novi
 	if record.NetworkSlot > 0 {
 		networkSpec, _ = newSandboxNetworkManager(s.cfg).SpecForSlot(record.ID, record.NetworkSlot)
 	}
+	runtimeType := runtimeTypeFromRecord(record.RuntimeType)
+	rootfsPath := paths.RootfsPath
+	rootfsFormat := "ext4"
+	if runtimeType == novitaboxv1.RuntimeType_RUNTIME_TYPE_CONTAINER {
+		rootfsPath = filepath.Join(layout.New(s.cfg.RootDir).SandboxDir(record.ID), "rootfs")
+		rootfsFormat = "dir"
+	}
 	return &novitaboxv1.RuntimeSpec{
 		SandboxId:   record.ID,
-		RuntimeType: runtimeTypeFromRecord(record.RuntimeType),
+		RuntimeType: runtimeType,
 		Machine: &novitaboxv1.MachineSpec{
 			Vcpu:     1,
 			MemoryMb: 512,
 		},
-		Kernel: &novitaboxv1.KernelSpec{
-			KernelPath: paths.KernelPath,
-			KernelArgs: templateKernelArgs(s.cfg.Template.KernelArgs),
-		},
 		Rootfs: &novitaboxv1.RootfsSpec{
-			Path:   paths.RootfsPath,
-			Format: "ext4",
-		},
-		Snapshot: &novitaboxv1.SnapshotSpec{
-			MemfilePath:  paths.MemfilePath,
-			SnapfilePath: paths.SnapfilePath,
-			SnapshotType: "full",
+			Path:   rootfsPath,
+			Format: rootfsFormat,
 		},
 		Network: networkSpec,
+		Kernel: func() *novitaboxv1.KernelSpec {
+			if runtimeType != novitaboxv1.RuntimeType_RUNTIME_TYPE_FIRECRACKER {
+				return nil
+			}
+			return &novitaboxv1.KernelSpec{
+				KernelPath: paths.KernelPath,
+				KernelArgs: templateKernelArgs(s.cfg.Template.KernelArgs),
+			}
+		}(),
+		Snapshot: func() *novitaboxv1.SnapshotSpec {
+			if runtimeType != novitaboxv1.RuntimeType_RUNTIME_TYPE_FIRECRACKER {
+				return nil
+			}
+			return &novitaboxv1.SnapshotSpec{
+				MemfilePath:  paths.MemfilePath,
+				SnapfilePath: paths.SnapfilePath,
+				SnapshotType: "full",
+			}
+		}(),
 	}
 }
 
@@ -635,44 +653,56 @@ func (s *sandboxService) completeRuntimeSpec(record store.SandboxRecord, spec *n
 		spec = s.runtimeSpecForSandbox(record)
 	}
 	paths := sandboxRuntimePaths(s.cfg.RootDir, record.ID)
+	runtimeType := runtimeTypeFromRecord(record.RuntimeType)
 	spec.SandboxId = record.ID
-	spec.RuntimeType = runtimeTypeFromRecord(record.RuntimeType)
+	spec.RuntimeType = runtimeType
 	if spec.Machine == nil {
-		spec.Machine = &novitaboxv1.MachineSpec{
-			Vcpu:     s.cfg.Template.VCPU,
-			MemoryMb: s.cfg.Template.MemoryMB,
-		}
+		spec.Machine = &novitaboxv1.MachineSpec{}
 	}
-	if spec.Kernel == nil {
-		spec.Kernel = &novitaboxv1.KernelSpec{}
+	if spec.Machine.Vcpu == 0 {
+		spec.Machine.Vcpu = s.cfg.Template.VCPU
 	}
-	if spec.Kernel.KernelPath == "" {
-		spec.Kernel.KernelPath = paths.KernelPath
-	}
-	if len(spec.Kernel.KernelArgs) == 0 {
-		spec.Kernel.KernelArgs = templateKernelArgs(s.cfg.Template.KernelArgs)
+	if spec.Machine.MemoryMb == 0 {
+		spec.Machine.MemoryMb = s.cfg.Template.MemoryMB
 	}
 	if spec.Rootfs == nil {
-		spec.Rootfs = &novitaboxv1.RootfsSpec{
-			Path:   paths.RootfsPath,
-			Format: "ext4",
-		}
+		spec.Rootfs = &novitaboxv1.RootfsSpec{}
 	}
 	if spec.Rootfs.Path == "" {
-		spec.Rootfs.Path = paths.RootfsPath
-	}
-	if spec.Snapshot == nil {
-		spec.Snapshot = &novitaboxv1.SnapshotSpec{
-			MemfilePath:  paths.MemfilePath,
-			SnapfilePath: paths.SnapfilePath,
-			SnapshotType: "full",
+		if runtimeType == novitaboxv1.RuntimeType_RUNTIME_TYPE_CONTAINER {
+			spec.Rootfs.Path = filepath.Join(layout.New(s.cfg.RootDir).SandboxDir(record.ID), "rootfs")
+			spec.Rootfs.Format = "dir"
+		} else {
+			spec.Rootfs.Path = paths.RootfsPath
+			spec.Rootfs.Format = "ext4"
 		}
 	}
-	if spec.Snapshot.MemfilePath == "" {
-		spec.Snapshot.MemfilePath = paths.MemfilePath
-	}
-	if spec.Snapshot.SnapfilePath == "" {
-		spec.Snapshot.SnapfilePath = paths.SnapfilePath
+	if runtimeType == novitaboxv1.RuntimeType_RUNTIME_TYPE_FIRECRACKER {
+		if spec.Kernel == nil {
+			spec.Kernel = &novitaboxv1.KernelSpec{}
+		}
+		if spec.Kernel.KernelPath == "" {
+			spec.Kernel.KernelPath = paths.KernelPath
+		}
+		if len(spec.Kernel.KernelArgs) == 0 {
+			spec.Kernel.KernelArgs = templateKernelArgs(s.cfg.Template.KernelArgs)
+		}
+		if spec.Snapshot == nil {
+			spec.Snapshot = &novitaboxv1.SnapshotSpec{
+				MemfilePath:  paths.MemfilePath,
+				SnapfilePath: paths.SnapfilePath,
+				SnapshotType: "full",
+			}
+		}
+		if spec.Snapshot.MemfilePath == "" {
+			spec.Snapshot.MemfilePath = paths.MemfilePath
+		}
+		if spec.Snapshot.SnapfilePath == "" {
+			spec.Snapshot.SnapfilePath = paths.SnapfilePath
+		}
+	} else {
+		spec.Kernel = nil
+		spec.Snapshot = nil
 	}
 	if record.NetworkSlot > 0 {
 		if networkSpec, err := newSandboxNetworkManager(s.cfg).Complete(record.ID, record.NetworkSlot, spec.Network); err == nil {
@@ -706,7 +736,7 @@ func (s *sandboxService) prepareSandboxRuntimeFiles(ctx context.Context, record 
 		if err != nil {
 			return fmt.Errorf("get template %q: %w", record.TemplateID, err)
 		}
-		if err := cloneOrCopyFile(template.RootfsPath, spec.GetRootfs().GetPath()); err != nil {
+		if err := cloneOrCopyPath(template.RootfsPath, spec.GetRootfs().GetPath()); err != nil {
 			return fmt.Errorf("prepare sandbox rootfs from template %q: %w", record.TemplateID, err)
 		}
 		if template.MemfilePath != "" && spec.GetSnapshot().GetMemfilePath() != "" {
@@ -726,7 +756,7 @@ func (s *sandboxService) prepareSandboxRuntimeFiles(ctx context.Context, record 
 		if err != nil {
 			return fmt.Errorf("get image %q: %w", record.ImageID, err)
 		}
-		if err := cloneOrCopyFile(image.RootfsPath, spec.GetRootfs().GetPath()); err != nil {
+		if err := cloneOrCopyPath(image.RootfsPath, spec.GetRootfs().GetPath()); err != nil {
 			return fmt.Errorf("prepare sandbox rootfs from image %q: %w", record.ImageID, err)
 		}
 		return nil
@@ -735,7 +765,7 @@ func (s *sandboxService) prepareSandboxRuntimeFiles(ctx context.Context, record 
 	return nil
 }
 
-func ensureShim(ctx context.Context, cfg config.Config, socketPath string) error {
+func ensureShim(ctx context.Context, cfg config.Config, socketPath string, runtimeDriver string) error {
 	if _, err := os.Stat(socketPath); err == nil {
 		if err := waitShimReady(ctx, socketPath, 500*time.Millisecond); err == nil {
 			return nil
@@ -749,12 +779,16 @@ func ensureShim(ctx context.Context, cfg config.Config, socketPath string) error
 	if err != nil {
 		return err
 	}
+	if runtimeDriver == "" {
+		runtimeDriver = cfg.Boxshim.RuntimeDriver
+	}
 	cmd := exec.Command(
 		shimBin,
 		"--root", cfg.RootDir,
 		"--socket", socketPath,
-		"--runtime-driver", cfg.Boxshim.RuntimeDriver,
+		"--runtime-driver", runtimeDriver,
 		"--firecracker-bin", cfg.Firecracker.BinaryPath,
+		"--runsc-bin", cfg.GVisor.RunscBinaryPath,
 	)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	if err := cmd.Start(); err != nil {
@@ -765,9 +799,9 @@ func ensureShim(ctx context.Context, cfg config.Config, socketPath string) error
 	if err := os.WriteFile(pidPath, []byte(fmt.Sprintf("%d\n", cmd.Process.Pid)), 0o644); err != nil {
 		return fmt.Errorf("write shim pid: %w", err)
 	}
-	if err := cmd.Process.Release(); err != nil {
-		return fmt.Errorf("release boxshim process: %w", err)
-	}
+	go func() {
+		_ = cmd.Wait()
+	}()
 
 	if err := waitShimReady(ctx, socketPath, 5*time.Second); err != nil {
 		return fmt.Errorf("wait for boxshim %q ready: %w", socketPath, err)
@@ -986,10 +1020,47 @@ func runtimeTypeFromRecord(runtimeType string) novitaboxv1.RuntimeType {
 	switch strings.ToLower(runtimeType) {
 	case "runtime_type_cloud_hypervisor", "cloud-hypervisor", "cloud_hypervisor":
 		return novitaboxv1.RuntimeType_RUNTIME_TYPE_CLOUD_HYPERVISOR
-	case "runtime_type_container", "container":
+	case "runtime_type_container", "container", "gvisor":
 		return novitaboxv1.RuntimeType_RUNTIME_TYPE_CONTAINER
 	case "runtime_type_firecracker", "firecracker", "":
 		return novitaboxv1.RuntimeType_RUNTIME_TYPE_FIRECRACKER
+	default:
+		return novitaboxv1.RuntimeType_RUNTIME_TYPE_FIRECRACKER
+	}
+}
+
+func runtimeDriverFromRuntimeType(runtimeType novitaboxv1.RuntimeType) string {
+	switch runtimeType {
+	case novitaboxv1.RuntimeType_RUNTIME_TYPE_CONTAINER:
+		return "gvisor"
+	case novitaboxv1.RuntimeType_RUNTIME_TYPE_CLOUD_HYPERVISOR:
+		return "cloud-hypervisor"
+	default:
+		return "firecracker"
+	}
+}
+
+func runtimeDriverFromRecord(runtimeType string) string {
+	switch strings.ToLower(strings.TrimSpace(runtimeType)) {
+	case "stub":
+		return "stub"
+	case "runtime_type_container", "container", "gvisor":
+		return "gvisor"
+	case "runtime_type_cloud_hypervisor", "cloud-hypervisor", "cloud_hypervisor":
+		return "cloud-hypervisor"
+	case "runtime_type_firecracker", "firecracker", "":
+		return "firecracker"
+	default:
+		return strings.TrimSpace(runtimeType)
+	}
+}
+
+func runtimeTypeFromRuntimeDriver(runtimeDriver string) novitaboxv1.RuntimeType {
+	switch strings.ToLower(strings.TrimSpace(runtimeDriver)) {
+	case "gvisor", "container", "runtime_type_container":
+		return novitaboxv1.RuntimeType_RUNTIME_TYPE_CONTAINER
+	case "cloud-hypervisor", "cloud_hypervisor", "runtime_type_cloud_hypervisor":
+		return novitaboxv1.RuntimeType_RUNTIME_TYPE_CLOUD_HYPERVISOR
 	default:
 		return novitaboxv1.RuntimeType_RUNTIME_TYPE_FIRECRACKER
 	}
@@ -1006,13 +1077,41 @@ func newArtifactService(cfg config.Config, logger *log.Logger, store store.Store
 	return &artifactService{cfg: cfg, logger: logger, store: store}
 }
 
+func (s *artifactService) templateRuntimeDriver(ctx context.Context, templateID string) (string, error) {
+	runtimeDriver := runtimeDriverFromRecord(s.cfg.Boxshim.RuntimeDriver)
+	if s.store == nil {
+		return runtimeDriver, nil
+	}
+	record, err := s.store.GetTemplate(ctx, templateID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return runtimeDriver, nil
+		}
+		return "", err
+	}
+	if record.Metadata != nil {
+		if configured := strings.TrimSpace(record.Metadata["runtimeType"]); configured != "" {
+			return runtimeDriverFromRecord(configured), nil
+		}
+	}
+	if record.RootfsPath != "" && record.MemfilePath == "" && record.SnapfilePath == "" {
+		return "gvisor", nil
+	}
+	return runtimeDriver, nil
+}
+
 func (s *artifactService) CreateTemplate(ctx context.Context, req *novitaboxv1.CreateTemplateRequest) (*novitaboxv1.TemplateInfo, error) {
 	templateID := req.GetTemplateId()
 	if templateID == "" {
 		return nil, errors.New("template_id is required")
 	}
+	runtimeDriver, err := s.templateRuntimeDriver(ctx, templateID)
+	if err != nil {
+		return nil, err
+	}
 	s.logger.Info("starting template artifact build",
 		"template_id", templateID,
+		"runtime_driver", runtimeDriver,
 		"docker_image", req.GetDockerImage(),
 		"from_template", req.GetFromTemplate(),
 		"image_id", req.GetImageId(),
@@ -1025,22 +1124,33 @@ func (s *artifactService) CreateTemplate(ctx context.Context, req *novitaboxv1.C
 		return nil, fmt.Errorf("create template directory: %w", err)
 	}
 
-	paths := templateArtifactPaths(templateDir)
+	paths, err := s.templateArtifactPaths(ctx, templateID, templateDir, runtimeDriver)
+	if err != nil {
+		return nil, err
+	}
 	s.logger.Info("materializing template rootfs", "template_id", templateID, "rootfs_path", paths.RootfsPath)
-	if err := s.materializeTemplateRootfs(ctx, req, paths.RootfsPath); err != nil {
+	if err := s.materializeTemplateRootfs(ctx, req, paths.RootfsPath, runtimeDriver); err != nil {
 		s.logger.Error("materialize template rootfs failed", "template_id", templateID, "error", err)
 		return nil, err
 	}
 
-	s.logger.Info("injecting template init into rootfs", "template_id", templateID)
-	if err := s.injectTemplateInit(ctx, paths.RootfsPath); err != nil {
-		s.logger.Error("inject template init into rootfs failed", "template_id", templateID, "error", err)
+	s.logger.Info("injecting template runtime files", "template_id", templateID)
+	if err := s.injectTemplateRuntimeFiles(ctx, paths, runtimeDriver); err != nil {
+		s.logger.Error("inject template runtime files failed", "template_id", templateID, "error", err)
 		return nil, err
 	}
-	s.logger.Info("creating template snapshot", "template_id", templateID, "memfile_path", paths.MemfilePath, "snapfile_path", paths.SnapfilePath)
-	if err := s.createTemplateSnapshot(ctx, req, templateID, paths); err != nil {
-		s.logger.Error("create template snapshot failed", "template_id", templateID, "error", err)
-		return nil, err
+	if isGVisorRuntimeDriver(runtimeDriver) {
+		s.logger.Info("creating gvisor template", "template_id", templateID, "rootfs_path", paths.RootfsPath)
+		if err := s.createGVisorTemplate(ctx, req, templateID, paths, runtimeDriver); err != nil {
+			s.logger.Error("create gvisor template failed", "template_id", templateID, "error", err)
+			return nil, err
+		}
+	} else {
+		s.logger.Info("creating template snapshot", "template_id", templateID, "memfile_path", paths.MemfilePath, "snapfile_path", paths.SnapfilePath)
+		if err := s.createTemplateSnapshot(ctx, req, templateID, paths, runtimeDriver); err != nil {
+			s.logger.Error("create template snapshot failed", "template_id", templateID, "error", err)
+			return nil, err
+		}
 	}
 
 	record := store.TemplateRecord{
@@ -1048,6 +1158,9 @@ func (s *artifactService) CreateTemplate(ctx context.Context, req *novitaboxv1.C
 		RootfsPath:   paths.RootfsPath,
 		MemfilePath:  paths.MemfilePath,
 		SnapfilePath: paths.SnapfilePath,
+		Metadata: map[string]string{
+			"runtimeType": runtimeDriver,
+		},
 	}
 	if err := s.store.CreateTemplate(ctx, record); err != nil {
 		existing, getErr := s.store.GetTemplate(ctx, templateID)
@@ -1171,37 +1284,304 @@ func debugfsQuote(path string) string {
 	return `"` + strings.ReplaceAll(path, `"`, `\"`) + `"`
 }
 
-func (s *artifactService) createTemplateSnapshot(ctx context.Context, req *novitaboxv1.CreateTemplateRequest, templateID string, paths artifactPaths) error {
-	if s.cfg.Template.KernelPath == "" {
-		return errors.New("template snapshot build requires --template-kernel")
+func (s *artifactService) templateArtifactPaths(ctx context.Context, templateID string, templateDir string, runtimeDriver string) (artifactPaths, error) {
+	if s.store != nil {
+		record, err := s.store.GetTemplate(ctx, templateID)
+		if err == nil && record.RootfsPath != "" {
+			return artifactPaths{
+				RootfsPath:   record.RootfsPath,
+				MemfilePath:  record.MemfilePath,
+				SnapfilePath: record.SnapfilePath,
+			}, nil
+		}
+		if err != nil && !errors.Is(err, store.ErrNotFound) {
+			return artifactPaths{}, err
+		}
 	}
-	if strings.EqualFold(s.cfg.Boxshim.RuntimeDriver, "stub") {
-		if err := ensureFile(paths.MemfilePath); err != nil {
-			return fmt.Errorf("create template memfile placeholder: %w", err)
+	return templateArtifactPaths(templateDir, runtimeDriver), nil
+}
+
+func (s *artifactService) injectTemplateRuntimeFiles(ctx context.Context, paths artifactPaths, runtimeDriver string) error {
+	if isGVisorRuntimeDriver(runtimeDriver) {
+		return s.injectTemplateBoxdBinary(paths.RootfsPath)
+	}
+	return s.injectTemplateInit(ctx, paths.RootfsPath)
+}
+
+func (s *artifactService) injectTemplateBoxdBinary(rootfsPath string) error {
+	guestPath := s.cfg.Template.BoxdGuestPath
+	if guestPath == "" {
+		guestPath = "/novitabox/agent/boxd"
+	}
+	boxdPath := s.cfg.Template.BoxdBinaryPath
+	if boxdPath == "" {
+		return errors.New("template boxd binary path is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(shimruntime.ContainerPathInRootfs(rootfsPath, guestPath)), 0o755); err != nil {
+		return fmt.Errorf("create gvisor boxd dir: %w", err)
+	}
+	if err := cloneOrCopyFile(boxdPath, shimruntime.ContainerPathInRootfs(rootfsPath, guestPath)); err != nil {
+		return fmt.Errorf("inject gvisor boxd binary: %w", err)
+	}
+	if err := injectTemplateNetworkingFiles(rootfsPath, true); err != nil {
+		return err
+	}
+	if err := injectDomesticAptSources(rootfsPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func injectTemplateNetworkingFiles(rootfsPath string, preserveHostResolver bool) error {
+	if err := writeTemplateResolvConf(filepath.Join(rootfsPath, "etc", "resolv.conf"), preserveHostResolver); err != nil {
+		return fmt.Errorf("inject gvisor resolv.conf: %w", err)
+	}
+	if err := writeTemplateHosts(filepath.Join(rootfsPath, "etc", "hosts")); err != nil {
+		return fmt.Errorf("inject gvisor hosts: %w", err)
+	}
+	return nil
+}
+
+func writeTemplateResolvConf(path string, preserveHostResolver bool) error {
+	_ = preserveHostResolver
+	nameservers := []string{"114.114.114.114"}
+	var buf bytes.Buffer
+	for _, ns := range nameservers {
+		buf.WriteString("nameserver ")
+		buf.WriteString(ns)
+		buf.WriteByte('\n')
+	}
+	buf.WriteString("options timeout:2 attempts:2\n")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o644)
+}
+
+func injectDomesticAptSources(rootfsPath string) error {
+	aptDir := filepath.Join(rootfsPath, "etc", "apt")
+	paths := []string{filepath.Join(aptDir, "sources.list")}
+	if entries, err := os.ReadDir(filepath.Join(aptDir, "sources.list.d")); err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			if strings.HasSuffix(name, ".list") || strings.HasSuffix(name, ".sources") {
+				paths = append(paths, filepath.Join(aptDir, "sources.list.d", name))
+			}
 		}
-		if err := ensureFile(paths.SnapfilePath); err != nil {
-			return fmt.Errorf("create template snapfile placeholder: %w", err)
-		}
-		return nil
 	}
 
-	buildID := "template-build-" + templateID
+	changed := false
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("read apt sources %q: %w", path, err)
+		}
+		rewritten := rewriteAptSources(data)
+		if bytes.Equal(rewritten, data) {
+			continue
+		}
+		if err := os.WriteFile(path, rewritten, 0o644); err != nil {
+			return fmt.Errorf("write apt sources %q: %w", path, err)
+		}
+		changed = true
+	}
+	if changed {
+		return nil
+	}
+	return nil
+}
+
+func rewriteAptSources(data []byte) []byte {
+	replacements := []struct {
+		old string
+		new string
+	}{
+		{"https://archive.ubuntu.com/ubuntu", "https://mirrors.aliyun.com/ubuntu"},
+		{"https://archive.ubuntu.com/ubuntu/", "https://mirrors.aliyun.com/ubuntu/"},
+		{"http://archive.ubuntu.com/ubuntu", "http://mirrors.aliyun.com/ubuntu"},
+		{"http://archive.ubuntu.com/ubuntu/", "http://mirrors.aliyun.com/ubuntu/"},
+		{"https://security.ubuntu.com/ubuntu", "https://mirrors.aliyun.com/ubuntu"},
+		{"https://security.ubuntu.com/ubuntu/", "https://mirrors.aliyun.com/ubuntu/"},
+		{"http://security.ubuntu.com/ubuntu", "http://mirrors.aliyun.com/ubuntu"},
+		{"http://security.ubuntu.com/ubuntu/", "http://mirrors.aliyun.com/ubuntu/"},
+		{"https://ports.ubuntu.com/ubuntu-ports", "https://mirrors.aliyun.com/ubuntu-ports"},
+		{"https://ports.ubuntu.com/ubuntu-ports/", "https://mirrors.aliyun.com/ubuntu-ports/"},
+		{"http://ports.ubuntu.com/ubuntu-ports", "http://mirrors.aliyun.com/ubuntu-ports"},
+		{"http://ports.ubuntu.com/ubuntu-ports/", "http://mirrors.aliyun.com/ubuntu-ports/"},
+		{"https://deb.debian.org/debian", "https://mirrors.aliyun.com/debian"},
+		{"https://deb.debian.org/debian/", "https://mirrors.aliyun.com/debian/"},
+		{"http://deb.debian.org/debian", "http://mirrors.aliyun.com/debian"},
+		{"http://deb.debian.org/debian/", "http://mirrors.aliyun.com/debian/"},
+		{"https://security.debian.org/debian-security", "https://mirrors.aliyun.com/debian-security"},
+		{"https://security.debian.org/debian-security/", "https://mirrors.aliyun.com/debian-security/"},
+		{"http://security.debian.org/debian-security", "http://mirrors.aliyun.com/debian-security"},
+		{"http://security.debian.org/debian-security/", "http://mirrors.aliyun.com/debian-security/"},
+		{"https://ftp.debian.org/debian", "https://mirrors.aliyun.com/debian"},
+		{"https://ftp.debian.org/debian/", "https://mirrors.aliyun.com/debian/"},
+		{"http://ftp.debian.org/debian", "http://mirrors.aliyun.com/debian"},
+		{"http://ftp.debian.org/debian/", "http://mirrors.aliyun.com/debian/"},
+	}
+	out := string(data)
+	for _, replacement := range replacements {
+		out = strings.ReplaceAll(out, replacement.old, replacement.new)
+	}
+	return []byte(out)
+}
+
+func hasUsableNameserver(data []byte) bool {
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "nameserver ") {
+			continue
+		}
+		ns := strings.TrimSpace(strings.TrimPrefix(line, "nameserver "))
+		if ns == "" || strings.HasPrefix(ns, "127.") || ns == "::1" || ns == "localhost" {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func writeTemplateHosts(path string) error {
+	content := templateHostsContent()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o644)
+}
+
+func templateHostsContent() string {
+	return templateHostsContentWithResolver(resolveTemplateHostIPv4)
+}
+
+func templateHostsContentWithResolver(resolve func(string) string) string {
+	var buf strings.Builder
+	buf.WriteString("127.0.0.1 localhost\n")
+	buf.WriteString("::1 localhost ip6-localhost ip6-loopback\n")
+	for _, entry := range templateHostMappingsWithResolver(resolve) {
+		buf.WriteString(entry.ip)
+		buf.WriteByte(' ')
+		buf.WriteString(entry.host)
+		buf.WriteByte('\n')
+	}
+	return buf.String()
+}
+
+type templateHostMapping struct {
+	host string
+	ip   string
+}
+
+func templateHostMappings() []templateHostMapping {
+	return templateHostMappingsWithResolver(resolveTemplateHostIPv4)
+}
+
+func templateHostMappingsWithResolver(resolve func(string) string) []templateHostMapping {
+	hosts := []string{
+		"mirrors.aliyun.com",
+		"archive.ubuntu.com",
+		"security.ubuntu.com",
+	}
+	out := make([]templateHostMapping, 0, len(hosts))
+	for _, host := range hosts {
+		ip := resolve(host)
+		if ip == "" {
+			continue
+		}
+		out = append(out, templateHostMapping{host: host, ip: ip})
+	}
+	return out
+}
+
+func resolveTemplateHostIPv4(host string) string {
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return ""
+	}
+	for _, ip := range ips {
+		if ip4 := ip.To4(); ip4 != nil {
+			return ip4.String()
+		}
+	}
+	return ""
+}
+
+func collectNameservers() []string {
+	candidates := []string{"/etc/resolv.conf", "/run/systemd/resolve/resolv.conf"}
+	seen := map[string]struct{}{}
+	var out []string
+	for _, candidate := range candidates {
+		data, err := os.ReadFile(candidate)
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "nameserver ") {
+				continue
+			}
+			ns := strings.TrimSpace(strings.TrimPrefix(line, "nameserver "))
+			if ns == "" || strings.HasPrefix(ns, "127.") || ns == "::1" || ns == "localhost" {
+				continue
+			}
+			if _, ok := seen[ns]; ok {
+				continue
+			}
+			seen[ns] = struct{}{}
+			out = append(out, ns)
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	return out
+}
+
+func (s *artifactService) createGVisorTemplate(ctx context.Context, req *novitaboxv1.CreateTemplateRequest, templateID string, paths artifactPaths, runtimeDriver string) error {
+	buildID, err := newInternalBuildID()
+	if err != nil {
+		return fmt.Errorf("generate template build id: %w", err)
+	}
 	buildDir := filepath.Join(layout.New(s.cfg.RootDir).SandboxDir(buildID))
 	var internalNetworkSlot uint32
+	success := false
 	if err := os.RemoveAll(buildDir); err != nil {
 		return fmt.Errorf("remove stale template build sandbox: %w", err)
 	}
 	if err := os.MkdirAll(buildDir, 0o755); err != nil {
-		return fmt.Errorf("create template snapshot build dir: %w", err)
+		return fmt.Errorf("create template build dir: %w", err)
 	}
 	defer func() {
-		if err := cleanupInternalSandbox(context.Background(), s.cfg, buildID, internalNetworkSlot); err != nil {
-			s.logger.Warn("cleanup template build sandbox failed", "sandbox_id", buildID, "error", err)
+		if success {
+			if err := cleanupInternalSandbox(context.Background(), s.cfg, buildID, internalNetworkSlot, runtimeTypeFromRuntimeDriver(runtimeDriver)); err != nil {
+				s.logger.Warn("cleanup template build sandbox failed", "sandbox_id", buildID, "error", err)
+			}
+			return
+		}
+		if keepFailedGVisorTemplateBuilds() {
+			s.logger.Warn("preserving failed gvisor template build sandbox for debugging", "sandbox_id", buildID)
+			return
+		}
+		if err := cleanupInternalSandbox(context.Background(), s.cfg, buildID, internalNetworkSlot, runtimeTypeFromRuntimeDriver(runtimeDriver)); err != nil {
+			s.logger.Warn("cleanup failed template build sandbox failed", "sandbox_id", buildID, "error", err)
 		}
 	}()
 
 	shimSocket := filepath.Join(buildDir, "shim.sock")
-	if err := ensureShim(ctx, s.cfg, shimSocket); err != nil {
+	if err := ensureShim(ctx, s.cfg, shimSocket, runtimeDriver); err != nil {
 		return fmt.Errorf("start template build shim: %w", err)
 	}
 
@@ -1213,7 +1593,118 @@ func (s *artifactService) createTemplateSnapshot(ctx context.Context, req *novit
 
 	spec := &novitaboxv1.RuntimeSpec{
 		SandboxId:   buildID,
-		RuntimeType: runtimeTypeFromRecord(s.cfg.Boxshim.RuntimeDriver),
+		RuntimeType: runtimeTypeFromRuntimeDriver(runtimeDriver),
+		Machine: &novitaboxv1.MachineSpec{
+			Vcpu:     s.cfg.Template.VCPU,
+			MemoryMb: s.cfg.Template.MemoryMB,
+		},
+		Rootfs: &novitaboxv1.RootfsSpec{
+			Path:   paths.RootfsPath,
+			Format: "dir",
+		},
+		Agent: &novitaboxv1.AgentSpec{
+			Type:     "boxd",
+			Protocol: "grpc",
+			Port:     49983,
+		},
+	}
+	if err := s.attachAgentDrive(ctx, spec); err != nil {
+		return err
+	}
+
+	networkSpec, err := s.internalSandboxNetworkSpecForTemplateBuild(ctx, buildID)
+	if err != nil {
+		return fmt.Errorf("prepare template build network spec: %w", err)
+	}
+	if networkSpec != nil {
+		internalNetworkSlot = networkSpec.GetSlot()
+	}
+	spec.Network = networkSpec
+	if err := newSandboxNetworkManager(s.cfg).Prepare(ctx, spec.GetRuntimeType(), spec.GetNetwork()); err != nil {
+		return fmt.Errorf("prepare template build network: %w", err)
+	}
+
+	if _, err := shim.CreateRuntime(ctx, &novitaboxv1.CreateRuntimeRequest{RuntimeSpec: spec}); err != nil {
+		return fmt.Errorf("create template build runtime: %w", err)
+	}
+	if holdGVisorTemplateBuildSandbox() {
+		return fmt.Errorf("holding gvisor template build sandbox for debugging")
+	}
+
+	agentURL, err := templateBuildAgentURL(s.cfg, buildID, spec.GetNetwork(), runtimeDriver)
+	if err != nil {
+		_, _ = shim.KillRuntime(context.Background(), &novitaboxv1.KillRuntimeRequest{SandboxId: buildID})
+		return err
+	}
+	if err := s.waitTemplateRuntimeReady(ctx, agentURL.health); err != nil {
+		_, _ = shim.KillRuntime(context.Background(), &novitaboxv1.KillRuntimeRequest{SandboxId: buildID})
+		return err
+	}
+	if err := s.runTemplateBuildCommands(ctx, req, agentURL.exec); err != nil {
+		_, _ = shim.KillRuntime(context.Background(), &novitaboxv1.KillRuntimeRequest{SandboxId: buildID})
+		return err
+	}
+	if _, err := shim.StopRuntime(ctx, &novitaboxv1.StopRuntimeRequest{SandboxId: buildID, TimeoutSeconds: 30}); err != nil {
+		_, _ = shim.KillRuntime(context.Background(), &novitaboxv1.KillRuntimeRequest{SandboxId: buildID})
+		return fmt.Errorf("stop gvisor template build runtime: %w", err)
+	}
+	success = true
+	return nil
+}
+
+func (s *artifactService) createTemplateSnapshot(ctx context.Context, req *novitaboxv1.CreateTemplateRequest, templateID string, paths artifactPaths, runtimeDriver string) error {
+	if s.cfg.Template.KernelPath == "" {
+		return errors.New("template snapshot build requires --template-kernel")
+	}
+	if strings.EqualFold(runtimeDriver, "stub") {
+		if err := ensureFile(paths.MemfilePath); err != nil {
+			return fmt.Errorf("create template memfile placeholder: %w", err)
+		}
+		if err := ensureFile(paths.SnapfilePath); err != nil {
+			return fmt.Errorf("create template snapfile placeholder: %w", err)
+		}
+		return nil
+	}
+
+	buildID, err := newInternalBuildID()
+	if err != nil {
+		return fmt.Errorf("generate template build id: %w", err)
+	}
+	buildDir := filepath.Join(layout.New(s.cfg.RootDir).SandboxDir(buildID))
+	var internalNetworkSlot uint32
+	success := false
+	if err := os.RemoveAll(buildDir); err != nil {
+		return fmt.Errorf("remove stale template build sandbox: %w", err)
+	}
+	if err := os.MkdirAll(buildDir, 0o755); err != nil {
+		return fmt.Errorf("create template snapshot build dir: %w", err)
+	}
+	defer func() {
+		if success {
+			if err := cleanupInternalSandbox(context.Background(), s.cfg, buildID, internalNetworkSlot, runtimeTypeFromRuntimeDriver(runtimeDriver)); err != nil {
+				s.logger.Warn("cleanup template build sandbox failed", "sandbox_id", buildID, "error", err)
+			}
+			return
+		}
+		if err := cleanupInternalSandbox(context.Background(), s.cfg, buildID, internalNetworkSlot, runtimeTypeFromRuntimeDriver(runtimeDriver)); err != nil {
+			s.logger.Warn("cleanup failed template build sandbox failed", "sandbox_id", buildID, "error", err)
+		}
+	}()
+
+	shimSocket := filepath.Join(buildDir, "shim.sock")
+	if err := ensureShim(ctx, s.cfg, shimSocket, runtimeDriver); err != nil {
+		return fmt.Errorf("start template build shim: %w", err)
+	}
+
+	shim, closeShim, err := dialShim(ctx, shimSocket)
+	if err != nil {
+		return fmt.Errorf("dial template build shim: %w", err)
+	}
+	defer closeShim()
+
+	spec := &novitaboxv1.RuntimeSpec{
+		SandboxId:   buildID,
+		RuntimeType: runtimeTypeFromRuntimeDriver(runtimeDriver),
 		Machine: &novitaboxv1.MachineSpec{
 			Vcpu:     s.cfg.Template.VCPU,
 			MemoryMb: s.cfg.Template.MemoryMB,
@@ -1232,7 +1723,7 @@ func (s *artifactService) createTemplateSnapshot(ctx context.Context, req *novit
 			SnapshotType: "full",
 		},
 	}
-	networkSpec, err := s.internalSandboxNetworkSpec(ctx, buildID)
+	networkSpec, err := s.internalSandboxNetworkSpecForTemplateBuild(ctx, buildID)
 	if err != nil {
 		return fmt.Errorf("prepare template build network spec: %w", err)
 	}
@@ -1243,15 +1734,14 @@ func (s *artifactService) createTemplateSnapshot(ctx context.Context, req *novit
 	if err := s.attachAgentDrive(ctx, spec); err != nil {
 		return err
 	}
-	if err := newSandboxNetworkManager(s.cfg).Ensure(ctx, spec.GetNetwork()); err != nil {
+	if err := newSandboxNetworkManager(s.cfg).Prepare(ctx, spec.GetRuntimeType(), spec.GetNetwork()); err != nil {
 		return fmt.Errorf("prepare template build network: %w", err)
 	}
 
 	if _, err := shim.CreateRuntime(ctx, &novitaboxv1.CreateRuntimeRequest{RuntimeSpec: spec}); err != nil {
 		return fmt.Errorf("create template build runtime: %w", err)
 	}
-
-	agentURL, err := templateBuildAgentURL(s.cfg, buildID, spec.GetNetwork())
+	agentURL, err := templateBuildAgentURL(s.cfg, buildID, spec.GetNetwork(), runtimeDriver)
 	if err != nil {
 		_, _ = shim.KillRuntime(context.Background(), &novitaboxv1.KillRuntimeRequest{SandboxId: buildID})
 		return err
@@ -1270,6 +1760,7 @@ func (s *artifactService) createTemplateSnapshot(ctx context.Context, req *novit
 		return fmt.Errorf("export firecracker template snapshot: %w", err)
 	}
 
+	success = true
 	return nil
 }
 
@@ -1294,12 +1785,65 @@ func (s *artifactService) internalSandboxNetworkSpec(ctx context.Context, sandbo
 			}
 		}
 	}
+	markUsedNetworkSlotsFromHostRoutes(ctx, s.cfg, used)
 	for slot := uint32(1); slot <= maxSlot; slot++ {
 		if _, ok := used[slot]; !ok {
 			return manager.SpecForSlot(sandboxID, slot)
 		}
 	}
 	return nil, fmt.Errorf("no internal sandbox network slots available")
+}
+
+func (s *artifactService) internalSandboxNetworkSpecForTemplateBuild(ctx context.Context, sandboxID string) (*novitaboxv1.NetworkSpec, error) {
+	cfg := s.cfg
+	cfg.Network.Enabled = true
+	manager := newSandboxNetworkManager(cfg)
+	maxSlot, err := manager.MaxSlots()
+	if err != nil {
+		return nil, err
+	}
+	used := map[uint32]struct{}{}
+	if s.store != nil {
+		records, err := s.store.ListSandboxes(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, record := range records {
+			if record.NetworkSlot > 0 {
+				used[record.NetworkSlot] = struct{}{}
+			}
+		}
+	}
+	markUsedNetworkSlotsFromHostRoutes(ctx, cfg, used)
+	for slot := uint32(1); slot <= maxSlot; slot++ {
+		if _, ok := used[slot]; !ok {
+			return manager.SpecForSlot(sandboxID, slot)
+		}
+	}
+	return nil, fmt.Errorf("no internal sandbox network slots available")
+}
+
+func markUsedNetworkSlotsFromHostRoutes(ctx context.Context, cfg config.Config, used map[uint32]struct{}) {
+	out, err := exec.CommandContext(ctx, "ip", "route", "show").Output()
+	if err != nil {
+		return
+	}
+	markUsedNetworkSlotsFromRouteOutput(cfg.Network.HostAccessCIDR, string(out), used)
+}
+
+func markUsedNetworkSlotsFromRouteOutput(hostAccessCIDR string, routeOutput string, used map[uint32]struct{}) {
+	for _, line := range strings.Split(routeOutput, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		hostAccessIP := strings.TrimSuffix(fields[0], "/32")
+		slot, err := networkSlotFromHostAccessIP(hostAccessCIDR, hostAccessIP)
+		if err != nil {
+			continue
+		}
+		used[slot] = struct{}{}
+	}
 }
 
 func templateKernelArgs(configured []string) []string {
@@ -1324,32 +1868,42 @@ type templateBuildAgentURLs struct {
 	exec   string
 }
 
-func templateBuildAgentURL(cfg config.Config, buildID string, networkSpec *novitaboxv1.NetworkSpec) (templateBuildAgentURLs, error) {
+const templateBuildExecTimeout = 10 * time.Minute
+
+func templateBuildAgentURL(cfg config.Config, buildID string, networkSpec *novitaboxv1.NetworkSpec, runtimeDriver string) (templateBuildAgentURLs, error) {
 	if cfg.Template.AgentHealthURL != "" || cfg.Template.AgentExecURL != "" {
 		return templateBuildAgentURLs{
 			health: cfg.Template.AgentHealthURL,
 			exec:   cfg.Template.AgentExecURL,
 		}, nil
 	}
-	if !cfg.Network.Enabled {
-		return templateBuildAgentURLs{}, nil
-	}
-	hostIP := ""
-	if networkSpec != nil {
-		hostIP = networkSpec.GetHostAccessIp()
-	}
-	if hostIP == "" {
-		return templateBuildAgentURLs{}, fmt.Errorf("template build %q agent host access ip is empty", buildID)
-	}
 	_, port, err := net.SplitHostPort(cfg.Boxd.Addr)
 	if err != nil {
 		return templateBuildAgentURLs{}, fmt.Errorf("parse boxd address %q: %w", cfg.Boxd.Addr, err)
+	}
+	if networkSpec == nil || networkSpec.GetHostAccessIp() == "" {
+		baseURL := "http://127.0.0.1:" + port
+		return templateBuildAgentURLs{
+			health: baseURL + "/healthz",
+			exec:   baseURL + "/exec",
+		}, nil
+	}
+	hostIP, err := templateBuildAgentHostIP(networkSpec)
+	if err != nil {
+		return templateBuildAgentURLs{}, err
 	}
 	baseURL := "http://" + net.JoinHostPort(hostIP, port)
 	return templateBuildAgentURLs{
 		health: baseURL + "/healthz",
 		exec:   baseURL + "/exec",
 	}, nil
+}
+
+func templateBuildAgentHostIP(networkSpec *novitaboxv1.NetworkSpec) (string, error) {
+	if networkSpec == nil {
+		return "", nil
+	}
+	return networkSpec.GetHostAccessIp(), nil
 }
 
 func (s *artifactService) waitTemplateRuntimeReady(ctx context.Context, healthURL string) error {
@@ -1425,7 +1979,7 @@ func templateBuildStepCommand(step *novitaboxv1.TemplateBuildStep) []string {
 }
 
 func execTemplateCommand(ctx context.Context, url string, cmd []string, envVars map[string]string) error {
-	return execTemplateCommandWithClient(ctx, url, cmd, envVars, &http.Client{Timeout: 30 * time.Second})
+	return execTemplateCommandWithClient(ctx, url, cmd, envVars, &http.Client{Timeout: templateBuildExecTimeout})
 }
 
 func execTemplateCommandWithClient(ctx context.Context, url string, cmd []string, envVars map[string]string, client *http.Client) error {
@@ -1500,33 +2054,48 @@ func waitHTTPHealthWithClient(ctx context.Context, url string, timeout time.Dura
 	return fmt.Errorf("wait for template agent health %q timed out: %w", url, lastErr)
 }
 
-func (s *artifactService) materializeTemplateRootfs(ctx context.Context, req *novitaboxv1.CreateTemplateRequest, dest string) error {
+func (s *artifactService) materializeTemplateRootfs(ctx context.Context, req *novitaboxv1.CreateTemplateRequest, dest string, runtimeDriver string) error {
 	switch {
 	case req.GetFromTemplate() != "":
 		source, err := s.store.GetTemplate(ctx, req.GetFromTemplate())
 		if err != nil {
 			return fmt.Errorf("get source template %q: %w", req.GetFromTemplate(), err)
 		}
-		return cloneOrCopyFile(source.RootfsPath, dest)
+		if isGVisorRuntimeDriver(runtimeDriver) {
+			if info, statErr := os.Stat(source.RootfsPath); statErr != nil || !info.IsDir() {
+				return fmt.Errorf("gvisor template build requires a directory rootfs source, got %q", source.RootfsPath)
+			}
+		}
+		return cloneOrCopyPath(source.RootfsPath, dest)
 	case req.GetImageId() != "":
 		source, err := s.store.GetImage(ctx, req.GetImageId())
 		if err != nil {
 			return fmt.Errorf("get source image %q: %w", req.GetImageId(), err)
 		}
-		return cloneOrCopyFile(source.RootfsPath, dest)
+		if isGVisorRuntimeDriver(runtimeDriver) {
+			if info, statErr := os.Stat(source.RootfsPath); statErr != nil || !info.IsDir() {
+				return fmt.Errorf("gvisor template build requires a directory rootfs source, got %q", source.RootfsPath)
+			}
+		}
+		return cloneOrCopyPath(source.RootfsPath, dest)
 	case req.GetDockerImage() != "":
-		return s.materializeDockerImage(ctx, req.GetDockerImage(), dest)
+		return s.materializeDockerImage(ctx, req.GetDockerImage(), dest, runtimeDriver)
 	case req.GetSandboxId() != "":
 		source := sandboxRuntimePaths(s.cfg.RootDir, req.GetSandboxId()).RootfsPath
-		return cloneOrCopyFile(source, dest)
+		if isGVisorRuntimeDriver(runtimeDriver) {
+			if info, statErr := os.Stat(source); statErr != nil || !info.IsDir() {
+				return fmt.Errorf("gvisor template build requires a directory rootfs source, got %q", source)
+			}
+		}
+		return cloneOrCopyPath(source, dest)
 	default:
 		return errors.New("one of from_template, image_id, docker_image, or sandbox_id is required")
 	}
 }
 
-func (s *artifactService) materializeDockerImage(ctx context.Context, image string, dest string) error {
+func (s *artifactService) materializeDockerImage(ctx context.Context, image string, dest string, runtimeDriver string) error {
 	if isLocalFile(image) {
-		return cloneOrCopyFile(image, dest)
+		return cloneOrCopyPath(image, dest)
 	}
 
 	s.logger.Info("exporting docker image to rootfs", "image", image, "dest", dest)
@@ -1570,6 +2139,13 @@ func (s *artifactService) materializeDockerImage(ctx context.Context, image stri
 		return fmt.Errorf("extract docker rootfs failed: %w: %s", err, strings.TrimSpace(string(output)))
 	}
 
+	if isGVisorRuntimeDriver(runtimeDriver) {
+		s.logger.Info("creating directory rootfs from docker export", "image", image, "dest", dest)
+		if err := cloneOrCopyPath(rootfsDir, dest); err != nil {
+			return err
+		}
+		return nil
+	}
 	s.logger.Info("creating ext4 rootfs from docker export", "image", image, "dest", dest)
 	if err := createExt4FromDir(ctx, rootfsDir, dest); err != nil {
 		return err
@@ -1629,12 +2205,26 @@ func (s *artifactService) DeleteTemplate(ctx context.Context, req *novitaboxv1.D
 		return nil, err
 	}
 	if record.RootfsPath != "" {
-		if err := os.RemoveAll(filepath.Dir(record.RootfsPath)); err != nil {
+		target := templateArtifactRemovalTarget(s.cfg.RootDir, req.GetTemplateId(), record.RootfsPath)
+		if err := os.RemoveAll(target); err != nil {
 			return nil, fmt.Errorf("remove template artifact directory: %w", err)
 		}
 	}
 
 	return &emptypb.Empty{}, nil
+}
+
+func templateArtifactRemovalTarget(rootDir string, templateID string, rootfsPath string) string {
+	templateDir := layout.New(rootDir).TemplateDir(templateID)
+	cleanRootfs := filepath.Clean(rootfsPath)
+	cleanTemplateDir := filepath.Clean(templateDir)
+	if cleanRootfs == cleanTemplateDir || strings.HasPrefix(cleanRootfs, cleanTemplateDir+string(os.PathSeparator)) {
+		return cleanTemplateDir
+	}
+	if info, err := os.Stat(cleanRootfs); err == nil && info.IsDir() {
+		return cleanRootfs
+	}
+	return filepath.Dir(cleanRootfs)
 }
 
 func (s *artifactService) CreateImage(ctx context.Context, req *novitaboxv1.CreateImageRequest) (*novitaboxv1.ImageInfo, error) {
@@ -1658,8 +2248,18 @@ func (s *artifactService) CreateImage(ctx context.Context, req *novitaboxv1.Crea
 		return nil, fmt.Errorf("create image directory: %w", err)
 	}
 
+	template, err := s.store.GetTemplate(ctx, req.GetTemplateId())
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, status.Error(codes.NotFound, "template not found")
+		}
+		return nil, err
+	}
 	rootfsPath := filepath.Join(imageDir, "rootfs.ext4")
-	if err := s.materializeImageRootfs(ctx, req, rootfsPath); err != nil {
+	if template.MemfilePath == "" || template.SnapfilePath == "" {
+		rootfsPath = filepath.Join(imageDir, "rootfs")
+	}
+	if err := s.exportTemplateImageRootfs(ctx, *template, rootfsPath); err != nil {
 		return nil, err
 	}
 
@@ -1712,17 +2312,21 @@ func (s *artifactService) exportTemplateImageRootfs(ctx context.Context, templat
 		return status.Error(codes.InvalidArgument, "template rootfs is required")
 	}
 	if template.MemfilePath == "" || template.SnapfilePath == "" {
-		return status.Error(codes.InvalidArgument, "template snapshot is required")
+		return cloneOrCopyPath(template.RootfsPath, dest)
 	}
 	if strings.EqualFold(s.cfg.Boxshim.RuntimeDriver, "stub") {
-		return cloneOrCopyFile(template.RootfsPath, dest)
+		return cloneOrCopyPath(template.RootfsPath, dest)
 	}
 
-	buildID := "image-build-" + filepath.Base(filepath.Dir(dest))
+	buildID, err := newInternalBuildID()
+	if err != nil {
+		return fmt.Errorf("generate image build id: %w", err)
+	}
 	l := layout.New(s.cfg.RootDir)
 	buildDir := l.SandboxDir(buildID)
 	paths := sandboxRuntimePaths(s.cfg.RootDir, buildID)
 	var internalNetworkSlot uint32
+	success := false
 
 	if err := os.RemoveAll(buildDir); err != nil {
 		return fmt.Errorf("remove stale image build sandbox: %w", err)
@@ -1731,25 +2335,29 @@ func (s *artifactService) exportTemplateImageRootfs(ctx context.Context, templat
 		return fmt.Errorf("create image build snapshot directory: %w", err)
 	}
 	defer func() {
-		if err := cleanupInternalSandbox(context.Background(), s.cfg, buildID, internalNetworkSlot); err != nil {
+		if !success {
+			return
+		}
+		if err := cleanupInternalSandbox(context.Background(), s.cfg, buildID, internalNetworkSlot, novitaboxv1.RuntimeType_RUNTIME_TYPE_FIRECRACKER); err != nil {
 			s.logger.Warn("cleanup image build sandbox failed", "sandbox_id", buildID, "error", err)
 		}
 	}()
 
-	if err := cloneOrCopyFile(template.MemfilePath, paths.MemfilePath); err != nil {
+	if err := cloneOrCopyPath(template.MemfilePath, paths.MemfilePath); err != nil {
 		return fmt.Errorf("prepare image build memfile from template %q: %w", template.ID, err)
 	}
-	if err := cloneOrCopyFile(template.SnapfilePath, paths.SnapfilePath); err != nil {
+	if err := cloneOrCopyPath(template.SnapfilePath, paths.SnapfilePath); err != nil {
 		return fmt.Errorf("prepare image build snapfile from template %q: %w", template.ID, err)
 	}
-	if s.cfg.Template.KernelPath != "" {
-		if err := linkOrCopyFile(s.cfg.Template.KernelPath, paths.KernelPath); err != nil {
-			return fmt.Errorf("prepare image build kernel: %w", err)
-		}
+	if s.cfg.Template.KernelPath == "" {
+		return errors.New("image export from template requires --template-kernel")
+	}
+	if err := linkOrCopyFile(s.cfg.Template.KernelPath, paths.KernelPath); err != nil {
+		return fmt.Errorf("prepare image build kernel: %w", err)
 	}
 
 	shimSocket := filepath.Join(buildDir, "shim.sock")
-	if err := ensureShim(ctx, s.cfg, shimSocket); err != nil {
+	if err := ensureShim(ctx, s.cfg, shimSocket, "firecracker"); err != nil {
 		return fmt.Errorf("start image build shim: %w", err)
 	}
 
@@ -1770,10 +2378,7 @@ func (s *artifactService) exportTemplateImageRootfs(ctx context.Context, templat
 	if err := s.attachAgentDrive(ctx, spec); err != nil {
 		return err
 	}
-	if strings.EqualFold(s.cfg.Boxshim.RuntimeDriver, "firecracker") && spec.GetKernel().GetKernelPath() == "" {
-		return errors.New("image export from template requires --template-kernel")
-	}
-	if err := newSandboxNetworkManager(s.cfg).Ensure(ctx, spec.GetNetwork()); err != nil {
+	if err := newSandboxNetworkManager(s.cfg).Prepare(ctx, spec.GetRuntimeType(), spec.GetNetwork()); err != nil {
 		return fmt.Errorf("prepare image build network: %w", err)
 	}
 
@@ -1787,18 +2392,18 @@ func (s *artifactService) exportTemplateImageRootfs(ctx context.Context, templat
 		}); err != nil {
 			return fmt.Errorf("stop image build runtime: %w", err)
 		}
-		if err := cloneOrCopyFile(workRootfsPath, dest); err != nil {
+		if err := cloneOrCopyPath(workRootfsPath, dest); err != nil {
 			return fmt.Errorf("export image rootfs from template %q: %w", template.ID, err)
 		}
+		success = true
 		return nil
 	})
 }
 
 func (s *artifactService) imageBuildRuntimeSpec(sandboxID string, rootfsPath string, paths sandboxRuntimeArtifactPaths, networkSpec *novitaboxv1.NetworkSpec) *novitaboxv1.RuntimeSpec {
-	runtimeType := runtimeTypeFromRecord(s.cfg.Boxshim.RuntimeDriver)
 	spec := &novitaboxv1.RuntimeSpec{
 		SandboxId:   sandboxID,
-		RuntimeType: runtimeType,
+		RuntimeType: novitaboxv1.RuntimeType_RUNTIME_TYPE_FIRECRACKER,
 		Machine: &novitaboxv1.MachineSpec{
 			Vcpu:     s.cfg.Template.VCPU,
 			MemoryMb: s.cfg.Template.MemoryMB,
@@ -1823,9 +2428,6 @@ func (s *artifactService) imageBuildRuntimeSpec(sandboxID string, rootfsPath str
 			Port:     49983,
 		},
 	}
-	if s.cfg.Template.KernelPath == "" && !strings.EqualFold(s.cfg.Boxshim.RuntimeDriver, "firecracker") {
-		spec.Kernel.KernelPath = ""
-	}
 	return spec
 }
 
@@ -1838,7 +2440,7 @@ func (s *artifactService) attachAgentDrive(ctx context.Context, spec *novitaboxv
 }
 
 func attachAgentDrive(ctx context.Context, cfg config.Config, spec *novitaboxv1.RuntimeSpec) error {
-	if spec == nil || strings.EqualFold(cfg.Boxshim.RuntimeDriver, "stub") {
+	if spec == nil || strings.EqualFold(cfg.Boxshim.RuntimeDriver, "stub") || spec.GetRuntimeType() == novitaboxv1.RuntimeType_RUNTIME_TYPE_CONTAINER {
 		return nil
 	}
 	agentPath, err := ensureAgentImage(ctx, cfg)
@@ -1964,7 +2566,8 @@ func restoreTemplateRootfs(rootfsPath string, backupPath string) error {
 	return nil
 }
 
-func cleanupInternalSandbox(ctx context.Context, cfg config.Config, sandboxID string, networkSlot uint32) error {
+func cleanupInternalSandbox(ctx context.Context, cfg config.Config, sandboxID string, networkSlot uint32, runtimeType novitaboxv1.RuntimeType) error {
+	_ = runtimeType
 	sandboxDir := layout.New(cfg.RootDir).SandboxDir(sandboxID)
 	shimSocket := filepath.Join(sandboxDir, "shim.sock")
 	if shim, closeShim, err := dialShim(ctx, shimSocket); err == nil {
@@ -1979,7 +2582,17 @@ func cleanupInternalSandbox(ctx context.Context, cfg config.Config, sandboxID st
 			return err
 		}
 	}
-	return os.RemoveAll(sandboxDir)
+	return removeSandboxDirectory(sandboxDir)
+}
+
+func removeSandboxDirectory(sandboxDir string) error {
+	if err := shimruntime.UnmountUnder(sandboxDir); err != nil {
+		return fmt.Errorf("unmount sandbox mounts: %w", err)
+	}
+	if err := os.RemoveAll(sandboxDir); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *artifactService) ListImages(ctx context.Context, _ *novitaboxv1.ListImagesRequest) (*novitaboxv1.ListImagesResponse, error) {
@@ -2047,7 +2660,12 @@ type artifactPaths struct {
 	SnapfilePath string
 }
 
-func templateArtifactPaths(dir string) artifactPaths {
+func templateArtifactPaths(dir string, runtimeDriver string) artifactPaths {
+	if isGVisorRuntimeDriver(runtimeDriver) {
+		return artifactPaths{
+			RootfsPath: filepath.Join(dir, "rootfs"),
+		}
+	}
 	return artifactPaths{
 		RootfsPath:   filepath.Join(dir, "rootfs.ext4"),
 		MemfilePath:  filepath.Join(dir, "memfile"),
@@ -2067,6 +2685,10 @@ func copyFile(src string, dst string) error {
 	if filepath.Clean(src) == filepath.Clean(dst) {
 		return nil
 	}
+	info, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source %q: %w", src, err)
+	}
 	in, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("open source %q: %w", src, err)
@@ -2080,13 +2702,18 @@ func copyFile(src string, dst string) error {
 	if err != nil {
 		return fmt.Errorf("open destination %q: %w", dst, err)
 	}
-	defer out.Close()
 
 	if _, err := io.Copy(out, in); err != nil {
 		return fmt.Errorf("copy %q to %q: %w", src, dst, err)
 	}
 	if err := out.Sync(); err != nil {
 		return fmt.Errorf("sync destination %q: %w", dst, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close destination %q: %w", dst, err)
+	}
+	if err := os.Chmod(dst, portableFileMode(info.Mode())); err != nil {
+		return fmt.Errorf("chmod destination %q: %w", dst, err)
 	}
 
 	return nil
@@ -2096,10 +2723,87 @@ func cloneOrCopyFile(src string, dst string) error {
 	if filepath.Clean(src) == filepath.Clean(dst) {
 		return nil
 	}
+	info, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source %q: %w", src, err)
+	}
 	if err := reflinkFile(src, dst); err == nil {
+		if err := os.Chmod(dst, portableFileMode(info.Mode())); err != nil {
+			return fmt.Errorf("chmod destination %q: %w", dst, err)
+		}
 		return nil
 	}
 	return copyFile(src, dst)
+}
+
+func cloneOrCopyPath(src string, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source %q: %w", src, err)
+	}
+	if info.IsDir() {
+		return copyDir(src, dst)
+	}
+	return cloneOrCopyFile(src, dst)
+}
+
+func copyDir(src string, dst string) error {
+	if filepath.Clean(src) == filepath.Clean(dst) {
+		return nil
+	}
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source dir %q: %w", src, err)
+	}
+	if err := os.RemoveAll(dst); err != nil {
+		return fmt.Errorf("remove destination dir %q: %w", dst, err)
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return fmt.Errorf("create destination dir %q: %w", dst, err)
+	}
+	if err := os.Chmod(dst, portableFileMode(srcInfo.Mode())); err != nil {
+		return fmt.Errorf("chmod destination dir %q: %w", dst, err)
+	}
+	return filepath.Walk(src, func(current string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if current == src {
+			return nil
+		}
+		rel, err := filepath.Rel(src, current)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if info.Mode()&os.ModeSymlink != 0 {
+			linkTarget, err := os.Readlink(current)
+			if err != nil {
+				return err
+			}
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			if err := os.RemoveAll(target); err != nil {
+				return err
+			}
+			return os.Symlink(linkTarget, target)
+		}
+		if info.IsDir() {
+			if err := os.MkdirAll(target, portableFileMode(info.Mode())); err != nil {
+				return err
+			}
+			return os.Chmod(target, portableFileMode(info.Mode()))
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		return cloneOrCopyFile(current, target)
+	})
+}
+
+func portableFileMode(mode os.FileMode) os.FileMode {
+	return mode & (os.ModePerm | os.ModeSetuid | os.ModeSetgid | os.ModeSticky)
 }
 
 func linkOrCopyFile(src string, dst string) error {
@@ -2159,6 +2863,43 @@ func templateRecordToProto(record store.TemplateRecord) *novitaboxv1.TemplateInf
 	}
 }
 
+func isGVisorRuntimeDriver(runtimeDriver string) bool {
+	switch strings.ToLower(strings.TrimSpace(runtimeDriver)) {
+	case "gvisor", "container", "runtime_type_container":
+		return true
+	default:
+		return false
+	}
+}
+
+func keepFailedGVisorTemplateBuilds() bool {
+	value := strings.TrimSpace(strings.ToLower(os.Getenv("NOVITABOX_KEEP_FAILED_GVISOR_TEMPLATE_BUILDS")))
+	switch value {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func holdGVisorTemplateBuildSandbox() bool {
+	value := strings.TrimSpace(strings.ToLower(os.Getenv("NOVITABOX_HOLD_GVISOR_TEMPLATE_BUILDS")))
+	switch value {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func newInternalBuildID() (string, error) {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
 func imageRecordToProto(record store.ImageRecord) *novitaboxv1.ImageInfo {
 	return &novitaboxv1.ImageInfo{
 		ImageId:       record.ID,
@@ -2188,6 +2929,7 @@ func (s *nodeService) NodeStatus(context.Context, *novitaboxv1.NodeStatusRequest
 		Ready:   true,
 		RuntimeTypes: []novitaboxv1.RuntimeType{
 			novitaboxv1.RuntimeType_RUNTIME_TYPE_FIRECRACKER,
+			novitaboxv1.RuntimeType_RUNTIME_TYPE_CONTAINER,
 			novitaboxv1.RuntimeType_RUNTIME_TYPE_CLOUD_HYPERVISOR,
 		},
 	}, nil
@@ -2199,6 +2941,10 @@ func (s *nodeService) ListRuntimes(context.Context, *novitaboxv1.ListRuntimesReq
 			{
 				RuntimeType:  novitaboxv1.RuntimeType_RUNTIME_TYPE_FIRECRACKER,
 				Capabilities: firecrackerCapabilities(),
+			},
+			{
+				RuntimeType:  novitaboxv1.RuntimeType_RUNTIME_TYPE_CONTAINER,
+				Capabilities: gvisorCapabilities(),
 			},
 			{
 				RuntimeType:  novitaboxv1.RuntimeType_RUNTIME_TYPE_CLOUD_HYPERVISOR,
@@ -2214,6 +2960,8 @@ func (s *nodeService) GetRuntimeCapabilities(_ context.Context, req *novitaboxv1
 		return firecrackerCapabilities(), nil
 	case novitaboxv1.RuntimeType_RUNTIME_TYPE_CLOUD_HYPERVISOR:
 		return cloudHypervisorCapabilities(), nil
+	case novitaboxv1.RuntimeType_RUNTIME_TYPE_CONTAINER:
+		return gvisorCapabilities(), nil
 	default:
 		return &novitaboxv1.RuntimeCapabilities{}, nil
 	}
@@ -2254,5 +3002,23 @@ func cloudHypervisorCapabilities() *novitaboxv1.RuntimeCapabilities {
 		GracefulShutdown:  true,
 		SerialConsole:     true,
 		Jailer:            true,
+	}
+}
+
+func gvisorCapabilities() *novitaboxv1.RuntimeCapabilities {
+	return &novitaboxv1.RuntimeCapabilities{
+		StartFromImage:    true,
+		StartFromTemplate: true,
+		StartFromSnapshot: false,
+		Pause:             false,
+		Resume:            false,
+		FullSnapshot:      false,
+		DiffSnapshot:      false,
+		Gpu:               true,
+		Vsock:             false,
+		TapNetwork:        false,
+		GracefulShutdown:  true,
+		SerialConsole:     false,
+		Jailer:            false,
 	}
 }

--- a/internal/boxshim/runtime/firecracker.go
+++ b/internal/boxshim/runtime/firecracker.go
@@ -1009,6 +1009,10 @@ func unmountUnder(root string) error {
 	return nil
 }
 
+func UnmountUnder(root string) error {
+	return unmountUnder(root)
+}
+
 func mountPointsUnder(root string) ([]string, error) {
 	root = filepath.Clean(root)
 	data, err := os.ReadFile("/proc/self/mountinfo")

--- a/internal/boxshim/runtime/gvisor.go
+++ b/internal/boxshim/runtime/gvisor.go
@@ -1,0 +1,1061 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/goccy/go-yaml"
+	"github.com/novitalabs/NovitaBox/internal/config"
+	"github.com/novitalabs/NovitaBox/internal/log"
+	novitaboxv1 "github.com/novitalabs/NovitaBox/internal/pb/novitabox/v1"
+	"github.com/novitalabs/NovitaBox/internal/storage/layout"
+)
+
+const (
+	gvisorStateDirName = "runsc"
+	gvisorBundleName   = "bundle"
+	gvisorLogName      = "runsc.log"
+	gvisorNetNSDir     = "/var/run/netns"
+)
+
+type GVisorDriver struct {
+	cfg    config.Config
+	logger *log.Logger
+
+	mu      sync.Mutex
+	info    *novitaboxv1.RuntimeInfo
+	spec    *novitaboxv1.RuntimeSpec
+	stopped bool
+}
+
+func NewGVisorDriver(cfg config.Config, logger *log.Logger) *GVisorDriver {
+	return &GVisorDriver{cfg: cfg, logger: logger}
+}
+
+func (d *GVisorDriver) Create(ctx context.Context, spec *novitaboxv1.RuntimeSpec) (*novitaboxv1.RuntimeInfo, error) {
+	return d.start(ctx, spec, "create")
+}
+
+func (d *GVisorDriver) Start(ctx context.Context, spec *novitaboxv1.RuntimeSpec) (*novitaboxv1.RuntimeInfo, error) {
+	return d.start(ctx, spec, "start")
+}
+
+func (d *GVisorDriver) Resume(context.Context, *novitaboxv1.RuntimeSpec) (*novitaboxv1.RuntimeInfo, error) {
+	return nil, errors.New("gvisor resume is not supported yet")
+}
+
+func (d *GVisorDriver) Pause(context.Context, string) (*novitaboxv1.RuntimeInfo, error) {
+	return nil, errors.New("gvisor pause is not supported yet")
+}
+
+func (d *GVisorDriver) Kill(ctx context.Context, sandboxID string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if err := d.checkSandboxLocked(sandboxID); err != nil {
+		return err
+	}
+	if err := d.stopLocked(ctx, sandboxID, 0, true); err != nil {
+		return err
+	}
+	d.info.State = novitaboxv1.RuntimeState_RUNTIME_STATE_EXITED
+	d.info.Pid = 0
+	d.stopped = true
+	return nil
+}
+
+func (d *GVisorDriver) Stop(ctx context.Context, sandboxID string, timeout time.Duration) (*novitaboxv1.RuntimeInfo, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if err := d.checkSandboxLocked(sandboxID); err != nil {
+		return nil, err
+	}
+	if err := d.stopLocked(ctx, sandboxID, timeout, false); err != nil {
+		return nil, err
+	}
+	d.info.State = novitaboxv1.RuntimeState_RUNTIME_STATE_STOPPED
+	d.info.Pid = 0
+	d.stopped = true
+	return cloneRuntimeInfo(d.info), nil
+}
+
+func (d *GVisorDriver) Reboot(ctx context.Context, sandboxID string, timeout time.Duration) (*novitaboxv1.RuntimeInfo, error) {
+	d.mu.Lock()
+	if err := d.checkSandboxLocked(sandboxID); err != nil {
+		d.mu.Unlock()
+		return nil, err
+	}
+	spec := d.spec
+	if err := d.stopLocked(ctx, sandboxID, timeout, false); err != nil {
+		d.mu.Unlock()
+		return nil, err
+	}
+	d.mu.Unlock()
+
+	return d.start(ctx, spec, "reboot")
+}
+
+func (d *GVisorDriver) Status(_ context.Context, sandboxID string) (*novitaboxv1.RuntimeInfo, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.info == nil {
+		return &novitaboxv1.RuntimeInfo{
+			SandboxId:   sandboxID,
+			RuntimeType: novitaboxv1.RuntimeType_RUNTIME_TYPE_CONTAINER,
+			State:       novitaboxv1.RuntimeState_RUNTIME_STATE_UNKNOWN,
+		}, nil
+	}
+	if sandboxID != "" && d.info.GetSandboxId() != sandboxID {
+		return nil, fmt.Errorf("runtime sandbox mismatch: have %q, got %q", d.info.GetSandboxId(), sandboxID)
+	}
+
+	return cloneRuntimeInfo(d.info), nil
+}
+
+func (d *GVisorDriver) Capabilities(context.Context, novitaboxv1.RuntimeType) (*novitaboxv1.RuntimeCapabilities, error) {
+	return gvisorCapabilities(), nil
+}
+
+func (d *GVisorDriver) start(ctx context.Context, spec *novitaboxv1.RuntimeSpec, action string) (*novitaboxv1.RuntimeInfo, error) {
+	spec, err := normalizeSpec(spec)
+	if err != nil {
+		return nil, err
+	}
+	spec.RuntimeType = novitaboxv1.RuntimeType_RUNTIME_TYPE_CONTAINER
+	if err := validateGVisorSpec(d.cfg, spec); err != nil {
+		return nil, err
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.info != nil && !d.stopped && d.info.GetState() == novitaboxv1.RuntimeState_RUNTIME_STATE_RUNNING {
+		return nil, fmt.Errorf("runtime for sandbox %q is already running", d.info.GetSandboxId())
+	}
+
+	paths := d.paths(spec.GetSandboxId())
+	_ = unmountUnder(paths.sandboxDir)
+	if err := os.RemoveAll(paths.bundleDir); err != nil {
+		return nil, fmt.Errorf("remove stale gvisor bundle: %w", err)
+	}
+	if err := os.RemoveAll(paths.stateDir); err != nil {
+		return nil, fmt.Errorf("remove stale gvisor state dir: %w", err)
+	}
+	if err := os.MkdirAll(paths.bundleDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create gvisor bundle: %w", err)
+	}
+	if err := os.MkdirAll(paths.stateDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create gvisor state dir: %w", err)
+	}
+	if err := writeGVisorBundleConfig(d.cfg, spec, filepath.Join(paths.bundleDir, "config.json")); err != nil {
+		return nil, err
+	}
+
+	_ = d.runsc(ctx, paths, false, "delete", "--force", spec.GetSandboxId())
+	gpuEnabled := spec.GetMachine().GetGpu() > 0
+	if err := d.runsc(ctx, paths, gpuEnabled, "create", "--bundle", paths.bundleDir, spec.GetSandboxId()); err != nil {
+		_ = d.runsc(context.Background(), paths, false, "delete", "--force", spec.GetSandboxId())
+		_ = unmountUnder(paths.sandboxDir)
+		return nil, fmt.Errorf("create gvisor container: %w", err)
+	}
+	if err := d.runsc(ctx, paths, gpuEnabled, "start", spec.GetSandboxId()); err != nil {
+		_ = d.runsc(context.Background(), paths, false, "delete", "--force", spec.GetSandboxId())
+		_ = unmountUnder(paths.sandboxDir)
+		return nil, fmt.Errorf("start gvisor container: %w", err)
+	}
+
+	info := &novitaboxv1.RuntimeInfo{
+		SandboxId:         spec.GetSandboxId(),
+		RuntimeType:       novitaboxv1.RuntimeType_RUNTIME_TYPE_CONTAINER,
+		State:             novitaboxv1.RuntimeState_RUNTIME_STATE_RUNNING,
+		Pid:               d.containerPID(ctx, paths, spec.GetSandboxId()),
+		ShimSocketPath:    d.cfg.Boxshim.SocketPath,
+		RuntimeSocketPath: paths.stateDir,
+	}
+	d.info = info
+	d.spec = spec
+	d.stopped = false
+
+	d.logger.Info("started gvisor runtime",
+		"sandbox_id", spec.GetSandboxId(),
+		"action", action,
+		"pid", info.GetPid(),
+		"rootfs", spec.GetRootfs().GetPath(),
+	)
+	return cloneRuntimeInfo(info), nil
+}
+
+func (d *GVisorDriver) stopLocked(ctx context.Context, sandboxID string, timeout time.Duration, force bool) error {
+	paths := d.paths(sandboxID)
+	defer func() {
+		_ = unmountUnder(paths.sandboxDir)
+	}()
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	if !force {
+		_ = d.runsc(ctx, paths, false, "kill", sandboxID, "TERM")
+		deadline := time.Now().Add(timeout)
+		for time.Now().Before(deadline) {
+			if d.containerPID(ctx, paths, sandboxID) == 0 {
+				_ = d.runsc(ctx, paths, false, "delete", "--force", sandboxID)
+				return nil
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(200 * time.Millisecond):
+			}
+		}
+	}
+	_ = d.runsc(ctx, paths, false, "kill", sandboxID, "KILL")
+	if err := d.runsc(ctx, paths, false, "delete", "--force", sandboxID); err != nil {
+		return fmt.Errorf("delete gvisor container: %w", err)
+	}
+	return nil
+}
+
+func (d *GVisorDriver) checkSandboxLocked(sandboxID string) error {
+	if sandboxID == "" {
+		return errors.New("sandbox_id is required")
+	}
+	if d.info == nil {
+		return fmt.Errorf("runtime for sandbox %q is not created", sandboxID)
+	}
+	if d.info.GetSandboxId() != sandboxID {
+		return fmt.Errorf("runtime sandbox mismatch: have %q, got %q", d.info.GetSandboxId(), sandboxID)
+	}
+	return nil
+}
+
+type gvisorPaths struct {
+	sandboxDir string
+	stateDir   string
+	bundleDir  string
+	logPath    string
+}
+
+func (d *GVisorDriver) paths(sandboxID string) gvisorPaths {
+	sandboxDir := layout.New(d.cfg.RootDir).SandboxDir(sandboxID)
+	return gvisorPaths{
+		sandboxDir: sandboxDir,
+		stateDir:   filepath.Join(sandboxDir, gvisorStateDirName),
+		bundleDir:  filepath.Join(sandboxDir, gvisorBundleName),
+		logPath:    filepath.Join(sandboxDir, gvisorLogName),
+	}
+}
+
+func (d *GVisorDriver) runsc(ctx context.Context, paths gvisorPaths, gpu bool, args ...string) error {
+	runsc := d.cfg.GVisor.RunscBinaryPath
+	if runsc == "" {
+		runsc = config.DefaultRunscBinaryPath(d.cfg.RootDir)
+	}
+	cmdArgs := []string{"--root", paths.stateDir, "--overlay2=none"}
+	if gpu {
+		cmdArgs = append(cmdArgs, "--nvproxy")
+	}
+	cmdArgs = append(cmdArgs, args...)
+	cmd := exec.CommandContext(ctx, runsc, cmdArgs...)
+	logFile, err := os.OpenFile(paths.logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open gvisor log: %w", err)
+	}
+	defer logFile.Close()
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runsc %s failed: %w", strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+func (d *GVisorDriver) containerPID(ctx context.Context, paths gvisorPaths, sandboxID string) int64 {
+	runsc := d.cfg.GVisor.RunscBinaryPath
+	if runsc == "" {
+		runsc = config.DefaultRunscBinaryPath(d.cfg.RootDir)
+	}
+	cmd := exec.CommandContext(ctx, runsc, "--root", paths.stateDir, "state", sandboxID)
+	data, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	var state struct {
+		Pid int64 `json:"pid"`
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		return 0
+	}
+	return state.Pid
+}
+
+func validateGVisorSpec(cfg config.Config, spec *novitaboxv1.RuntimeSpec) error {
+	if spec.GetRootfs() == nil || spec.GetRootfs().GetPath() == "" {
+		return errors.New("runtime_spec.rootfs.path is required for gvisor")
+	}
+	info, err := os.Stat(spec.GetRootfs().GetPath())
+	if err != nil {
+		return fmt.Errorf("stat gvisor rootfs: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("gvisor rootfs %q must be a directory", spec.GetRootfs().GetPath())
+	}
+	boxdPath := ContainerPathInRootfs(spec.GetRootfs().GetPath(), cfg.Template.BoxdGuestPath)
+	if _, err := os.Stat(boxdPath); err != nil {
+		return fmt.Errorf("stat gvisor boxd binary %q: %w", boxdPath, err)
+	}
+	return nil
+}
+
+func writeGVisorBundleConfig(cfg config.Config, spec *novitaboxv1.RuntimeSpec, dest string) error {
+	ociSpec, err := newGVisorOCISpec(cfg, spec)
+	if err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(ociSpec, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal gvisor OCI spec: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return fmt.Errorf("create gvisor bundle dir: %w", err)
+	}
+	if err := os.WriteFile(dest, data, 0o644); err != nil {
+		return fmt.Errorf("write gvisor OCI spec: %w", err)
+	}
+	return nil
+}
+
+type gvisorOCISpec struct {
+	OCIVersion string             `json:"ociVersion"`
+	Process    gvisorOCIProcess   `json:"process"`
+	Root       gvisorOCIRoot      `json:"root"`
+	Hostname   string             `json:"hostname,omitempty"`
+	Mounts     []gvisorOCIMount   `json:"mounts,omitempty"`
+	Hooks      *gvisorOCIHooks    `json:"hooks,omitempty"`
+	Linux      gvisorOCILinuxSpec `json:"linux"`
+}
+
+type gvisorOCIProcess struct {
+	Terminal        bool                  `json:"terminal"`
+	User            gvisorOCIUser         `json:"user"`
+	Args            []string              `json:"args"`
+	Env             []string              `json:"env"`
+	Cwd             string                `json:"cwd"`
+	Capabilities    gvisorOCICapabilities `json:"capabilities"`
+	Rlimits         []gvisorOCIRlimit     `json:"rlimits,omitempty"`
+	NoNewPrivileges bool                  `json:"noNewPrivileges"`
+}
+
+type gvisorOCIUser struct {
+	UID uint32 `json:"uid"`
+	GID uint32 `json:"gid"`
+}
+
+type gvisorOCICapabilities struct {
+	Bounding    []string `json:"bounding"`
+	Effective   []string `json:"effective"`
+	Inheritable []string `json:"inheritable"`
+	Permitted   []string `json:"permitted"`
+	Ambient     []string `json:"ambient"`
+}
+
+type gvisorOCIRlimit struct {
+	Type string `json:"type"`
+	Hard uint64 `json:"hard"`
+	Soft uint64 `json:"soft"`
+}
+
+type gvisorOCIRoot struct {
+	Path     string `json:"path"`
+	Readonly bool   `json:"readonly"`
+}
+
+type gvisorOCIMount struct {
+	Destination string   `json:"destination"`
+	Type        string   `json:"type"`
+	Source      string   `json:"source"`
+	Options     []string `json:"options,omitempty"`
+}
+
+type gvisorOCILinuxSpec struct {
+	Namespaces    []gvisorOCINamespace `json:"namespaces"`
+	MaskedPaths   []string             `json:"maskedPaths,omitempty"`
+	ReadonlyPaths []string             `json:"readonlyPaths,omitempty"`
+	Devices       []gvisorOCIDevice    `json:"devices,omitempty"`
+	Resources     gvisorOCIResources   `json:"resources"`
+}
+
+type gvisorOCIHooks struct {
+	Prestart []gvisorOCIHook `json:"prestart,omitempty"`
+}
+
+type gvisorOCIHook struct {
+	Path    string   `json:"path"`
+	Args    []string `json:"args,omitempty"`
+	Env     []string `json:"env,omitempty"`
+	Timeout *uint32  `json:"timeout,omitempty"`
+}
+
+type gvisorOCINamespace struct {
+	Type string `json:"type"`
+	Path string `json:"path,omitempty"`
+}
+
+type gvisorOCIResources struct {
+	Memory  *gvisorOCIMemory          `json:"memory,omitempty"`
+	CPU     *gvisorOCICPU             `json:"cpu,omitempty"`
+	Pids    *gvisorOCIPids            `json:"pids,omitempty"`
+	Devices []gvisorOCIResourceDevice `json:"devices,omitempty"`
+}
+
+type gvisorOCIResourceDevice struct {
+	Allow  bool   `json:"allow"`
+	Type   string `json:"type,omitempty"`
+	Major  *int64 `json:"major,omitempty"`
+	Minor  *int64 `json:"minor,omitempty"`
+	Access string `json:"access,omitempty"`
+}
+
+type gvisorOCIDevice struct {
+	Path     string `json:"path"`
+	Type     string `json:"type"`
+	Major    int64  `json:"major"`
+	Minor    int64  `json:"minor"`
+	FileMode uint32 `json:"fileMode,omitempty"`
+	UID      uint32 `json:"uid"`
+	GID      uint32 `json:"gid"`
+}
+
+type gvisorOCIMemory struct {
+	Limit *int64 `json:"limit,omitempty"`
+}
+
+type gvisorOCICPU struct {
+	Shares *uint64 `json:"shares,omitempty"`
+	Quota  *int64  `json:"quota,omitempty"`
+	Period *uint64 `json:"period,omitempty"`
+}
+
+type gvisorOCIPids struct {
+	Limit int64 `json:"limit"`
+}
+
+func newGVisorOCISpec(cfg config.Config, spec *novitaboxv1.RuntimeSpec) (gvisorOCISpec, error) {
+	boxdPath := cfg.Template.BoxdGuestPath
+	if boxdPath == "" {
+		boxdPath = "/novitabox/agent/boxd"
+	}
+	boxdRoot := path.Dir(path.Dir(boxdPath))
+	if boxdRoot == "." || boxdRoot == "/" {
+		boxdRoot = "/novitabox"
+	}
+	boxdAddr := cfg.Template.BoxdGuestAddr
+	if boxdAddr == "" {
+		boxdAddr = "0.0.0.0:49983"
+	}
+	caps := defaultContainerCapabilities()
+	period := uint64(100000)
+	quota := int64(spec.GetMachine().GetVcpu()) * int64(period)
+	if quota == 0 {
+		quota = int64(period)
+	}
+	memoryLimit := int64(spec.GetMachine().GetMemoryMb()) * 1024 * 1024
+	if memoryLimit == 0 {
+		memoryLimit = 512 * 1024 * 1024
+	}
+	namespaces := []gvisorOCINamespace{
+		{Type: "pid"},
+		{Type: "ipc"},
+		{Type: "uts"},
+		{Type: "mount"},
+	}
+	if spec.GetNetwork().GetNamespaceName() != "" {
+		namespaces = append(namespaces, gvisorOCINamespace{
+			Type: "network",
+			Path: filepath.Join(gvisorNetNSDir, spec.GetNetwork().GetNamespaceName()),
+		})
+	}
+	env := []string{
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"HOME=/root",
+		"TERM=xterm-256color",
+	}
+	gpuCount := spec.GetMachine().GetGpu()
+	cdiEdits, cdiFound, err := loadNvidiaCDIEdits(gpuCount)
+	if err != nil {
+		return gvisorOCISpec{}, err
+	}
+	var devices []gvisorOCIDevice
+	var deviceRules []gvisorOCIResourceDevice
+	if cdiFound {
+		env = append(env, cdiEdits.env...)
+		devices = append(devices, cdiEdits.devices...)
+		deviceRules = append(deviceRules, cdiEdits.rules...)
+		if len(devices) == 0 && gpuCount > 0 {
+			devices, deviceRules, err = nvidiaDeviceSpecs(gpuCount)
+			if err != nil {
+				return gvisorOCISpec{}, err
+			}
+		}
+	} else if gpuCount > 0 {
+		gpuEnv := nvidiaVisibleDevicesEnv(gpuCount)
+		env = append(env,
+			"NVIDIA_DRIVER_CAPABILITIES=compute,utility",
+			"CUDA_VISIBLE_DEVICES="+gpuEnv,
+			"NVIDIA_VISIBLE_DEVICES="+gpuEnv,
+		)
+		devices, deviceRules, err = nvidiaDeviceSpecs(gpuCount)
+		if err != nil {
+			return gvisorOCISpec{}, err
+		}
+	}
+	if gpuCount > 0 {
+		gpuEnv := nvidiaVisibleDevicesEnv(gpuCount)
+		env = setEnv(env,
+			"NVIDIA_DRIVER_CAPABILITIES=compute,utility",
+			"CUDA_VISIBLE_DEVICES="+gpuEnv,
+			"NVIDIA_VISIBLE_DEVICES="+gpuEnv,
+			"LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu/vdpau:/usr/lib64",
+		)
+	}
+	mounts := []gvisorOCIMount{
+		{Destination: "/proc", Type: "proc", Source: "proc", Options: []string{"nosuid", "noexec", "nodev"}},
+		{Destination: "/dev", Type: "tmpfs", Source: "tmpfs", Options: []string{"nosuid", "strictatime", "mode=755", "size=65536k"}},
+		{Destination: "/dev/pts", Type: "devpts", Source: "devpts", Options: []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"}},
+		{Destination: "/dev/shm", Type: "tmpfs", Source: "shm", Options: []string{"nosuid", "noexec", "nodev", "mode=1777", "size=65536k"}},
+		{Destination: "/sys", Type: "sysfs", Source: "sysfs", Options: []string{"nosuid", "noexec", "nodev", "ro"}},
+	}
+	mounts = append(mounts, cdiEdits.mounts...)
+	ociHooks := cdiEdits.hooks
+
+	return gvisorOCISpec{
+		OCIVersion: "1.0.2",
+		Process: gvisorOCIProcess{
+			Terminal:     false,
+			User:         gvisorOCIUser{UID: 0, GID: 0},
+			Args:         []string{boxdPath, "--root", boxdRoot, "--addr", boxdAddr},
+			Env:          env,
+			Cwd:          "/",
+			Capabilities: caps,
+			Rlimits: []gvisorOCIRlimit{
+				{Type: "RLIMIT_NOFILE", Hard: 4096, Soft: 4096},
+			},
+			NoNewPrivileges: false,
+		},
+		Root:     gvisorOCIRoot{Path: spec.GetRootfs().GetPath(), Readonly: spec.GetRootfs().GetReadonly()},
+		Hostname: spec.GetSandboxId(),
+		Mounts:   mounts,
+		Hooks:    ociHooks,
+		Linux: gvisorOCILinuxSpec{
+			Namespaces: namespaces,
+			Devices:    devices,
+			MaskedPaths: []string{
+				"/proc/acpi",
+				"/proc/kcore",
+				"/proc/keys",
+				"/proc/latency_stats",
+				"/proc/timer_list",
+				"/proc/timer_stats",
+				"/proc/sched_debug",
+				"/sys/firmware",
+			},
+			ReadonlyPaths: []string{
+				"/proc/asound",
+				"/proc/bus",
+				"/proc/fs",
+				"/proc/irq",
+				"/proc/sys",
+				"/proc/sysrq-trigger",
+			},
+			Resources: gvisorOCIResources{
+				Memory:  &gvisorOCIMemory{Limit: &memoryLimit},
+				CPU:     &gvisorOCICPU{Quota: &quota, Period: &period},
+				Pids:    &gvisorOCIPids{Limit: 512},
+				Devices: deviceRules,
+			},
+		},
+	}, nil
+}
+
+func defaultContainerCapabilities() gvisorOCICapabilities {
+	caps := []string{
+		"CAP_AUDIT_WRITE",
+		"CAP_CHOWN",
+		"CAP_DAC_OVERRIDE",
+		"CAP_FOWNER",
+		"CAP_FSETID",
+		"CAP_KILL",
+		"CAP_MKNOD",
+		"CAP_NET_BIND_SERVICE",
+		"CAP_NET_RAW",
+		"CAP_SETFCAP",
+		"CAP_SETGID",
+		"CAP_SETPCAP",
+		"CAP_SETUID",
+		"CAP_SYS_CHROOT",
+	}
+	return gvisorOCICapabilities{
+		Bounding:    caps,
+		Effective:   caps,
+		Inheritable: []string{},
+		Permitted:   caps,
+		Ambient:     []string{},
+	}
+}
+
+type nvidiaDeviceStat struct {
+	major int64
+	minor int64
+	mode  uint32
+	uid   uint32
+	gid   uint32
+}
+
+var statNvidiaDevice = readNvidiaDeviceStat
+
+func nvidiaDeviceSpecs(gpuCount uint32) ([]gvisorOCIDevice, []gvisorOCIResourceDevice, error) {
+	if gpuCount == 0 {
+		return nil, nil, nil
+	}
+
+	paths := []string{"/dev/nvidiactl", "/dev/nvidia-uvm"}
+	for i := uint32(0); i < gpuCount; i++ {
+		paths = append(paths, "/dev/nvidia"+strconv.FormatUint(uint64(i), 10))
+	}
+
+	devices := make([]gvisorOCIDevice, 0, len(paths))
+	rules := make([]gvisorOCIResourceDevice, 0, len(paths))
+	for _, devicePath := range paths {
+		st, err := statNvidiaDevice(devicePath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("stat nvidia device %q: %w", devicePath, err)
+		}
+		major := st.major
+		minor := st.minor
+		devices = append(devices, gvisorOCIDevice{
+			Path:     devicePath,
+			Type:     "c",
+			Major:    major,
+			Minor:    minor,
+			FileMode: st.mode,
+			UID:      st.uid,
+			GID:      st.gid,
+		})
+		rules = append(rules, gvisorOCIResourceDevice{
+			Allow:  true,
+			Type:   "c",
+			Major:  &major,
+			Minor:  &minor,
+			Access: "rwm",
+		})
+	}
+
+	return devices, rules, nil
+}
+
+func nvidiaVisibleDevicesEnv(gpuCount uint32) string {
+	if gpuCount == 0 {
+		return ""
+	}
+	values := make([]string, 0, gpuCount)
+	for i := uint32(0); i < gpuCount; i++ {
+		values = append(values, strconv.FormatUint(uint64(i), 10))
+	}
+	return strings.Join(values, ",")
+}
+
+type cdiNvidiaEdits struct {
+	env     []string
+	mounts  []gvisorOCIMount
+	hooks   *gvisorOCIHooks
+	devices []gvisorOCIDevice
+	rules   []gvisorOCIResourceDevice
+}
+
+type cdiSpecFile struct {
+	ContainerEdits *cdiContainerEdits `json:"containerEdits" yaml:"containerEdits"`
+	Devices        []cdiDevice        `json:"devices" yaml:"devices"`
+}
+
+type cdiDevice struct {
+	Name           string             `json:"name" yaml:"name"`
+	ContainerEdits *cdiContainerEdits `json:"containerEdits" yaml:"containerEdits"`
+}
+
+type cdiContainerEdits struct {
+	DeviceNodes []cdiDeviceNode `json:"deviceNodes" yaml:"deviceNodes"`
+	Env         []string        `json:"env" yaml:"env"`
+	Mounts      []cdiMount      `json:"mounts" yaml:"mounts"`
+	Hooks       []cdiHook       `json:"hooks" yaml:"hooks"`
+}
+
+type cdiDeviceNode struct {
+	Path     string  `json:"path" yaml:"path"`
+	Type     string  `json:"type" yaml:"type"`
+	Major    *int64  `json:"major,omitempty" yaml:"major,omitempty"`
+	Minor    *int64  `json:"minor,omitempty" yaml:"minor,omitempty"`
+	FileMode *uint32 `json:"fileMode,omitempty" yaml:"fileMode,omitempty"`
+	UID      *uint32 `json:"uid,omitempty" yaml:"uid,omitempty"`
+	GID      *uint32 `json:"gid,omitempty" yaml:"gid,omitempty"`
+}
+
+type cdiMount struct {
+	HostPath      string   `json:"hostPath" yaml:"hostPath"`
+	ContainerPath string   `json:"containerPath" yaml:"containerPath"`
+	Options       []string `json:"options,omitempty" yaml:"options,omitempty"`
+}
+
+type cdiHook struct {
+	HookName string   `json:"hookName" yaml:"hookName"`
+	Path     string   `json:"path" yaml:"path"`
+	Args     []string `json:"args,omitempty" yaml:"args,omitempty"`
+	Env      []string `json:"env,omitempty" yaml:"env,omitempty"`
+	Timeout  *uint32  `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+}
+
+func loadNvidiaCDIEdits(gpuCount uint32) (cdiNvidiaEdits, bool, error) {
+	if gpuCount == 0 {
+		return cdiNvidiaEdits{}, false, nil
+	}
+	spec, err := findNvidiaCDISpec()
+	if err != nil {
+		return cdiNvidiaEdits{}, false, err
+	}
+	if spec == "" {
+		return cdiNvidiaEdits{}, false, nil
+	}
+
+	parsed, err := readCDISpec(spec)
+	if err != nil {
+		return cdiNvidiaEdits{}, false, err
+	}
+
+	out := cdiNvidiaEdits{}
+	mergeCDIContainerEdits(&out, parsed.ContainerEdits)
+	selected := false
+	for i := uint32(0); i < gpuCount; i++ {
+		name := fmt.Sprintf("nvidia.com/gpu=%d", i)
+		if edit := findCDIDeviceEdit(parsed.Devices, name); edit != nil {
+			mergeCDIContainerEdits(&out, edit)
+			selected = true
+		}
+	}
+	if edit := findCDIDeviceEdit(parsed.Devices, "nvidia.com/gpu=all"); edit != nil {
+		mergeCDIContainerEdits(&out, edit)
+		selected = true
+	}
+	if !selected && len(parsed.Devices) > 0 {
+		limit := int(gpuCount)
+		if limit > len(parsed.Devices) {
+			limit = len(parsed.Devices)
+		}
+		for i := 0; i < limit; i++ {
+			mergeCDIContainerEdits(&out, parsed.Devices[i].ContainerEdits)
+		}
+	}
+	return out, true, nil
+}
+
+func findNvidiaCDISpec() (string, error) {
+	candidates := []string{
+		"/etc/cdi/nvidia.yaml",
+		"/etc/cdi/nvidia.yml",
+		"/etc/cdi/nvidia.json",
+		"/var/run/cdi/nvidia.yaml",
+		"/var/run/cdi/nvidia.yml",
+		"/var/run/cdi/nvidia.json",
+	}
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		} else if !os.IsNotExist(err) {
+			return "", err
+		}
+	}
+	return "", nil
+}
+
+func readCDISpec(path string) (*cdiSpecFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var spec cdiSpecFile
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("parse CDI spec %q: %w", path, err)
+	}
+	return &spec, nil
+}
+
+func findCDIDeviceEdit(devices []cdiDevice, name string) *cdiContainerEdits {
+	for i := range devices {
+		if devices[i].Name == name {
+			return devices[i].ContainerEdits
+		}
+	}
+	return nil
+}
+
+func mergeCDIContainerEdits(dst *cdiNvidiaEdits, edits *cdiContainerEdits) {
+	if edits == nil {
+		return
+	}
+	dst.env = append(dst.env, edits.Env...)
+	for _, node := range edits.DeviceNodes {
+		if node.Path == "" || node.Type == "" {
+			continue
+		}
+		nodeStat, err := readDeviceNodeStat(node.Path)
+		if err != nil {
+			nodeStat = nil
+		}
+		device := gvisorOCIDevice{
+			Path: node.Path,
+			Type: node.Type,
+			UID:  derefUint32(node.UID),
+			GID:  derefUint32(node.GID),
+		}
+		if nodeStat != nil {
+			device.UID = nodeStat.uid
+			device.GID = nodeStat.gid
+		}
+		if node.FileMode != nil {
+			device.FileMode = *node.FileMode
+		} else if nodeStat != nil {
+			device.FileMode = nodeStat.mode
+		}
+		if node.Major != nil {
+			device.Major = *node.Major
+		} else if nodeStat != nil {
+			device.Major = nodeStat.major
+		}
+		if node.Minor != nil {
+			device.Minor = *node.Minor
+		} else if nodeStat != nil {
+			device.Minor = nodeStat.minor
+		}
+		major := node.Major
+		minor := node.Minor
+		if nodeStat != nil {
+			major = &device.Major
+			minor = &device.Minor
+		}
+		dst.devices = append(dst.devices, device)
+		dst.rules = append(dst.rules, gvisorOCIResourceDevice{
+			Allow:  true,
+			Type:   node.Type,
+			Major:  major,
+			Minor:  minor,
+			Access: "rwm",
+		})
+	}
+	for _, mount := range edits.Mounts {
+		if mount.HostPath == "" || mount.ContainerPath == "" {
+			continue
+		}
+		dst.mounts = append(dst.mounts, gvisorOCIMount{
+			Source:      mount.HostPath,
+			Destination: mount.ContainerPath,
+			Type:        "bind",
+			Options:     append([]string{}, mount.Options...),
+		})
+	}
+	appendNvidiaLibrarySymlinkHooks(dst)
+	if len(edits.Hooks) > 0 {
+		if dst.hooks == nil {
+			dst.hooks = &gvisorOCIHooks{}
+		}
+		for _, hook := range edits.Hooks {
+			if hook.HookName != "" && hook.HookName != "createContainer" {
+				continue
+			}
+			if len(hook.Args) > 1 && hook.Args[1] == "update-ldcache" {
+				continue
+			}
+			dst.hooks.Prestart = append(dst.hooks.Prestart, gvisorOCIHook{
+				Path:    hook.Path,
+				Args:    append([]string{}, hook.Args...),
+				Env:     append([]string{}, hook.Env...),
+				Timeout: hook.Timeout,
+			})
+		}
+	}
+}
+
+func appendNvidiaLibrarySymlinkHooks(dst *cdiNvidiaEdits) {
+	links := nvidiaLibrarySymlinks(dst.mounts)
+	if len(links) == 0 {
+		return
+	}
+	if dst.hooks == nil {
+		dst.hooks = &gvisorOCIHooks{}
+	}
+	args := []string{"nvidia-cdi-hook", "create-symlinks"}
+	for _, link := range links {
+		if hasNvidiaSymlinkHook(dst.hooks.Prestart, link) {
+			continue
+		}
+		args = append(args, "--link", link)
+	}
+	if len(args) == 2 {
+		return
+	}
+	dst.hooks.Prestart = append(dst.hooks.Prestart, gvisorOCIHook{
+		Path: "/usr/bin/nvidia-cdi-hook",
+		Args: args,
+		Env:  []string{"NVIDIA_CTK_DEBUG=false"},
+	})
+}
+
+func nvidiaLibrarySymlinks(mounts []gvisorOCIMount) []string {
+	var out []string
+	for _, mount := range mounts {
+		dir, file := path.Split(mount.Destination)
+		switch {
+		case strings.HasPrefix(file, "libcuda.so.") && file != "libcuda.so.1":
+			out = append(out, file+"::"+path.Join(dir, "libcuda.so.1"))
+		case strings.HasPrefix(file, "libnvidia-ml.so.") && file != "libnvidia-ml.so.1":
+			out = append(out,
+				file+"::"+path.Join(dir, "libnvidia-ml.so.1"),
+				"libnvidia-ml.so.1::"+path.Join(dir, "libnvidia-ml.so"),
+			)
+		}
+	}
+	return out
+}
+
+func hasNvidiaSymlinkHook(hooks []gvisorOCIHook, link string) bool {
+	for _, hook := range hooks {
+		if len(hook.Args) < 2 || hook.Args[1] != "create-symlinks" {
+			continue
+		}
+		for _, arg := range hook.Args {
+			if arg == link {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func derefUint32(v *uint32) uint32 {
+	if v == nil {
+		return 0
+	}
+	return *v
+}
+
+func setEnv(env []string, values ...string) []string {
+	existing := make(map[string]struct{}, len(env))
+	for _, value := range values {
+		key, _, ok := strings.Cut(value, "=")
+		if !ok {
+			continue
+		}
+		existing[key] = struct{}{}
+	}
+	out := make([]string, 0, len(env)+len(values))
+	for _, item := range env {
+		key, _, ok := strings.Cut(item, "=")
+		if ok {
+			if _, replace := existing[key]; replace {
+				continue
+			}
+		}
+		out = append(out, item)
+	}
+	for _, value := range values {
+		if _, _, ok := strings.Cut(value, "="); ok {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+type deviceNodeStat struct {
+	major int64
+	minor int64
+	mode  uint32
+	uid   uint32
+	gid   uint32
+}
+
+func readDeviceNodeStat(path string) (*deviceNodeStat, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil, fmt.Errorf("unsupported stat type %T", info.Sys())
+	}
+	if info.Mode()&os.ModeCharDevice == 0 {
+		return nil, fmt.Errorf("%s is not a device node", path)
+	}
+	return &deviceNodeStat{
+		major: deviceMajor(uint64(stat.Rdev)),
+		minor: deviceMinor(uint64(stat.Rdev)),
+		mode:  uint32(info.Mode().Perm()),
+		uid:   stat.Uid,
+		gid:   stat.Gid,
+	}, nil
+}
+
+func readNvidiaDeviceStat(path string) (nvidiaDeviceStat, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nvidiaDeviceStat{}, err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nvidiaDeviceStat{}, fmt.Errorf("unsupported stat type %T", info.Sys())
+	}
+	if info.Mode()&os.ModeCharDevice == 0 {
+		return nvidiaDeviceStat{}, fmt.Errorf("%s is not a device node", path)
+	}
+	return nvidiaDeviceStat{
+		major: deviceMajor(uint64(stat.Rdev)),
+		minor: deviceMinor(uint64(stat.Rdev)),
+		mode:  uint32(info.Mode().Perm()),
+		uid:   stat.Uid,
+		gid:   stat.Gid,
+	}, nil
+}
+
+func deviceMajor(dev uint64) int64 {
+	return int64(((dev >> 8) & 0xfff) | ((dev >> 32) & 0xfffff000))
+}
+
+func deviceMinor(dev uint64) int64 {
+	return int64((dev & 0xff) | ((dev >> 12) & 0xffffff00))
+}
+
+func gvisorCapabilities() *novitaboxv1.RuntimeCapabilities {
+	return &novitaboxv1.RuntimeCapabilities{
+		StartFromImage:    true,
+		StartFromTemplate: true,
+		StartFromSnapshot: false,
+		Pause:             false,
+		Resume:            false,
+		FullSnapshot:      false,
+		DiffSnapshot:      false,
+		Gpu:               true,
+		Vsock:             false,
+		TapNetwork:        false,
+		GracefulShutdown:  true,
+		SerialConsole:     false,
+		Jailer:            false,
+	}
+}

--- a/internal/boxshim/runtime/gvisor_test.go
+++ b/internal/boxshim/runtime/gvisor_test.go
@@ -1,0 +1,264 @@
+package runtime
+
+import (
+	"os"
+	"testing"
+
+	"github.com/novitalabs/NovitaBox/internal/config"
+	novitaboxv1 "github.com/novitalabs/NovitaBox/internal/pb/novitabox/v1"
+)
+
+func TestNewGVisorOCISpecDoesNotInjectHostProxy(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:6789")
+	t.Setenv("HTTPS_PROXY", "http://localhost:7890")
+	t.Setenv("ALL_PROXY", "socks5://127.0.0.1:7891")
+	t.Setenv("NO_PROXY", "example.com")
+
+	spec, err := newGVisorOCISpec(config.Default(), gvisorSpecForTest("sbx-test", "10.11.0.9"))
+	if err != nil {
+		t.Fatalf("new gvisor oci spec: %v", err)
+	}
+	env := envMap(spec.Process.Env)
+
+	for _, key := range []string{"HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy", "NO_PROXY", "no_proxy"} {
+		if got := env[key]; got != "" {
+			t.Fatalf("%s = %q, want no inherited proxy env", key, got)
+		}
+	}
+}
+
+func TestNewGVisorOCISpecDoesNotInjectProxyForTemplateBuild(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:6789")
+	t.Setenv("HTTPS_PROXY", "http://localhost:7890")
+	t.Setenv("ALL_PROXY", "socks5://127.0.0.1:7891")
+
+	spec, err := newGVisorOCISpec(config.Default(), gvisorSpecForTest("template-build-tpl-test", "10.11.0.1"))
+	if err != nil {
+		t.Fatalf("new gvisor oci spec: %v", err)
+	}
+	env := envMap(spec.Process.Env)
+
+	for _, key := range []string{"HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy", "NO_PROXY", "no_proxy"} {
+		if got := env[key]; got != "" {
+			t.Fatalf("%s = %q, want no inherited proxy env", key, got)
+		}
+	}
+}
+
+func TestNewGVisorOCISpecInjectsNvidiaDevicesWhenGpuEnabled(t *testing.T) {
+	oldStat := statNvidiaDevice
+	t.Cleanup(func() {
+		statNvidiaDevice = oldStat
+	})
+
+	statNvidiaDevice = func(path string) (nvidiaDeviceStat, error) {
+		switch path {
+		case "/dev/nvidiactl":
+			return nvidiaDeviceStat{major: 195, minor: 255, mode: 0o666, uid: 0, gid: 0}, nil
+		case "/dev/nvidia-uvm":
+			return nvidiaDeviceStat{major: 511, minor: 0, mode: 0o666, uid: 0, gid: 0}, nil
+		case "/dev/nvidia0":
+			return nvidiaDeviceStat{major: 195, minor: 0, mode: 0o666, uid: 0, gid: 0}, nil
+		default:
+			return nvidiaDeviceStat{}, os.ErrNotExist
+		}
+	}
+
+	spec, err := newGVisorOCISpec(config.Default(), func() *novitaboxv1.RuntimeSpec {
+		spec := gvisorSpecForTest("sbx-gpu", "10.11.0.9")
+		spec.Machine.Gpu = 1
+		return spec
+	}())
+	if err != nil {
+		t.Fatalf("new gvisor oci spec: %v", err)
+	}
+
+	env := envMap(spec.Process.Env)
+	if got := env["NVIDIA_VISIBLE_DEVICES"]; got != "0" {
+		t.Fatalf("NVIDIA_VISIBLE_DEVICES = %q, want 0", got)
+	}
+	if got := env["CUDA_VISIBLE_DEVICES"]; got != "0" {
+		t.Fatalf("CUDA_VISIBLE_DEVICES = %q, want 0", got)
+	}
+	if got := env["NVIDIA_DRIVER_CAPABILITIES"]; got != "compute,utility" {
+		t.Fatalf("NVIDIA_DRIVER_CAPABILITIES = %q, want compute,utility", got)
+	}
+	if got := env["LD_LIBRARY_PATH"]; got != "/usr/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu/vdpau:/usr/lib64" {
+		t.Fatalf("LD_LIBRARY_PATH = %q, want NVIDIA library paths", got)
+	}
+	if len(spec.Linux.Devices) != 3 {
+		t.Fatalf("linux.devices len = %d, want 3", len(spec.Linux.Devices))
+	}
+	if len(spec.Linux.Resources.Devices) != 3 {
+		t.Fatalf("linux.resources.devices len = %d, want 3", len(spec.Linux.Resources.Devices))
+	}
+}
+
+func TestMergeCDIContainerEdits(t *testing.T) {
+	major := int64(195)
+	minor := int64(0)
+	mode := uint32(0o666)
+	uid := uint32(0)
+	gid := uint32(0)
+	dst := cdiNvidiaEdits{}
+
+	mergeCDIContainerEdits(&dst, &cdiContainerEdits{
+		Env: []string{"NVIDIA_VISIBLE_DEVICES=0"},
+		DeviceNodes: []cdiDeviceNode{
+			{
+				Path:     "/dev/nvidia0",
+				Type:     "c",
+				Major:    &major,
+				Minor:    &minor,
+				FileMode: &mode,
+				UID:      &uid,
+				GID:      &gid,
+			},
+		},
+		Mounts: []cdiMount{
+			{HostPath: "/host/lib", ContainerPath: "/usr/lib/libnvidia.so", Options: []string{"ro"}},
+		},
+		Hooks: []cdiHook{
+			{HookName: "createContainer", Path: "/usr/bin/nvidia-ctk", Args: []string{"hook", "createContainer"}},
+		},
+	})
+
+	if got := len(dst.env); got != 1 {
+		t.Fatalf("env len = %d, want 1", got)
+	}
+	if got := len(dst.devices); got != 1 {
+		t.Fatalf("devices len = %d, want 1", got)
+	}
+	if got := dst.devices[0].Path; got != "/dev/nvidia0" {
+		t.Fatalf("device path = %q, want /dev/nvidia0", got)
+	}
+	if got := len(dst.rules); got != 1 {
+		t.Fatalf("rules len = %d, want 1", got)
+	}
+	if got := len(dst.mounts); got != 1 {
+		t.Fatalf("mounts len = %d, want 1", got)
+	}
+	if got := len(dst.hooks.Prestart); got != 1 {
+		t.Fatalf("hooks len = %d, want 1", got)
+	}
+}
+
+func TestMergeCDIContainerEditsSkipsUpdateLdcacheHook(t *testing.T) {
+	dst := cdiNvidiaEdits{}
+
+	mergeCDIContainerEdits(&dst, &cdiContainerEdits{
+		Hooks: []cdiHook{
+			{HookName: "createContainer", Path: "/usr/bin/nvidia-cdi-hook", Args: []string{"nvidia-cdi-hook", "update-ldcache", "--folder", "/usr/lib/x86_64-linux-gnu"}},
+			{HookName: "createContainer", Path: "/usr/bin/nvidia-cdi-hook", Args: []string{"nvidia-cdi-hook", "enable-cuda-compat"}},
+		},
+	})
+
+	if dst.hooks == nil {
+		t.Fatalf("hooks should contain non-ldcache hook")
+	}
+	if got := len(dst.hooks.Prestart); got != 1 {
+		t.Fatalf("hooks len = %d, want 1", got)
+	}
+	if got := dst.hooks.Prestart[0].Args[1]; got != "enable-cuda-compat" {
+		t.Fatalf("hook = %q, want enable-cuda-compat", got)
+	}
+}
+
+func TestMergeCDIContainerEditsAddsNvidiaLibrarySymlinkHook(t *testing.T) {
+	dst := cdiNvidiaEdits{}
+
+	mergeCDIContainerEdits(&dst, &cdiContainerEdits{
+		Mounts: []cdiMount{
+			{HostPath: "/host/libcuda.so.570.124.06", ContainerPath: "/usr/lib/x86_64-linux-gnu/libcuda.so.570.124.06"},
+			{HostPath: "/host/libnvidia-ml.so.570.124.06", ContainerPath: "/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.570.124.06"},
+		},
+	})
+
+	if dst.hooks == nil || len(dst.hooks.Prestart) != 1 {
+		t.Fatalf("hooks = %#v, want generated symlink hook", dst.hooks)
+	}
+	args := dst.hooks.Prestart[0].Args
+	for _, want := range []string{
+		"libcuda.so.570.124.06::/usr/lib/x86_64-linux-gnu/libcuda.so.1",
+		"libnvidia-ml.so.570.124.06::/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1",
+		"libnvidia-ml.so.1::/usr/lib/x86_64-linux-gnu/libnvidia-ml.so",
+	} {
+		if !containsString(args, want) {
+			t.Fatalf("symlink hook args = %#v, missing %q", args, want)
+		}
+	}
+}
+
+func TestMergeCDIContainerEditsUsesHostDeviceStatWhenMetadataMissing(t *testing.T) {
+	dst := cdiNvidiaEdits{}
+
+	mergeCDIContainerEdits(&dst, &cdiContainerEdits{
+		DeviceNodes: []cdiDeviceNode{
+			{
+				Path: "/dev/null",
+				Type: "c",
+			},
+		},
+	})
+
+	if got := len(dst.rules); got != 1 {
+		t.Fatalf("rules len = %d, want 1", got)
+	}
+	if dst.rules[0].Major == nil || dst.rules[0].Minor == nil {
+		t.Fatalf("rules major/minor should be populated from host device stat: %#v", dst.rules[0])
+	}
+}
+
+func clearProxyEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"HTTP_PROXY", "http_proxy",
+		"HTTPS_PROXY", "https_proxy",
+		"ALL_PROXY", "all_proxy",
+		"NO_PROXY", "no_proxy",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+func gvisorSpecForTest(sandboxID string, hostAccessIP string) *novitaboxv1.RuntimeSpec {
+	return &novitaboxv1.RuntimeSpec{
+		SandboxId: sandboxID,
+		Machine: &novitaboxv1.MachineSpec{
+			Vcpu:     1,
+			MemoryMb: 512,
+		},
+		Rootfs: &novitaboxv1.RootfsSpec{
+			Path: "/tmp/rootfs",
+		},
+		Network: &novitaboxv1.NetworkSpec{
+			NamespaceName: "nb-test",
+			HostAccessIp:  hostAccessIP,
+			Slot:          1,
+		},
+	}
+}
+
+func envMap(env []string) map[string]string {
+	out := make(map[string]string, len(env))
+	for _, entry := range env {
+		for i, ch := range entry {
+			if ch == '=' {
+				out[entry[:i]] = entry[i+1:]
+				break
+			}
+		}
+	}
+	return out
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/boxshim/runtime/path.go
+++ b/internal/boxshim/runtime/path.go
@@ -1,0 +1,10 @@
+package runtime
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func ContainerPathInRootfs(rootfs string, guestPath string) string {
+	return filepath.Join(rootfs, filepath.FromSlash(strings.TrimPrefix(guestPath, "/")))
+}

--- a/internal/boxshim/server/server.go
+++ b/internal/boxshim/server/server.go
@@ -48,6 +48,8 @@ func newRuntimeDriver(cfg config.Config, logger *log.Logger) shimruntime.Driver 
 		return shimruntime.NewStubDriver(cfg, logger.Component("stub"))
 	case "firecracker":
 		return shimruntime.NewFirecrackerDriver(cfg, logger.Component("firecracker"))
+	case "gvisor", "container":
+		return shimruntime.NewGVisorDriver(cfg, logger.Component("gvisor"))
 	default:
 		return shimruntime.NewUnsupportedDriver(fmt.Sprintf("unknown runtime driver %q", cfg.Boxshim.RuntimeDriver))
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	Boxd        ServiceConfig
 	Storage     StorageConfig
 	Firecracker FirecrackerConfig
+	GVisor      GVisorConfig
 	Template    TemplateBuildConfig
 	Network     NetworkConfig
 }
@@ -32,6 +33,10 @@ type StorageConfig struct {
 
 type FirecrackerConfig struct {
 	BinaryPath string
+}
+
+type GVisorConfig struct {
+	RunscBinaryPath string
 }
 
 type NetworkConfig struct {

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -15,6 +15,7 @@ type ServiceOptions struct {
 	RuntimeDriver         string
 	BoxshimBinaryPath     string
 	FirecrackerBinaryPath string
+	RunscBinaryPath       string
 	TemplateKernelPath    string
 	TemplateSnapshotWait  uint32
 	TemplateAgentHealth   string
@@ -55,6 +56,12 @@ func ApplyServiceOptions(defaults Config, name string, opts ServiceOptions) (Con
 	}
 	if cfg.Firecracker.BinaryPath == "" {
 		cfg.Firecracker.BinaryPath = DefaultFirecrackerBinaryPath(cfg.RootDir)
+	}
+	if opts.RunscBinaryPath != "" {
+		cfg.GVisor.RunscBinaryPath = opts.RunscBinaryPath
+	}
+	if cfg.GVisor.RunscBinaryPath == "" {
+		cfg.GVisor.RunscBinaryPath = DefaultRunscBinaryPath(cfg.RootDir)
 	}
 	if opts.TemplateKernelPath != "" {
 		cfg.Template.KernelPath = opts.TemplateKernelPath
@@ -133,6 +140,7 @@ type BoxshimOptions struct {
 	SocketPath            string
 	RuntimeDriver         string
 	FirecrackerBinaryPath string
+	RunscBinaryPath       string
 	DBPath                string
 }
 
@@ -142,12 +150,16 @@ func ApplyBoxshimOptions(defaults Config, opts BoxshimOptions) Config {
 	cfg.Boxshim.SocketPath = opts.SocketPath
 	cfg.Boxshim.RuntimeDriver = opts.RuntimeDriver
 	cfg.Firecracker.BinaryPath = opts.FirecrackerBinaryPath
+	cfg.GVisor.RunscBinaryPath = opts.RunscBinaryPath
 	cfg.Storage.DBPath = opts.DBPath
 	if cfg.Storage.DBPath == "" {
 		cfg.Storage.DBPath = DefaultDBPath(cfg.RootDir)
 	}
 	if cfg.Firecracker.BinaryPath == "" {
 		cfg.Firecracker.BinaryPath = DefaultFirecrackerBinaryPath(cfg.RootDir)
+	}
+	if cfg.GVisor.RunscBinaryPath == "" {
+		cfg.GVisor.RunscBinaryPath = DefaultRunscBinaryPath(cfg.RootDir)
 	}
 
 	return cfg
@@ -175,6 +187,10 @@ func DefaultFirecrackerBinaryPath(rootDir string) string {
 
 func DefaultFirecrackerJailerBinaryPath(rootDir string) string {
 	return filepath.Join(rootDir, "jailer")
+}
+
+func DefaultRunscBinaryPath(rootDir string) string {
+	return filepath.Join(rootDir, "runsc")
 }
 
 func withPort(addr string, port int) (string, error) {

--- a/internal/pb/novitabox/v1/types.pb.go
+++ b/internal/pb/novitabox/v1/types.pb.go
@@ -584,7 +584,7 @@ type MachineSpec struct {
 	Vcpu          uint32                 `protobuf:"varint,1,opt,name=vcpu,proto3" json:"vcpu,omitempty"`
 	MemoryMb      uint32                 `protobuf:"varint,2,opt,name=memory_mb,json=memoryMb,proto3" json:"memory_mb,omitempty"`
 	Hugepages     bool                   `protobuf:"varint,3,opt,name=hugepages,proto3" json:"hugepages,omitempty"`
-	Gpu           bool                   `protobuf:"varint,4,opt,name=gpu,proto3" json:"gpu,omitempty"`
+	Gpu           uint32                 `protobuf:"varint,4,opt,name=gpu,proto3" json:"gpu,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -640,11 +640,11 @@ func (x *MachineSpec) GetHugepages() bool {
 	return false
 }
 
-func (x *MachineSpec) GetGpu() bool {
+func (x *MachineSpec) GetGpu() uint32 {
 	if x != nil {
 		return x.Gpu
 	}
-	return false
+	return 0
 }
 
 type KernelSpec struct {
@@ -1599,7 +1599,7 @@ const file_novitabox_v1_types_proto_rawDesc = "" +
 	"\x04vcpu\x18\x01 \x01(\rR\x04vcpu\x12\x1b\n" +
 	"\tmemory_mb\x18\x02 \x01(\rR\bmemoryMb\x12\x1c\n" +
 	"\thugepages\x18\x03 \x01(\bR\thugepages\x12\x10\n" +
-	"\x03gpu\x18\x04 \x01(\bR\x03gpu\"k\n" +
+	"\x03gpu\x18\x04 \x01(\rR\x03gpu\"k\n" +
 	"\n" +
 	"KernelSpec\x12\x1f\n" +
 	"\vkernel_path\x18\x01 \x01(\tR\n" +

--- a/internal/runtime/spec.go
+++ b/internal/runtime/spec.go
@@ -13,7 +13,7 @@ type Spec struct {
 type MachineSpec struct {
 	VCPU     uint32
 	MemoryMB uint32
-	GPU      bool
+	GPU      uint32
 }
 
 type RootfsSpec struct {

--- a/proto/novitabox/v1/types.proto
+++ b/proto/novitabox/v1/types.proto
@@ -82,7 +82,7 @@ message MachineSpec {
   uint32 vcpu = 1;
   uint32 memory_mb = 2;
   bool hugepages = 3;
-  bool gpu = 4;
+  uint32 gpu = 4;
 }
 
 message KernelSpec {


### PR DESCRIPTION
- add gVisor runtime driver and OCI bundle generation
- support runtimeType=gvisor for templates and sandboxes
- wire sandbox networking for gVisor network namespaces
- add GPU count API support and NVIDIA CDI-based device injection
- enable runsc nvproxy and inject NVIDIA library paths/symlinks
- skip incompatible NVIDIA CDI update-ldcache hook under runsc
- clean leaked sandbox mounts before removing gVisor rootfs dirs
- preserve directory rootfs templates and clean template dirs on delete
- add tests for gVisor runtime, GPU injection, networking, and cleanup