### PR TITLE
docs: update gVisor and GPU documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="Apache 2.0 License"></a>
 </div>
 
-**The local edition of Novita Sandbox** — a secure, MicroVM-based execution environment for AI Agents.
+**The local edition of Novita Sandbox** — a secure execution environment for AI Agents, with MicroVM and gVisor runtime options.
 
 NovitaBox brings Novita's production sandbox stack to your laptop, on-prem servers, or edge devices. Run AI Agents
 locally with millisecond startup times, zero cloud latency, and complete data privacy. Use the standard **Novita Sandbox
@@ -25,13 +25,12 @@ SDK** to write your agent code once, then run it locally with NovitaBox or in No
   cloud dependency at runtime.
 - **🔒 Privacy by design** — Code, files, and execution traces never leave your machine. Suitable for air-gapped,
   regulated, or data-sensitive workloads.
-- **⚡ Millisecond startup** — Powered by MicroVM technology with kernel-level isolation. Spin up sandboxes in
-  milliseconds with minimal memory overhead.
+- **⚡ Fast startup** — Use Firecracker for MicroVM snapshot startup or gVisor for container-style sandboxes.
 - **🔁 One codebase, local to production** — Use Novita Sandbox SDK for both NovitaBox local development and Novita
   production.
 - **🛠️ Full template lifecycle** — Build, publish, and manage custom sandbox image templates locally.
-- **🧩 Multiple runtimes** — Supports both Firecracker and Cloud Hypervisor runtimes, so you can choose the MicroVM
-  backend that fits your environment.
+- **🧩 Multiple runtimes** — Supports Firecracker, gVisor, and Cloud Hypervisor runtime backends.
+- **🎮 NVIDIA GPU support** — gVisor sandboxes can expose NVIDIA GPUs with `--gpu <count>` through runsc `nvproxy` and NVIDIA CDI.
 - **🌐 E2B SDK compatible** — Existing E2B SDK code works without modification. Migrate by changing one endpoint.
 
 ## 🚀 Quick Start
@@ -54,7 +53,7 @@ curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/i
 
 The release installer detects your operating system and CPU architecture, downloads the matching prebuilt components,
 and runs the platform installer. On macOS it downloads both Darwin binaries for the host and Linux binaries for the Lima
-VM. Firecracker and the guest kernel are kept on the stable `v0.0.1` runtime assets by default.
+VM. Firecracker and the guest kernel are kept on the stable `v0.0.1` runtime assets by default. gVisor deployments also need a `runsc` binary available at `$ROOT_DIR/runsc` or configured with `--runsc-bin`.
 
 Linux installs configure local DNS and HTTPS proxy by default. On macOS, enable host DNS and proxy explicitly:
 
@@ -104,11 +103,13 @@ mount -o loop /data/novitabox.img /data/novitabox
 https://github.com/novitalabs/NovitaBox/releases/download/v0.0.1/firecracker
 # firecracker guest kernel
 https://github.com/novitalabs/NovitaBox/releases/download/v0.0.1/vmlinux.bin
+# gVisor runsc, required for --runtime gvisor
+https://gvisor.dev/docs/user_guide/install/
 ```
 
 #### Start the NovitaBox Server
 
-Ensure your local machine has KVM (Linux) or equivalent virtualization features enabled.
+Ensure your local machine has KVM (Linux) or equivalent virtualization features enabled when you use Firecracker or Cloud Hypervisor.
 
 ```bash
 # clone the repository
@@ -169,6 +170,16 @@ sudo systemctl restart caddy
   --run 'apt-get install -y curl'
 ```
 
+Build a gVisor template:
+
+```bash
+/data/novitabox/boxctl \
+  --api http://127.0.0.1:8080 \
+  template build cuda-template \
+  --runtime gvisor \
+  --from-image nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubi8
+```
+
 #### Launch a sandbox
 
 ```bash
@@ -185,12 +196,28 @@ SANDBOX_ID=sbx-xxxxxxxxxxxxxxxxxxxx
   exec -it "$SANDBOX_ID" /bin/sh
 ```
 
+Launch a gVisor sandbox with one NVIDIA GPU:
+
+```bash
+/data/novitabox/boxctl sandbox create \
+  --template "$TEMPLATE_ID" \
+  --runtime gvisor \
+  --gpu 1
+```
+
+Verify GPU access:
+
+```bash
+/data/novitabox/boxctl sandbox exec "$SANDBOX_ID" /usr/bin/nvidia-smi
+/data/novitabox/boxctl sandbox exec "$SANDBOX_ID" /cuda-samples/vectorAdd
+```
+
 ---
 
 
 ## 🏗️ Architecture
 
-NovitaBox runs as a set of small host services and routes Novita Sandbox SDK calls to MicroVM instances managed locally:
+NovitaBox runs as a set of small host services and routes Novita Sandbox SDK calls to locally managed sandbox runtimes:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -208,13 +235,13 @@ NovitaBox runs as a set of small host services and routes Novita Sandbox SDK cal
 │         │                 │                   │             │
 │         ▼                 ▼                   ▼             │
 │  ┌─────────────────────────────────────────────────────┐    │
-│  │           MicroVM Manager (KVM / HVF)               │    │
+│  │        Runtime Manager (MicroVM / gVisor)           │    │
 │  └────────────────────┬────────────────────────────────┘    │
 │                       │                                     │
 │         ┌─────────────┴─────────────┐                       │
 │         ▼                           ▼                       │
 │  ┌──────────────┐            ┌──────────────┐               │
-│  │  Sandbox VM  │  …         │  Sandbox VM  │               │
+│  │  Sandbox     │  …         │  Sandbox     │               │
 │  │  (rootfs +   │            │  (rootfs +   │               │
 │  │   envd)      │            │   envd)      │               │
 │  └──────────────┘            └──────────────┘               │
@@ -228,10 +255,10 @@ NovitaBox is built around a runtime abstraction instead of being tied to one bac
 Currently supported runtimes:
 
 - Firecracker
+- gVisor
 - Cloud Hypervisor
 
-Runtime behavior is capability-driven. If a runtime does not support a feature, such as pause/resume with GPU
-passthrough, NovitaBox can degrade the API behavior explicitly instead of failing unpredictably.
+Runtime behavior is capability-driven. Firecracker provides MicroVM snapshot support. gVisor provides a directory-rootfs container runtime and NVIDIA GPU support through runsc `nvproxy` and NVIDIA CDI. If a runtime does not support a feature, such as pause/resume with GPU passthrough, NovitaBox can degrade the API behavior explicitly instead of failing unpredictably.
 
 #### Fixed Guest IP Networking
 
@@ -281,11 +308,11 @@ The state flow is intentionally simple:
 ```text
 docker image + start_cmd -> Template
 
-Template - memfile - snapfile -> Image
+Firecracker Template - memfile - snapfile -> Image
 Image -> sandbox -> Template
 
 Template -> Sandbox
-Sandbox -> Snapshot
+Firecracker Sandbox -> Snapshot
 ```
 
 This makes it clear which artifacts are portable, which artifacts are optimized for fast startup, and which state
@@ -302,8 +329,8 @@ belongs to a running sandbox.
 - **API:** [HTTP API](docs/api/http.md), [Internal RPC](docs/api/RPC.md)
 - **Architecture:** [Overview](docs/architecture/overview.md), [Components](docs/architecture/components.md), [RuntimeSpec](docs/architecture/runtime.md), [Artifact Model](docs/architecture/artifact.md), [Network](docs/architecture/network.md), [Sandbox Lifecycle](docs/architecture/lifecycle.md), [File Layout](docs/architecture/file-layout.md), [Security Model](docs/architecture/security.md)
 - **CLI reference:** [Template](docs/cli/template.md), [Sandbox](docs/cli/sandbox.md), [Image](docs/cli/image.md), [Runtime and snapshot](docs/cli/others.md)
-- **Changelog:** [v0.0.1](docs/changelog/v0.0.1.md)
-- **Chinese docs:** [使用手册](docs/zh/usage.md), [Architecture overview](docs/zh/architecture/overview.md), [v0.0.1 changelog](docs/zh/changelog/v0.0.1.md)
+- **Changelog:** [v0.0.3](docs/changelog/v0.0.3.md), [v0.0.1](docs/changelog/v0.0.1.md)
+- **Chinese docs:** [使用手册](docs/zh/usage.md), [Architecture overview](docs/zh/architecture/overview.md), [v0.0.3 changelog](docs/zh/changelog/v0.0.3.md), [v0.0.1 changelog](docs/zh/changelog/v0.0.1.md)
 
 ---
 

--- a/docs/api/RPC.md
+++ b/docs/api/RPC.md
@@ -18,6 +18,8 @@ service BoxletSandboxService {
 }
 ```
 
+`CreateSandboxRequest.runtime_type` selects the runtime backend. `RuntimeSpec.machine.gpu` requests the number of NVIDIA GPUs for runtimes that support GPU. Today GPU is implemented for gVisor.
+
 ### Boxlet Artifact Service
 
 ```proto
@@ -34,6 +36,8 @@ service BoxletArtifactService {
 }
 ```
 
+Templates store runtime metadata. Firecracker templates use `rootfs.ext4`, `memfile`, and `snapfile`; gVisor templates use a directory rootfs and no VM snapshot files.
+
 ### Boxlet Node Service
 
 ```proto
@@ -43,6 +47,8 @@ service BoxletNodeService {
   rpc GetRuntimeCapabilities(GetRuntimeCapabilitiesRequest) returns (RuntimeCapabilities);
 }
 ```
+
+`ListRuntimes` and `GetRuntimeCapabilities` report Firecracker, gVisor, and Cloud Hypervisor capabilities. Clients should check capabilities before assuming pause/resume, snapshot, GPU, or networking behavior.
 
 ### BoxShim Service
 

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -29,6 +29,14 @@ curl -sS -X POST http://127.0.0.1:8080/v3/templates \
   -d '{"name":"my-template"}'
 ```
 
+Create a gVisor template record:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/v3/templates \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"cuda-template","runtimeType":"gvisor"}'
+```
+
 Start a build:
 
 ```bash
@@ -74,6 +82,14 @@ Create a sandbox from a template:
 curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes \
   -H 'Content-Type: application/json' \
   -d '{"templateID":"tpl-xxxxxxxxxxxxxxxxxxxx"}'
+```
+
+Create a gVisor sandbox with one NVIDIA GPU:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes \
+  -H 'Content-Type: application/json' \
+  -d '{"templateID":"tpl-xxxxxxxxxxxxxxxxxxxx","runtime_type":"gvisor","gpu":1}'
 ```
 
 Create from an image:
@@ -151,7 +167,11 @@ curl -i -X DELETE http://127.0.0.1:8080/v1/images/img-xxxxxxxxxxxxxxxxxxxx
 curl -sS http://127.0.0.1:8080/v1/runtimes
 curl -sS http://127.0.0.1:8080/v1/runtimes/firecracker
 curl -sS http://127.0.0.1:8080/v1/runtimes/firecracker/capabilities
+curl -sS http://127.0.0.1:8080/v1/runtimes/gvisor
+curl -sS http://127.0.0.1:8080/v1/runtimes/gvisor/capabilities
 ```
+
+Runtime names accepted by the API include `firecracker`, `gvisor`, and `cloud-hypervisor`. The compatible template API uses `runtimeType`; sandbox creation uses `runtime_type`.
 
 ## Route Summary
 

--- a/docs/architecture/artifact.md
+++ b/docs/architecture/artifact.md
@@ -7,30 +7,32 @@ NovitaBox uses three artifact concepts.
 An Image contains only rootfs state.
 
 ```text
-Image = rootfs.ext4 + metadata
+Firecracker image = rootfs.ext4 + metadata
+gVisor image      = rootfs directory + metadata
 ```
 
 Images are portable and useful for migration.
 
 ### Template
 
-A Template contains rootfs, memory state, and VM snapshot state.
+A Template contains the fast-start state for a selected runtime.
 
 ```text
-Template = rootfs.ext4 + memfile + snapfile + metadata
+Firecracker template = rootfs.ext4 + memfile + snapfile + metadata
+gVisor template      = rootfs directory + metadata
 ```
 
-Templates are optimized for fast sandbox startup.
+Firecracker templates are optimized for VM snapshot startup. gVisor templates are directory rootfs templates and do not include `memfile` or `snapfile`.
 
 ### Snapshot
 
 A Snapshot is internal pause state bound to a sandbox.
 
 ```text
-Snapshot = rootfs.ext4 + memfile + snapfile + metadata
+Firecracker snapshot = rootfs.ext4 + memfile + snapfile + metadata
 ```
 
-Snapshot is not a user-convertible artifact. It is created by pause and consumed by resume.
+Snapshot is not a user-convertible artifact. It is created by pause and consumed by resume. gVisor pause/resume snapshots are not supported yet.
 
 ## Artifact Conversion
 
@@ -39,9 +41,17 @@ User-facing artifact conversion is intentionally limited:
 ```text
 docker image + start_cmd -> Template
 
-Template - memfile - snapfile -> Image
-Image -> sandbox -> Template
+Firecracker Template - memfile - snapfile -> Image
+Image -> Firecracker Template
 
 Template -> Sandbox
-Sandbox -> Snapshot
+Firecracker Sandbox -> Snapshot
+```
+
+For gVisor, conversion keeps directory rootfs state and skips VM memory/snapshot files:
+
+```text
+docker image -> directory-rootfs Template
+directory-rootfs Template -> directory-rootfs Image
+directory-rootfs Template -> gVisor Sandbox
 ```

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -22,7 +22,7 @@ Responsibilities:
 - start and manage `boxshim`
 - prepare local rootfs, memory, snapshot, and runtime files
 - manage local sandbox resources
-- prepare sandbox network namespace, tap, veth, routes, and NAT
+- prepare sandbox network namespace, tap or gVisor veth addresses, routes, and NAT
 - build templates
 - expose node runtime capabilities
 
@@ -41,11 +41,14 @@ Responsibilities:
 Runtime drivers:
 
 - Firecracker driver
+- gVisor driver
 - Cloud Hypervisor driver
+
+The gVisor driver writes an OCI bundle, starts `runsc`, and optionally enables NVIDIA GPU access through `runsc --nvproxy` and NVIDIA CDI.
 
 ### boxd
 
-`boxd` is the in-sandbox guest agent.
+`boxd` is the in-sandbox agent. In Firecracker it runs inside the guest VM. In gVisor it runs as the container init process inside the `runsc` sandbox.
 
 Responsibilities:
 

--- a/docs/architecture/file-layout.md
+++ b/docs/architecture/file-layout.md
@@ -10,11 +10,17 @@ $ROOT/images/<image_id>/
   rootfs.ext4
   metadata
 
+$ROOT/images/<image_id>/rootfs/
+  ... directory rootfs for gVisor images
+
 $ROOT/templates/<template_id>/
   rootfs.ext4
   memfile
   snapfile
   metadata
+
+$ROOT/templates/<template_id>/rootfs/
+  ... directory rootfs for gVisor templates
 
 $ROOT/sandboxes/<sandbox_id>/
   shim.sock
@@ -23,6 +29,18 @@ $ROOT/sandboxes/<sandbox_id>/
   firecracker.log
   kernel -> $ROOT/vmlinux.bin
   snapshot/
+
+$ROOT/sandboxes/<sandbox_id>/bundle/
+  config.json          # gVisor OCI bundle
+
+$ROOT/sandboxes/<sandbox_id>/runsc/
+  ... runsc state
+
+$ROOT/sandboxes/<sandbox_id>/runsc.log
+  ... gVisor runtime log
+
+$ROOT/sandboxes/<sandbox_id>/rootfs/
+  ... directory rootfs for gVisor sandboxes
 
 $ROOT/sandboxes/<sandbox_id>/snapshot/
   rootfs.ext4
@@ -37,5 +55,8 @@ $ROOT/boxlet
 $ROOT/boxproxy
 $ROOT/boxshim
 $ROOT/firecracker
+$ROOT/runsc
 $ROOT/vmlinux.bin
 ```
+
+Firecracker artifacts use `rootfs.ext4`, `memfile`, and `snapfile`. gVisor artifacts use directory rootfs paths and do not create VM memory snapshot files.

--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -3,8 +3,8 @@
 Supported sandbox operations:
 
 - create
-- pause
-- resume
+- pause, when supported by the selected runtime
+- resume, when supported by the selected runtime
 - kill
 - list
 - exec
@@ -46,3 +46,9 @@ failure:
 unknown:
   state cannot be confirmed during recovery -> Unknown
 ```
+
+Runtime notes:
+
+- Firecracker supports VM snapshot-oriented template startup and pause/resume.
+- gVisor supports create, stop, reboot, kill, exec, shell, and delete. It does not currently support pause/resume snapshots.
+- Deleting a sandbox unmounts leaked runtime mounts under the sandbox directory before removing rootfs files. This is especially important for gVisor GPU sandboxes because NVIDIA CDI hooks can temporarily mount `/proc` and `/run/nvidia-ctk-hook`.

--- a/docs/architecture/network.md
+++ b/docs/architecture/network.md
@@ -1,11 +1,11 @@
 ## Network
 
-NovitaBox uses a fixed guest IP model.
+NovitaBox uses a per-sandbox network namespace model. Firecracker and gVisor share the same host access CIDR and veth allocation scheme, but the runtime-facing side is different.
 
 Each sandbox has:
 
-- fixed guest IP inside the VM
-- fixed gateway IP inside its namespace
+- fixed runtime-facing IP for the agent
+- fixed gateway IP for Firecracker tap networking
 - unique host access IP on the host
 - unique sandbox identity
 
@@ -24,6 +24,8 @@ Sandbox B:
 ```
 
 Network layout:
+
+### Firecracker
 
 ```text
 Host root netns
@@ -49,6 +51,39 @@ Host root netns
 ```
 
 The host never needs to access `169.254.0.21` directly. It accesses the unique `host_access_ip`, and the sandbox namespace translates traffic into the fixed guest IP.
+
+### gVisor
+
+gVisor runs `boxd` as a process in the prepared network namespace. There is no VM tap device in the data path. `boxlet` puts the unique host access IP on the namespace veth and puts the fixed guest IP on loopback for compatibility with the rest of the agent model.
+
+```text
+Host root netns
+  |
+  | route 10.11.0.1/32 -> vh-nb-a -> nb-a
+  |
+  +-----------------------------+
+  | nb-a                        |
+  |                             |
+  | eth0                        |
+  | 10.12.0.3/31                |
+  | 10.11.0.1/32                |
+  |                             |
+  | lo                          |
+  | 127.0.0.1                   |
+  | 169.254.0.21/30             |
+  |                             |
+  | runsc sandbox + boxd        |
+  | listens on 0.0.0.0:49983    |
+  +-----------------------------+
+```
+
+Both runtimes use the same host access URL shape:
+
+```text
+http://<host_access_ip>:49983
+```
+
+This keeps `boxproxy`, template builds, and SDK traffic independent of the runtime implementation.
 
 Default CIDRs:
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -30,14 +30,24 @@ boxshim
         - one shim per sandbox
         - runtime parent process
         - exposes RPC over Unix socket/ttrpc
-        - manages Firecracker or Cloud Hypervisor
+        - manages Firecracker, gVisor, or Cloud Hypervisor
 
 boxd
-        - guest agent inside sandbox
+        - agent inside sandbox
         - exec
         - shell
         - file operations
 ```
+
+### Runtime Families
+
+NovitaBox supports MicroVM and gVisor container runtimes through the same `RuntimeSpec` contract.
+
+- Firecracker uses a VM rootfs, guest kernel, tap device, and VM snapshot artifacts.
+- gVisor uses a directory rootfs, OCI bundle, `runsc`, and the prepared sandbox network namespace directly.
+- Cloud Hypervisor is exposed through the same runtime capability model.
+
+NVIDIA GPU support is implemented on the gVisor path. `boxshim` enables `runsc --nvproxy`, reads NVIDIA CDI specs, injects GPU device nodes and driver libraries, and keeps runtime-specific NVIDIA setup inside the gVisor OCI bundle.
 
 
 ### Copy-on-Write Memory and Storage Direction
@@ -68,4 +78,4 @@ pausevm/<sandbox-id>/memory-ranges
 resumed VM memory
 ```
 
-For storage, btrfs or XFS is recommended to support reflink-based copies.
+For storage, btrfs or XFS is recommended to support reflink-based copies. Firecracker artifacts are file based; gVisor artifacts are directory-rootfs based.

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -12,7 +12,7 @@ boxlet
 
 boxshim
   -> selects runtime driver
-  -> translates RuntimeSpec into Firecracker or Cloud Hypervisor operations
+  -> translates RuntimeSpec into Firecracker, gVisor, or Cloud Hypervisor operations
 ```
 
 RuntimeSpec includes:
@@ -21,13 +21,43 @@ RuntimeSpec includes:
 - runtime type
 - machine resources
 - kernel and rootfs paths
-- snapshot paths
+- snapshot paths when the selected runtime uses VM snapshot state
 - network configuration
 - agent configuration
 - jailer configuration
 - labels and annotations
 
 Runtime-specific details should live in runtime driver options rather than leaking into the upper layers.
+
+## Supported Runtimes
+
+### Firecracker
+
+Firecracker is the default MicroVM runtime. It uses:
+
+- `rootfs.ext4`
+- guest kernel
+- `memfile` and `snapfile` for template startup and pause/resume
+- tap networking inside a per-sandbox network namespace
+
+Firecracker is the runtime to use when full VM snapshot behavior is required.
+
+### gVisor
+
+gVisor uses `runsc` as the low-level runtime. It uses:
+
+- directory rootfs
+- OCI bundle under the sandbox directory
+- existing host network namespace prepared by `boxlet`
+- optional NVIDIA GPU injection with `runsc --nvproxy`
+
+gVisor templates are directory-rootfs templates. They do not produce Firecracker `memfile` or `snapfile` artifacts.
+
+GPU support is enabled by setting `MachineSpec.gpu` to a positive count. NovitaBox reads NVIDIA CDI specs from standard locations such as `/etc/cdi/nvidia.yaml` and merges the device nodes, bind mounts, environment variables, and supported hooks into the OCI spec. The `update-ldcache` CDI hook is skipped under `runsc`; NovitaBox injects the NVIDIA library path and creates the required `libcuda.so.1` and `libnvidia-ml.so.1` links through CDI symlink hooks.
+
+### Cloud Hypervisor
+
+Cloud Hypervisor is exposed through the same runtime abstraction. Capability fields decide which operations are available to users.
 
 ## Runtime Capabilities
 
@@ -41,6 +71,8 @@ Each runtime exposes capabilities:
 - full snapshot
 - diff snapshot
 - GPU
+- vsock
+- tap networking
 - hotplug disk
 - live resize CPU
 - live resize memory
@@ -48,4 +80,4 @@ Each runtime exposes capabilities:
 - serial console
 - jailer
 
-Capabilities allow NovitaBox to degrade API behavior based on the selected runtime.
+Capabilities allow NovitaBox to degrade API behavior based on the selected runtime. For example, gVisor supports start from image/template and graceful shutdown, but does not currently support Firecracker-style pause/resume snapshots.

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -1,6 +1,8 @@
 ## Security Model
 
-NovitaBox uses jailer-based runtime restriction.
+NovitaBox uses runtime-specific isolation.
+
+Firecracker uses jailer-based runtime restriction.
 
 Jailer responsibilities:
 
@@ -17,3 +19,12 @@ Runtime should only see the files it needs:
 - rootfs.ext4
 - snapfile
 - memfile
+
+gVisor uses `runsc` sandboxing and OCI isolation. gVisor sandboxes use their own pid, ipc, uts, mount, and network namespaces. When GPU is requested, NovitaBox enables `runsc --nvproxy` and injects only the requested NVIDIA device nodes, driver libraries, and CDI setup hooks into the OCI bundle.
+
+GPU security notes:
+
+- GPU support is NVIDIA-specific.
+- The host must provide NVIDIA drivers, `nvidia-ctk`, `nvidia-cdi-hook`, and a CDI spec such as `/etc/cdi/nvidia.yaml`.
+- GPU access exposes the requested `/dev/nvidia*` devices to the sandbox.
+- NovitaBox sets `NVIDIA_VISIBLE_DEVICES`, `CUDA_VISIBLE_DEVICES`, and `NVIDIA_DRIVER_CAPABILITIES=compute,utility` for GPU sandboxes.

--- a/docs/changelog/v0.0.3.md
+++ b/docs/changelog/v0.0.3.md
@@ -1,0 +1,32 @@
+---
+title: v0.0.3 — 2026.07.22
+---
+
+## 2026.07.22 Release v0.0.3
+
+Adds gVisor runtime support and NVIDIA GPU support for local sandboxes.
+
+### Added
+
+- gVisor runtime driver backed by `runsc`.
+- Directory-rootfs templates, images, and sandboxes for gVisor.
+- `runtimeType: "gvisor"` template creation support.
+- `runtime_type: "gvisor"` sandbox creation support.
+- `--runtime gvisor` support in `boxctl template build` and `boxctl sandbox create`.
+- `--gpu <count>` support for gVisor sandboxes.
+- NVIDIA GPU injection through runsc `nvproxy` and NVIDIA CDI.
+- NVIDIA driver library path and symlink setup for common CUDA/NVML workloads.
+- Runtime capability reporting for gVisor.
+
+### Changed
+
+- Sandbox networking now prepares runtime-specific namespace wiring for Firecracker and gVisor.
+- Template and image artifact cleanup now handles both `rootfs.ext4` and directory-rootfs layouts.
+- Sandbox cleanup unmounts leaked runtime mounts before removing rootfs directories.
+
+### Notes
+
+- gVisor requires a `runsc` binary at `$ROOT/runsc` or a configured `--runsc-bin`.
+- gVisor GPU requires NVIDIA driver, `nvidia-ctk`, `nvidia-cdi-hook`, and a CDI spec such as `/etc/cdi/nvidia.yaml`.
+- GPU support is currently NVIDIA-specific.
+- gVisor pause/resume snapshots are not supported yet.

--- a/docs/cli/image.md
+++ b/docs/cli/image.md
@@ -1,6 +1,6 @@
 # Image CLI
 
-Images are rootfs-only artifacts. They are more portable than templates because they do not include Firecracker memory state.
+Images are rootfs-only artifacts. They are more portable than templates because they do not include runtime memory state. Firecracker images use `rootfs.ext4`; gVisor images use a directory rootfs.
 
 ```bash
 boxctl image [command]
@@ -57,3 +57,8 @@ The template command also exposes conversion:
 boxctl template convert tpl-xxxxxxxxxxxxxxxxxxxx \
   --image img-xxxxxxxxxxxxxxxxxxxx
 ```
+
+Runtime notes:
+
+- Converting a Firecracker template drops `memfile` and `snapfile`.
+- Converting a gVisor template copies the directory rootfs.

--- a/docs/cli/others.md
+++ b/docs/cli/others.md
@@ -1,17 +1,3 @@
-
-## runtime
-
-list
-list all runtime
-
-show
-show runtime capabilities
-
-
-## snapshot
-
-show
-show sandbox snapshot info
 # Runtime CLI
 
 Runtime commands show what the local runtime backend can do.
@@ -30,12 +16,14 @@ boxctl runtime list
 
 ```bash
 boxctl runtime show firecracker
+boxctl runtime show gvisor
 ```
 
 ## Capabilities
 
 ```bash
 boxctl runtime capabilities firecracker
+boxctl runtime capabilities gvisor
 ```
 
 Capability fields describe whether the runtime supports:
@@ -46,6 +34,14 @@ Capability fields describe whether the runtime supports:
 - pause and resume
 - full snapshots
 - networking
+- GPU
+- graceful shutdown
+
+Runtime summary:
+
+- `firecracker`: MicroVM runtime with VM snapshot support.
+- `gvisor`: `runsc` runtime with directory rootfs support and NVIDIA GPU support through `--gpu <count>`.
+- `cloud-hypervisor`: runtime backend exposed through the same capability API.
 
 ## Global Flags
 

--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -1,6 +1,6 @@
 # Sandbox CLI
 
-Sandbox commands manage running MicroVM sandboxes.
+Sandbox commands manage running sandboxes across supported runtimes.
 
 ```bash
 boxctl sandbox [command]
@@ -37,7 +37,32 @@ Options:
 - `--template <template_id>`: template id.
 - `--image <image_id>`: image id.
 - `--snapshot <snapshot_id>`: snapshot id.
-- `--runtime <runtime_type>`: runtime type, usually `firecracker`.
+- `--runtime <runtime_type>`: runtime type, for example `firecracker` or `gvisor`.
+- `--gpu <count>`: number of NVIDIA GPUs to expose to the sandbox. GPU support is currently implemented for gVisor.
+
+Create a gVisor sandbox:
+
+```bash
+boxctl sandbox create \
+  --template tpl-xxxxxxxxxxxxxxxxxxxx \
+  --runtime gvisor
+```
+
+Create a gVisor sandbox with one NVIDIA GPU:
+
+```bash
+boxctl sandbox create \
+  --template tpl-xxxxxxxxxxxxxxxxxxxx \
+  --runtime gvisor \
+  --gpu 1
+```
+
+Validate GPU access:
+
+```bash
+boxctl sandbox exec sbx-xxxxxxxxxxxxxxxxxxxx /usr/bin/nvidia-smi
+boxctl sandbox exec sbx-xxxxxxxxxxxxxxxxxxxx /cuda-samples/vectorAdd
+```
 
 ## List and Get
 
@@ -89,6 +114,8 @@ Pause creates sandbox-bound snapshot state and releases runtime resources when p
 ```bash
 boxctl sandbox pause sbx-xxxxxxxxxxxxxxxxxxxx
 ```
+
+Pause/resume snapshots are runtime dependent. Firecracker supports VM snapshot pause/resume. gVisor pause/resume snapshots are not supported yet.
 
 Resume starts the runtime again from the sandbox snapshot:
 

--- a/docs/cli/template.md
+++ b/docs/cli/template.md
@@ -19,6 +19,7 @@ Options:
 - `--template <template_id>`: choose a template id.
 - `--cpu <count>`: template CPU count.
 - `--memory <mb>`: template memory in MB.
+- `--runtime <runtime_type>`: runtime type for the template. Supported values include `firecracker` and `gvisor`.
 
 ## Build
 
@@ -47,6 +48,7 @@ Other options:
 - `--template <template_id>`: choose a template id.
 - `--cpu <count>`: template CPU count.
 - `--memory <mb>`: template memory in MB.
+- `--runtime <runtime_type>`: choose the runtime for the template.
 
 Examples:
 
@@ -57,6 +59,19 @@ boxctl template build python-template \
   --run 'apt-get install -y python3' \
   --exec 'python3 --version'
 ```
+
+Build a gVisor template:
+
+```bash
+boxctl template build cuda-template \
+  --runtime gvisor \
+  --from-image nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubi8
+```
+
+Runtime notes:
+
+- Firecracker templates use `rootfs.ext4`, `memfile`, and `snapfile`.
+- gVisor templates use a directory rootfs and do not create Firecracker VM snapshot files.
 
 ## List
 

--- a/docs/quick-start/boxctl.md
+++ b/docs/quick-start/boxctl.md
@@ -36,6 +36,7 @@ Build steps:
 - `--exec` splits the value by whitespace and executes it directly; it can be repeated.
 - `--start-cmd` and `--ready-cmd` are passed as template lifecycle commands.
 - `--template` can be used to choose a template id; otherwise one is generated.
+- `--runtime gvisor` builds a directory-rootfs gVisor template instead of a Firecracker snapshot template.
 
 Example:
 
@@ -48,6 +49,14 @@ Example:
 ```
 
 The response includes `templateID` and `buildID`. Save the `templateID` for sandbox creation.
+
+Build a gVisor template from an NVIDIA CUDA sample image:
+
+```bash
+/data/novitabox/boxctl template build cuda-template \
+  --runtime gvisor \
+  --from-image nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubi8
+```
 
 ## List and Inspect Templates
 
@@ -77,6 +86,23 @@ You can also create from an image:
 
 ```bash
 /data/novitabox/boxctl sandbox create --image img-xxxxxxxxxxxxxxxxxxxx
+```
+
+Create a gVisor sandbox:
+
+```bash
+/data/novitabox/boxctl sandbox create \
+  --template tpl-xxxxxxxxxxxxxxxxxxxx \
+  --runtime gvisor
+```
+
+Create a gVisor sandbox with one NVIDIA GPU:
+
+```bash
+/data/novitabox/boxctl sandbox create \
+  --template tpl-xxxxxxxxxxxxxxxxxxxx \
+  --runtime gvisor \
+  --gpu 1
 ```
 
 ## Execute Commands
@@ -158,7 +184,20 @@ Convert a template to an image:
 /data/novitabox/boxctl runtime list
 /data/novitabox/boxctl runtime show firecracker
 /data/novitabox/boxctl runtime capabilities firecracker
+/data/novitabox/boxctl runtime show gvisor
+/data/novitabox/boxctl runtime capabilities gvisor
 ```
+
+## GPU Validation
+
+For gVisor GPU sandboxes:
+
+```bash
+/data/novitabox/boxctl sandbox exec sbx-xxxxxxxxxxxxxxxxxxxx /usr/bin/nvidia-smi
+/data/novitabox/boxctl sandbox exec sbx-xxxxxxxxxxxxxxxxxxxx /cuda-samples/vectorAdd
+```
+
+`nvidia-smi` validates NVIDIA driver/NVML access. `vectorAdd` validates CUDA kernel execution when the template image contains CUDA samples.
 
 ## Troubleshooting
 

--- a/docs/quick-start/cli.md
+++ b/docs/quick-start/cli.md
@@ -72,3 +72,10 @@ When debugging NovitaBox itself, prefer `boxctl` because it exposes local-only c
 /data/novitabox/boxctl sandbox list
 /data/novitabox/boxctl exec -it sbx-xxxxxxxxxxxxxxxxxxxx /bin/sh
 ```
+
+Runtime selection and GPU requests are local NovitaBox features exposed by `boxctl` and the native HTTP API:
+
+```bash
+/data/novitabox/boxctl template build cuda-template --runtime gvisor --from-image nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubi8
+/data/novitabox/boxctl sandbox create --template tpl-xxxxxxxxxxxxxxxxxxxx --runtime gvisor --gpu 1
+```

--- a/docs/quick-start/install.md
+++ b/docs/quick-start/install.md
@@ -57,6 +57,14 @@ Override only when publishing new runtime assets:
 RELEASE_VERSION=v0.0.2 RUNTIME_ASSET_VERSION=v0.0.3 scripts/install-release.sh
 ```
 
+gVisor support requires a `runsc` binary. Put it at `$ROOT_DIR/runsc` or start `boxlet`/`boxshim` with `--runsc-bin`.
+
+NVIDIA GPU support for gVisor additionally requires the NVIDIA container toolkit on the host and a CDI spec:
+
+```bash
+sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+```
+
 ### Uninstall
 
 Linux:
@@ -74,10 +82,12 @@ curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/u
 ## Requirements
 
 - Linux x86_64 or arm64
-- KVM available at `/dev/kvm`
-- TUN/TAP available at `/dev/net/tun`
+- KVM available at `/dev/kvm` for Firecracker and Cloud Hypervisor
+- TUN/TAP available at `/dev/net/tun` for Firecracker tap networking
 - Docker for building templates from Docker images
 - Btrfs or another reflink-capable filesystem for `$ROOT`
+- `runsc` for gVisor sandboxes
+- NVIDIA driver, `nvidia-ctk`, and `nvidia-cdi-hook` for gVisor GPU sandboxes
 
 The installer uses Btrfs by default.
 
@@ -138,11 +148,12 @@ The installer:
 - installs Go when needed
 - creates a Btrfs image and mounts it at `$ROOT_DIR`
 - verifies reflink support
-- checks KVM and TUN/TAP
+- checks KVM and TUN/TAP for MicroVM runtimes
 - enables IPv4 forwarding
 - builds all NovitaBox components
 - installs binaries into `$ROOT_DIR`
 - installs Firecracker and guest kernel
+- uses `$ROOT_DIR/runsc` for gVisor when present
 - writes systemd services
 - optionally configures dnsmasq
 - optionally configures Caddy with local TLS
@@ -157,6 +168,7 @@ $ROOT_DIR/boxlet
 $ROOT_DIR/boxproxy
 $ROOT_DIR/boxshim
 $ROOT_DIR/firecracker
+$ROOT_DIR/runsc        # optional, required for gVisor
 $ROOT_DIR/vmlinux.bin
 ```
 
@@ -223,6 +235,12 @@ Start services manually:
 /data/novitabox/boxproxy --root /data/novitabox --addr 127.0.0.1:8082
 ```
 
+If `runsc` is not installed at `/data/novitabox/runsc`, pass it explicitly:
+
+```bash
+/data/novitabox/boxlet --root /data/novitabox --addr 127.0.0.1:8081 --runsc-bin /usr/local/bin/runsc
+```
+
 ## Notes
 
 The Firecracker full snapshot path depends on host KVM support. On some nested virtualization hosts, template snapshot creation can fail with:
@@ -232,3 +250,13 @@ Failed to get KVM vcpu msr: 0x3a
 ```
 
 That error is not a NovitaBox network issue. It means Firecracker could not save vCPU MSR state on the current host.
+
+For gVisor GPU validation:
+
+```bash
+nvidia-smi
+sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+/data/novitabox/boxctl runtime capabilities gvisor
+```
+
+Inside a GPU sandbox, `nvidia-smi` should list the host GPU and CUDA samples such as `/cuda-samples/vectorAdd` should complete with `Test PASSED`.

--- a/docs/quick-start/sdk.md
+++ b/docs/quick-start/sdk.md
@@ -46,6 +46,13 @@ sbx.close()
 
 The same code runs in Novita production with your production API key and endpoint. No code changes required.
 
+Runtime selection and GPU allocation are NovitaBox local control-plane options. Create those templates and sandboxes with `boxctl` or the native HTTP API, then use the SDK against the resulting template or sandbox:
+
+```bash
+/data/novitabox/boxctl template build cuda-template --runtime gvisor --from-image nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubi8
+/data/novitabox/boxctl sandbox create --template tpl-xxxxxxxxxxxxxxxxxxxx --runtime gvisor --gpu 1
+```
+
 ## Verify with boxctl
 
 When SDK calls fail, first check the underlying local state:


### PR DESCRIPTION
- Document gVisor runtime support across README, API, architecture, CLI, and quick-start guides
- Add NVIDIA GPU usage with --gpu count, runsc nvproxy, and CDI requirements
- Clarify Firecracker vs gVisor artifact, networking, lifecycle, and cleanup behavior
- Add v0.0.3 changelog entries for gVisor and GPU support
- Update Chinese usage and architecture docs