### PR TITLE
feat: add Firecracker balloon memory management

### DIFF
--- a/cmd/boxctl/main.go
+++ b/cmd/boxctl/main.go
@@ -137,7 +137,76 @@ func newSandboxCommand(apiAddr *string, proxyAddr *string) *cobra.Command {
 
 	cmd.AddCommand(newSandboxExecCommand(proxyAddr))
 	cmd.AddCommand(newShellCommand(proxyAddr))
+	cmd.AddCommand(newSandboxBalloonCommand(apiAddr))
 
+	return cmd
+}
+
+func newSandboxBalloonCommand(apiAddr *string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "balloon",
+		Short: "Manage Firecracker balloon memory",
+	}
+
+	var amountMiB uint32
+	setCmd := &cobra.Command{
+		Use:   "set <sandbox_id>",
+		Short: "Set the Firecracker balloon target in MiB",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return requestAndPrint(*apiAddr, http.MethodPatch, fmt.Sprintf("/v1/sandboxes/%s/balloon", url.PathEscape(args[0])), map[string]any{"amountMiB": amountMiB})
+		},
+	}
+	setCmd.Flags().Uint32Var(&amountMiB, "amount-mib", 0, "balloon target in MiB")
+
+	var interval uint32
+	statsCmd := &cobra.Command{
+		Use:   "stats <sandbox_id>",
+		Short: "Get Firecracker balloon statistics",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return requestAndPrint(*apiAddr, http.MethodGet, fmt.Sprintf("/v1/sandboxes/%s/balloon/statistics", url.PathEscape(args[0])), nil)
+		},
+	}
+
+	statsIntervalCmd := &cobra.Command{
+		Use:   "stats-interval <sandbox_id>",
+		Short: "Set Firecracker balloon statistics polling interval",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return requestAndPrint(*apiAddr, http.MethodPatch, fmt.Sprintf("/v1/sandboxes/%s/balloon/statistics", url.PathEscape(args[0])), map[string]any{"statsPollingIntervalS": interval})
+		},
+	}
+	statsIntervalCmd.Flags().Uint32Var(&interval, "interval-s", 1, "statistics polling interval in seconds")
+
+	hintingCmd := &cobra.Command{
+		Use:   "hinting",
+		Short: "Manage Firecracker free-page hinting",
+	}
+	var acknowledgeOnStop bool
+	hintingCmd.AddCommand(&cobra.Command{
+		Use:   "get <sandbox_id>",
+		Short: "Get free-page hinting status",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return requestAndPrint(*apiAddr, http.MethodGet, fmt.Sprintf("/v1/sandboxes/%s/balloon/hinting", url.PathEscape(args[0])), nil)
+		},
+	})
+	startHintingCmd := &cobra.Command{
+		Use:   "start <sandbox_id>",
+		Short: "Start free-page hinting",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return requestAndPrint(*apiAddr, http.MethodPost, fmt.Sprintf("/v1/sandboxes/%s/balloon/hinting/start", url.PathEscape(args[0])), map[string]any{"acknowledgeOnStop": acknowledgeOnStop})
+		},
+	}
+	startHintingCmd.Flags().BoolVar(&acknowledgeOnStop, "acknowledge-on-stop", true, "acknowledge completion after stopping the hinting run")
+	hintingCmd.AddCommand(startHintingCmd)
+	hintingCmd.AddCommand(simpleAPICommand(apiAddr, "stop <sandbox_id>", "Stop free-page hinting", http.MethodPost, "/v1/sandboxes/%s/balloon/hinting/stop", 1, map[string]any{}))
+
+	cmd.AddCommand(setCmd)
+	cmd.AddCommand(simpleAPICommand(apiAddr, "get <sandbox_id>", "Get Firecracker balloon configuration", http.MethodGet, "/v1/sandboxes/%s/balloon", 1, nil))
+	cmd.AddCommand(statsCmd, statsIntervalCmd, hintingCmd)
 	return cmd
 }
 

--- a/docs/api/RPC.md
+++ b/docs/api/RPC.md
@@ -15,6 +15,13 @@ service BoxletSandboxService {
 
   rpc GetSandbox(GetSandboxRequest) returns (SandboxInfo);
   rpc ListSandboxes(ListSandboxesRequest) returns (ListSandboxesResponse);
+  rpc UpdateSandboxBalloon(UpdateSandboxBalloonRequest) returns (BalloonConfig);
+  rpc GetSandboxBalloon(GetSandboxBalloonRequest) returns (BalloonConfig);
+  rpc GetSandboxBalloonStats(GetSandboxBalloonStatsRequest) returns (BalloonStats);
+  rpc UpdateSandboxBalloonStats(UpdateSandboxBalloonStatsRequest) returns (BalloonConfig);
+  rpc StartSandboxBalloonHinting(StartSandboxBalloonHintingRequest) returns (BalloonHintingStatus);
+  rpc StopSandboxBalloonHinting(StopSandboxBalloonHintingRequest) returns (BalloonHintingStatus);
+  rpc GetSandboxBalloonHinting(GetSandboxBalloonHintingRequest) returns (BalloonHintingStatus);
 }
 ```
 
@@ -65,5 +72,12 @@ service BoxShim {
 
   rpc Status(StatusRequest) returns (RuntimeInfo);
   rpc Capabilities(CapabilitiesRequest) returns (RuntimeCapabilities);
+  rpc UpdateBalloon(UpdateBalloonRequest) returns (BalloonConfig);
+  rpc GetBalloon(GetBalloonRequest) returns (BalloonConfig);
+  rpc GetBalloonStats(GetBalloonStatsRequest) returns (BalloonStats);
+  rpc UpdateBalloonStats(UpdateBalloonStatsRequest) returns (BalloonConfig);
+  rpc StartBalloonHinting(StartBalloonHintingRequest) returns (BalloonHintingStatus);
+  rpc StopBalloonHinting(StopBalloonHintingRequest) returns (BalloonHintingStatus);
+  rpc GetBalloonHinting(GetBalloonHintingRequest) returns (BalloonHintingStatus);
 }
 ```

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -127,6 +127,44 @@ curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx/pow
 curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx/reboot
 ```
 
+## Firecracker Balloon
+
+Firecracker sandboxes create a balloon device with an initial target of `0 MiB`. Balloon statistics, `deflate_on_oom`, free-page hinting, and free-page reporting are enabled by default. The device is available for live memory reclamation without reducing guest memory at sandbox creation time. `amountMiB` is the target amount of memory to reclaim from the guest.
+
+Set and inspect the target:
+
+```bash
+curl -sS -X PATCH http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx/balloon \
+  -H 'Content-Type: application/json' \
+  -d '{"amountMiB":1024}'
+
+curl -sS http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx/balloon
+```
+
+Read balloon statistics and change the polling interval:
+
+```bash
+curl -sS http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx/balloon/statistics
+
+curl -sS -X PATCH http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx/balloon/statistics \
+  -H 'Content-Type: application/json' \
+  -d '{"statsPollingIntervalS":1}'
+```
+
+Start, inspect, and stop free-page hinting:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx/balloon/hinting/start \
+  -H 'Content-Type: application/json' \
+  -d '{"acknowledgeOnStop":true}'
+curl -sS http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx/balloon/hinting
+curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx/balloon/hinting/stop
+```
+
+Hinting is a one-shot run, not a periodic task. Its status exposes Firecracker's `hostCmd` and optional `guestCmd`; command `0` is stopped, `1` is completed, and values greater than `1` identify a hinting run.
+
+Balloon endpoints return an unsupported/conflict response for gVisor and other runtimes. The guest kernel must include the virtio-balloon driver for reclamation, statistics, and free-page reporting to have an effect. Statistics include swap, fault, free/available memory, cache, HugeTLB, OOM, allocation stall, scan, and reclaim counters when the guest kernel exposes them.
+
 Delete:
 
 ```bash
@@ -201,6 +239,13 @@ DELETE /v1/templates/{template_id}
 POST   /v1/sandboxes/{sandbox_id}/poweroff
 POST   /v1/sandboxes/{sandbox_id}/poweron
 POST   /v1/sandboxes/{sandbox_id}/reboot
+GET    /v1/sandboxes/{sandbox_id}/balloon
+PATCH  /v1/sandboxes/{sandbox_id}/balloon
+GET    /v1/sandboxes/{sandbox_id}/balloon/statistics
+PATCH  /v1/sandboxes/{sandbox_id}/balloon/statistics
+GET    /v1/sandboxes/{sandbox_id}/balloon/hinting
+POST   /v1/sandboxes/{sandbox_id}/balloon/hinting/start
+POST   /v1/sandboxes/{sandbox_id}/balloon/hinting/stop
 
 POST   /v1/templates/convert
 

--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -143,6 +143,35 @@ Reboot:
 boxctl sandbox reboot sbx-xxxxxxxxxxxxxxxxxxxx
 ```
 
+## Balloon
+
+Firecracker sandboxes expose a balloon device with an initial target of `0 MiB`. Balloon statistics, deflate-on-OOM, free-page hinting, and free-page reporting are enabled by default. Set the target to reclaim guest memory, or set it back to zero to deflate the balloon:
+
+```bash
+boxctl sandbox balloon set sbx-xxxxxxxxxxxxxxxxxxxx --amount-mib 1024
+boxctl sandbox balloon get sbx-xxxxxxxxxxxxxxxxxxxx
+boxctl sandbox balloon set sbx-xxxxxxxxxxxxxxxxxxxx --amount-mib 0
+```
+
+Inspect statistics and configure their polling interval:
+
+```bash
+boxctl sandbox balloon stats sbx-xxxxxxxxxxxxxxxxxxxx
+boxctl sandbox balloon stats-interval sbx-xxxxxxxxxxxxxxxxxxxx --interval-s 1
+```
+
+Manage free-page hinting:
+
+```bash
+boxctl sandbox balloon hinting start sbx-xxxxxxxxxxxxxxxxxxxx
+boxctl sandbox balloon hinting get sbx-xxxxxxxxxxxxxxxxxxxx
+boxctl sandbox balloon hinting stop sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+Hinting is a one-shot run. Use `--acknowledge-on-stop=false` only when the caller needs to control completion acknowledgement explicitly.
+
+Balloon is supported by the Firecracker runtime. The guest kernel must include virtio-balloon support; the API can configure the device even when the guest does not currently report reclaimable pages.
+
 Hidden compatibility aliases are available:
 
 ```bash

--- a/internal/boxapi/handler/sandbox.go
+++ b/internal/boxapi/handler/sandbox.go
@@ -96,6 +96,55 @@ type snapshotResponse struct {
 	CreatedAtUnix int64  `json:"createdAtUnix,omitempty"`
 }
 
+type updateBalloonRequest struct {
+	AmountMiB *uint32 `json:"amountMiB" binding:"required"`
+}
+
+type updateBalloonStatsRequest struct {
+	StatsPollingIntervalS *uint32 `json:"statsPollingIntervalS" binding:"required"`
+}
+
+type startBalloonHintingRequest struct {
+	AcknowledgeOnStop *bool `json:"acknowledgeOnStop"`
+}
+
+type balloonConfigResponse struct {
+	AmountMiB             uint32 `json:"amountMiB"`
+	DeflateOnOOM          bool   `json:"deflateOnOOM"`
+	StatsPollingIntervalS uint32 `json:"statsPollingIntervalS"`
+	FreePageHinting       bool   `json:"freePageHinting"`
+	FreePageReporting     bool   `json:"freePageReporting"`
+}
+
+type balloonStatsResponse struct {
+	TargetMiB          uint32 `json:"targetMiB"`
+	ActualMiB          uint32 `json:"actualMiB"`
+	SwapIn             uint64 `json:"swapIn"`
+	SwapOut            uint64 `json:"swapOut"`
+	MajorFaults        uint64 `json:"majorFaults"`
+	MinorFaults        uint64 `json:"minorFaults"`
+	FreeMemory         uint64 `json:"freeMemory"`
+	TotalMemory        uint64 `json:"totalMemory"`
+	AvailableMemory    uint64 `json:"availableMemory"`
+	DiskCaches         uint64 `json:"diskCaches"`
+	HugetlbAllocations uint64 `json:"hugetlbAllocations"`
+	HugetlbFailures    uint64 `json:"hugetlbFailures"`
+	SharedMemory       uint64 `json:"sharedMemory"`
+	UnevictableMemory  uint64 `json:"unevictableMemory"`
+	OOMKill            uint64 `json:"oomKill"`
+	AllocStall         uint64 `json:"allocStall"`
+	AsyncScan          uint64 `json:"asyncScan"`
+	DirectScan         uint64 `json:"directScan"`
+	AsyncReclaim       uint64 `json:"asyncReclaim"`
+	DirectReclaim      uint64 `json:"directReclaim"`
+}
+
+type balloonHintingResponse struct {
+	State    string  `json:"state"`
+	HostCmd  uint32  `json:"hostCmd"`
+	GuestCmd *uint32 `json:"guestCmd,omitempty"`
+}
+
 func (h *Handler) CreateSandbox(c *gin.Context) {
 	if h.store == nil {
 		response.Error(c, response.ErrInternal("storage is not configured"))
@@ -178,6 +227,169 @@ func (h *Handler) CreateSandbox(c *gin.Context) {
 	}
 
 	response.JSON(c, http.StatusCreated, sandboxRecordResponse(*created))
+}
+
+func (h *Handler) UpdateSandboxBalloon(c *gin.Context) {
+	if !h.ensureBalloonClient(c) {
+		return
+	}
+	var req updateBalloonRequest
+	if err := c.ShouldBindJSON(&req); err != nil || req.AmountMiB == nil {
+		response.Error(c, response.ErrBadRequest("amountMiB is required"))
+		return
+	}
+	config, err := h.sandboxClient.UpdateSandboxBalloon(c.Request.Context(), &novitaboxv1.UpdateSandboxBalloonRequest{
+		SandboxId: c.Param("sandbox_id"),
+		AmountMib: *req.AmountMiB,
+	})
+	if err != nil {
+		h.respondSandboxBoxletError(c, err, "update sandbox balloon failed")
+		return
+	}
+	response.JSON(c, http.StatusOK, balloonConfigProtoResponse(config))
+}
+
+func (h *Handler) GetSandboxBalloon(c *gin.Context) {
+	if !h.ensureBalloonClient(c) {
+		return
+	}
+	config, err := h.sandboxClient.GetSandboxBalloon(c.Request.Context(), &novitaboxv1.GetSandboxBalloonRequest{SandboxId: c.Param("sandbox_id")})
+	if err != nil {
+		h.respondSandboxBoxletError(c, err, "get sandbox balloon failed")
+		return
+	}
+	response.JSON(c, http.StatusOK, balloonConfigProtoResponse(config))
+}
+
+func (h *Handler) GetSandboxBalloonStats(c *gin.Context) {
+	if !h.ensureBalloonClient(c) {
+		return
+	}
+	stats, err := h.sandboxClient.GetSandboxBalloonStats(c.Request.Context(), &novitaboxv1.GetSandboxBalloonStatsRequest{SandboxId: c.Param("sandbox_id")})
+	if err != nil {
+		h.respondSandboxBoxletError(c, err, "get sandbox balloon statistics failed")
+		return
+	}
+	response.JSON(c, http.StatusOK, balloonStatsProtoResponse(stats))
+}
+
+func (h *Handler) UpdateSandboxBalloonStats(c *gin.Context) {
+	if !h.ensureBalloonClient(c) {
+		return
+	}
+	var req updateBalloonStatsRequest
+	if err := c.ShouldBindJSON(&req); err != nil || req.StatsPollingIntervalS == nil {
+		response.Error(c, response.ErrBadRequest("statsPollingIntervalS is required"))
+		return
+	}
+	config, err := h.sandboxClient.UpdateSandboxBalloonStats(c.Request.Context(), &novitaboxv1.UpdateSandboxBalloonStatsRequest{
+		SandboxId:             c.Param("sandbox_id"),
+		StatsPollingIntervalS: *req.StatsPollingIntervalS,
+	})
+	if err != nil {
+		h.respondSandboxBoxletError(c, err, "update sandbox balloon statistics failed")
+		return
+	}
+	response.JSON(c, http.StatusOK, balloonConfigProtoResponse(config))
+}
+
+func (h *Handler) StartSandboxBalloonHinting(c *gin.Context) {
+	if !h.ensureBalloonClient(c) {
+		return
+	}
+	var req startBalloonHintingRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.Error(c, response.ErrBadRequest("invalid balloon hinting request body"))
+		return
+	}
+	acknowledgeOnStop := true
+	if req.AcknowledgeOnStop != nil {
+		acknowledgeOnStop = *req.AcknowledgeOnStop
+	}
+	status, err := h.sandboxClient.StartSandboxBalloonHinting(c.Request.Context(), &novitaboxv1.StartSandboxBalloonHintingRequest{
+		SandboxId:         c.Param("sandbox_id"),
+		AcknowledgeOnStop: acknowledgeOnStop,
+	})
+	if err != nil {
+		h.respondSandboxBoxletError(c, err, "start sandbox balloon hinting failed")
+		return
+	}
+	response.JSON(c, http.StatusOK, balloonHintingProtoResponse(status))
+}
+
+func (h *Handler) StopSandboxBalloonHinting(c *gin.Context) {
+	if !h.ensureBalloonClient(c) {
+		return
+	}
+	status, err := h.sandboxClient.StopSandboxBalloonHinting(c.Request.Context(), &novitaboxv1.StopSandboxBalloonHintingRequest{SandboxId: c.Param("sandbox_id")})
+	if err != nil {
+		h.respondSandboxBoxletError(c, err, "stop sandbox balloon hinting failed")
+		return
+	}
+	response.JSON(c, http.StatusOK, balloonHintingProtoResponse(status))
+}
+
+func (h *Handler) GetSandboxBalloonHinting(c *gin.Context) {
+	if !h.ensureBalloonClient(c) {
+		return
+	}
+	status, err := h.sandboxClient.GetSandboxBalloonHinting(c.Request.Context(), &novitaboxv1.GetSandboxBalloonHintingRequest{SandboxId: c.Param("sandbox_id")})
+	if err != nil {
+		h.respondSandboxBoxletError(c, err, "get sandbox balloon hinting failed")
+		return
+	}
+	response.JSON(c, http.StatusOK, balloonHintingProtoResponse(status))
+}
+
+func balloonConfigProtoResponse(config *novitaboxv1.BalloonConfig) balloonConfigResponse {
+	return balloonConfigResponse{
+		AmountMiB:             config.GetAmountMib(),
+		DeflateOnOOM:          config.GetDeflateOnOom(),
+		StatsPollingIntervalS: config.GetStatsPollingIntervalS(),
+		FreePageHinting:       config.GetFreePageHinting(),
+		FreePageReporting:     config.GetFreePageReporting(),
+	}
+}
+
+func (h *Handler) ensureBalloonClient(c *gin.Context) bool {
+	if h.sandboxClient != nil {
+		return true
+	}
+	response.Error(c, response.ErrInternal("boxlet sandbox service is not configured"))
+	return false
+}
+
+func balloonStatsProtoResponse(stats *novitaboxv1.BalloonStats) balloonStatsResponse {
+	return balloonStatsResponse{
+		TargetMiB:          stats.GetTargetMib(),
+		ActualMiB:          stats.GetActualMib(),
+		SwapIn:             stats.GetSwapIn(),
+		SwapOut:            stats.GetSwapOut(),
+		MajorFaults:        stats.GetMajorFaults(),
+		MinorFaults:        stats.GetMinorFaults(),
+		FreeMemory:         stats.GetFreeMemory(),
+		TotalMemory:        stats.GetTotalMemory(),
+		AvailableMemory:    stats.GetAvailableMemory(),
+		DiskCaches:         stats.GetDiskCaches(),
+		HugetlbAllocations: stats.GetHugetlbAllocations(),
+		HugetlbFailures:    stats.GetHugetlbFailures(),
+		SharedMemory:       stats.GetSharedMemory(),
+		UnevictableMemory:  stats.GetUnevictableMemory(),
+		OOMKill:            stats.GetOomKill(),
+		AllocStall:         stats.GetAllocStall(),
+		AsyncScan:          stats.GetAsyncScan(),
+		DirectScan:         stats.GetDirectScan(),
+		AsyncReclaim:       stats.GetAsyncReclaim(),
+		DirectReclaim:      stats.GetDirectReclaim(),
+	}
+}
+
+func balloonHintingProtoResponse(status *novitaboxv1.BalloonHintingStatus) balloonHintingResponse {
+	return balloonHintingResponse{
+		State:    status.GetState(),
+		HostCmd:  status.GetHostCmd(),
+		GuestCmd: status.GuestCmd,
+	}
 }
 
 func (h *Handler) ListSandboxes(c *gin.Context) {
@@ -582,6 +794,10 @@ func (h *Handler) respondSandboxBoxletError(c *gin.Context, err error, fallbackM
 		response.Error(c, response.ErrConflict("sandbox already exists"))
 	case codes.InvalidArgument:
 		response.Error(c, response.ErrBadRequest(status.Convert(err).Message()))
+	case codes.FailedPrecondition:
+		response.Error(c, response.ErrConflict(status.Convert(err).Message()))
+	case codes.Unimplemented:
+		response.Error(c, response.ErrNotImplemented(status.Convert(err).Message()))
 	default:
 		message := fallbackMessage
 		if status.Convert(err).Message() != "" {

--- a/internal/boxapi/handler/sandbox_test.go
+++ b/internal/boxapi/handler/sandbox_test.go
@@ -102,3 +102,31 @@ func (f *fakeSandboxClient) GetSandbox(context.Context, *novitaboxv1.GetSandboxR
 func (f *fakeSandboxClient) ListSandboxes(context.Context, *novitaboxv1.ListSandboxesRequest, ...grpc.CallOption) (*novitaboxv1.ListSandboxesResponse, error) {
 	return nil, nil
 }
+
+func (f *fakeSandboxClient) UpdateSandboxBalloon(context.Context, *novitaboxv1.UpdateSandboxBalloonRequest, ...grpc.CallOption) (*novitaboxv1.BalloonConfig, error) {
+	return nil, nil
+}
+
+func (f *fakeSandboxClient) GetSandboxBalloon(context.Context, *novitaboxv1.GetSandboxBalloonRequest, ...grpc.CallOption) (*novitaboxv1.BalloonConfig, error) {
+	return nil, nil
+}
+
+func (f *fakeSandboxClient) GetSandboxBalloonStats(context.Context, *novitaboxv1.GetSandboxBalloonStatsRequest, ...grpc.CallOption) (*novitaboxv1.BalloonStats, error) {
+	return nil, nil
+}
+
+func (f *fakeSandboxClient) UpdateSandboxBalloonStats(context.Context, *novitaboxv1.UpdateSandboxBalloonStatsRequest, ...grpc.CallOption) (*novitaboxv1.BalloonConfig, error) {
+	return nil, nil
+}
+
+func (f *fakeSandboxClient) StartSandboxBalloonHinting(context.Context, *novitaboxv1.StartSandboxBalloonHintingRequest, ...grpc.CallOption) (*novitaboxv1.BalloonHintingStatus, error) {
+	return nil, nil
+}
+
+func (f *fakeSandboxClient) StopSandboxBalloonHinting(context.Context, *novitaboxv1.StopSandboxBalloonHintingRequest, ...grpc.CallOption) (*novitaboxv1.BalloonHintingStatus, error) {
+	return nil, nil
+}
+
+func (f *fakeSandboxClient) GetSandboxBalloonHinting(context.Context, *novitaboxv1.GetSandboxBalloonHintingRequest, ...grpc.CallOption) (*novitaboxv1.BalloonHintingStatus, error) {
+	return nil, nil
+}

--- a/internal/boxapi/server/router.go
+++ b/internal/boxapi/server/router.go
@@ -80,6 +80,13 @@ func registerV1SandboxRoutes(v1 *gin.RouterGroup, h *handler.Handler) {
 		sandboxes.POST("/:sandbox_id/poweroff", h.PoweroffSandbox)
 		sandboxes.POST("/:sandbox_id/poweron", h.PoweronSandbox)
 		sandboxes.POST("/:sandbox_id/reboot", h.RebootSandbox)
+		sandboxes.GET("/:sandbox_id/balloon", h.GetSandboxBalloon)
+		sandboxes.PATCH("/:sandbox_id/balloon", h.UpdateSandboxBalloon)
+		sandboxes.GET("/:sandbox_id/balloon/statistics", h.GetSandboxBalloonStats)
+		sandboxes.PATCH("/:sandbox_id/balloon/statistics", h.UpdateSandboxBalloonStats)
+		sandboxes.GET("/:sandbox_id/balloon/hinting", h.GetSandboxBalloonHinting)
+		sandboxes.POST("/:sandbox_id/balloon/hinting/start", h.StartSandboxBalloonHinting)
+		sandboxes.POST("/:sandbox_id/balloon/hinting/stop", h.StopSandboxBalloonHinting)
 	}
 }
 

--- a/internal/boxlet/server/services.go
+++ b/internal/boxlet/server/services.go
@@ -173,6 +173,106 @@ func (s *sandboxService) GetSandbox(ctx context.Context, req *novitaboxv1.GetSan
 	return sandboxRecordToProto(*record, runtimeTypeFromRecord(record.RuntimeType)), nil
 }
 
+func (s *sandboxService) UpdateSandboxBalloon(ctx context.Context, req *novitaboxv1.UpdateSandboxBalloonRequest) (*novitaboxv1.BalloonConfig, error) {
+	shim, closeShim, err := s.dialBalloonSandboxShim(ctx, req.GetSandboxId())
+	if err != nil {
+		return nil, err
+	}
+	defer closeShim()
+	return shim.UpdateBalloon(ctx, &novitaboxv1.UpdateBalloonRequest{SandboxId: req.GetSandboxId(), AmountMib: req.GetAmountMib()})
+}
+
+func (s *sandboxService) GetSandboxBalloon(ctx context.Context, req *novitaboxv1.GetSandboxBalloonRequest) (*novitaboxv1.BalloonConfig, error) {
+	shim, closeShim, err := s.dialBalloonSandboxShim(ctx, req.GetSandboxId())
+	if err != nil {
+		return nil, err
+	}
+	defer closeShim()
+	return shim.GetBalloon(ctx, &novitaboxv1.GetBalloonRequest{SandboxId: req.GetSandboxId()})
+}
+
+func (s *sandboxService) GetSandboxBalloonStats(ctx context.Context, req *novitaboxv1.GetSandboxBalloonStatsRequest) (*novitaboxv1.BalloonStats, error) {
+	shim, closeShim, err := s.dialBalloonSandboxShim(ctx, req.GetSandboxId())
+	if err != nil {
+		return nil, err
+	}
+	defer closeShim()
+	return shim.GetBalloonStats(ctx, &novitaboxv1.GetBalloonStatsRequest{SandboxId: req.GetSandboxId()})
+}
+
+func (s *sandboxService) UpdateSandboxBalloonStats(ctx context.Context, req *novitaboxv1.UpdateSandboxBalloonStatsRequest) (*novitaboxv1.BalloonConfig, error) {
+	shim, closeShim, err := s.dialBalloonSandboxShim(ctx, req.GetSandboxId())
+	if err != nil {
+		return nil, err
+	}
+	defer closeShim()
+	return shim.UpdateBalloonStats(ctx, &novitaboxv1.UpdateBalloonStatsRequest{
+		SandboxId:             req.GetSandboxId(),
+		StatsPollingIntervalS: req.GetStatsPollingIntervalS(),
+	})
+}
+
+func (s *sandboxService) StartSandboxBalloonHinting(ctx context.Context, req *novitaboxv1.StartSandboxBalloonHintingRequest) (*novitaboxv1.BalloonHintingStatus, error) {
+	shim, closeShim, err := s.dialBalloonSandboxShim(ctx, req.GetSandboxId())
+	if err != nil {
+		return nil, err
+	}
+	defer closeShim()
+	return shim.StartBalloonHinting(ctx, &novitaboxv1.StartBalloonHintingRequest{
+		SandboxId:         req.GetSandboxId(),
+		AcknowledgeOnStop: req.GetAcknowledgeOnStop(),
+	})
+}
+
+func (s *sandboxService) StopSandboxBalloonHinting(ctx context.Context, req *novitaboxv1.StopSandboxBalloonHintingRequest) (*novitaboxv1.BalloonHintingStatus, error) {
+	shim, closeShim, err := s.dialBalloonSandboxShim(ctx, req.GetSandboxId())
+	if err != nil {
+		return nil, err
+	}
+	defer closeShim()
+	return shim.StopBalloonHinting(ctx, &novitaboxv1.StopBalloonHintingRequest{SandboxId: req.GetSandboxId()})
+}
+
+func (s *sandboxService) GetSandboxBalloonHinting(ctx context.Context, req *novitaboxv1.GetSandboxBalloonHintingRequest) (*novitaboxv1.BalloonHintingStatus, error) {
+	shim, closeShim, err := s.dialBalloonSandboxShim(ctx, req.GetSandboxId())
+	if err != nil {
+		return nil, err
+	}
+	defer closeShim()
+	return shim.GetBalloonHinting(ctx, &novitaboxv1.GetBalloonHintingRequest{SandboxId: req.GetSandboxId()})
+}
+
+func (s *sandboxService) dialBalloonSandboxShim(ctx context.Context, sandboxID string) (novitaboxv1.BoxShimClient, func() error, error) {
+	if sandboxID == "" {
+		return nil, nil, status.Error(codes.InvalidArgument, "sandbox_id is required")
+	}
+	record, err := s.store.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, nil, status.Error(codes.NotFound, "sandbox not found")
+		}
+		return nil, nil, err
+	}
+	shim, closeShim, err := s.dialSandboxShim(ctx, sandboxID)
+	if err != nil {
+		return nil, nil, err
+	}
+	caps, err := shim.Capabilities(ctx, &novitaboxv1.CapabilitiesRequest{RuntimeType: runtimeTypeFromRecord(record.RuntimeType)})
+	if err != nil {
+		_ = closeShim()
+		return nil, nil, fmt.Errorf("get runtime capabilities: %w", err)
+	}
+	if !caps.GetBalloon() {
+		_ = closeShim()
+		runtimeName := runtimeDriverFromRecord(record.RuntimeType)
+		if runtimeName == "" {
+			runtimeName = "unknown"
+		}
+		return nil, nil, status.Errorf(codes.Unimplemented, "balloon is not supported by runtime %q", runtimeName)
+	}
+	return shim, closeShim, nil
+}
+
 func (s *sandboxService) PauseSandbox(ctx context.Context, req *novitaboxv1.PauseSandboxRequest) (*novitaboxv1.SnapshotInfo, error) {
 	record, err := s.store.GetSandbox(ctx, req.GetSandboxId())
 	if err != nil {

--- a/internal/boxshim/runtime/driver.go
+++ b/internal/boxshim/runtime/driver.go
@@ -17,4 +17,11 @@ type Driver interface {
 	Reboot(ctx context.Context, sandboxID string, timeout time.Duration) (*novitaboxv1.RuntimeInfo, error)
 	Status(ctx context.Context, sandboxID string) (*novitaboxv1.RuntimeInfo, error)
 	Capabilities(ctx context.Context, runtimeType novitaboxv1.RuntimeType) (*novitaboxv1.RuntimeCapabilities, error)
+	UpdateBalloon(ctx context.Context, sandboxID string, amountMiB uint32) (*novitaboxv1.BalloonConfig, error)
+	GetBalloon(ctx context.Context, sandboxID string) (*novitaboxv1.BalloonConfig, error)
+	GetBalloonStats(ctx context.Context, sandboxID string) (*novitaboxv1.BalloonStats, error)
+	UpdateBalloonStats(ctx context.Context, sandboxID string, intervalSeconds uint32) (*novitaboxv1.BalloonConfig, error)
+	StartBalloonHinting(ctx context.Context, sandboxID string, acknowledgeOnStop bool) (*novitaboxv1.BalloonHintingStatus, error)
+	StopBalloonHinting(ctx context.Context, sandboxID string) (*novitaboxv1.BalloonHintingStatus, error)
+	GetBalloonHinting(ctx context.Context, sandboxID string) (*novitaboxv1.BalloonHintingStatus, error)
 }

--- a/internal/boxshim/runtime/firecracker.go
+++ b/internal/boxshim/runtime/firecracker.go
@@ -43,10 +43,12 @@ const (
 )
 
 type firecrackerLaunch struct {
-	cmd       *exec.Cmd
-	apiSocket string
-	logPath   string
-	jailer    *firecrackerJailerRuntime
+	cmd             *exec.Cmd
+	apiSocket       string
+	logPath         string
+	metricsHostPath string
+	metricsPath     string
+	jailer          *firecrackerJailerRuntime
 }
 
 type firecrackerJailerRuntime struct {
@@ -146,6 +148,12 @@ func (d *FirecrackerDriver) Create(ctx context.Context, spec *novitaboxv1.Runtim
 		if err := launch.jailer.prepareMounts(spec); err != nil {
 			return nil, err
 		}
+		if err := launch.jailer.ensureWritableByJailer(launch.metricsHostPath, false); err != nil {
+			return nil, fmt.Errorf("prepare firecracker metrics file permissions: %w", err)
+		}
+		if err := launch.jailer.bindFile(launch.metricsHostPath, launch.metricsPath); err != nil {
+			return nil, fmt.Errorf("bind firecracker metrics file: %w", err)
+		}
 	}
 
 	apiSocket, err := d.startFirecrackerLocked(launch)
@@ -160,7 +168,7 @@ func (d *FirecrackerDriver) Create(ctx context.Context, spec *novitaboxv1.Runtim
 		return nil, d.withLogTail(err)
 	}
 
-	if err := d.configureMachine(ctx, spec); err != nil {
+	if err := d.configureMachine(ctx, spec, launch.metricsPath); err != nil {
 		_ = d.killLocked()
 		return nil, d.withLogTail(err)
 	}
@@ -374,6 +382,12 @@ func (d *FirecrackerDriver) Resume(ctx context.Context, spec *novitaboxv1.Runtim
 		if err := launch.jailer.prepareMounts(spec); err != nil {
 			return nil, err
 		}
+		if err := launch.jailer.ensureWritableByJailer(launch.metricsHostPath, false); err != nil {
+			return nil, fmt.Errorf("prepare firecracker metrics file permissions: %w", err)
+		}
+		if err := launch.jailer.bindFile(launch.metricsHostPath, launch.metricsPath); err != nil {
+			return nil, fmt.Errorf("bind firecracker metrics file: %w", err)
+		}
 	}
 
 	apiSocket, err := d.startFirecrackerLocked(launch)
@@ -386,6 +400,10 @@ func (d *FirecrackerDriver) Resume(ctx context.Context, spec *novitaboxv1.Runtim
 	if err := d.waitForAPI(ctx, apiSocket); err != nil {
 		_ = d.killLocked()
 		return nil, d.withLogTail(err)
+	}
+	if err := d.client.PutMetrics(ctx, launch.metricsPath); err != nil {
+		_ = d.killLocked()
+		return nil, d.withLogTail(fmt.Errorf("configure firecracker metrics: %w", err))
 	}
 
 	req := firecrackerSnapshotLoadRequest{
@@ -512,14 +530,18 @@ func (d *FirecrackerDriver) Capabilities(context.Context, novitaboxv1.RuntimeTyp
 		Gpu:               false,
 		Vsock:             true,
 		TapNetwork:        true,
+		Balloon:           true,
 		GracefulShutdown:  true,
 		SerialConsole:     true,
 		Jailer:            true,
 	}, nil
 }
 
-func (d *FirecrackerDriver) configureMachine(ctx context.Context, spec *novitaboxv1.RuntimeSpec) error {
+func (d *FirecrackerDriver) configureMachine(ctx context.Context, spec *novitaboxv1.RuntimeSpec, metricsPath string) error {
 	spec = d.runtimeSpec(spec)
+	if err := d.client.PutMetrics(ctx, metricsPath); err != nil {
+		return fmt.Errorf("configure firecracker metrics: %w", err)
+	}
 	machine := spec.GetMachine()
 	vcpu := machine.GetVcpu()
 	if vcpu == 0 {
@@ -535,6 +557,17 @@ func (d *FirecrackerDriver) configureMachine(ctx context.Context, spec *novitabo
 		MemSizeMib: int64(memoryMB),
 	}); err != nil {
 		return fmt.Errorf("configure firecracker machine: %w", err)
+	}
+
+	balloon := effectiveBalloonSpec(spec.GetBalloon())
+	if err := d.client.PutBalloon(ctx, firecrackerBalloonConfig{
+		AmountMiB:             balloon.GetAmountMib(),
+		DeflateOnOOM:          balloon.GetDeflateOnOom(),
+		StatsPollingIntervalS: balloon.GetStatsPollingIntervalS(),
+		FreePageHinting:       balloon.GetFreePageHinting(),
+		FreePageReporting:     balloon.GetFreePageReporting(),
+	}); err != nil {
+		return fmt.Errorf("configure firecracker balloon: %w", err)
 	}
 
 	if err := d.client.PutBootSource(ctx, firecrackerBootSource{
@@ -586,6 +619,188 @@ func (d *FirecrackerDriver) configureMachine(ctx context.Context, spec *novitabo
 	return nil
 }
 
+func effectiveBalloonSpec(spec *novitaboxv1.BalloonSpec) *novitaboxv1.BalloonSpec {
+	if spec == nil {
+		spec = &novitaboxv1.BalloonSpec{}
+	}
+
+	// Keep all Firecracker balloon features enabled. The target amount remains
+	// caller-controlled, while the feature bits are creation-time capabilities.
+	cloned := *spec
+	cloned.DeflateOnOom = true
+	if cloned.StatsPollingIntervalS == 0 {
+		cloned.StatsPollingIntervalS = 1
+	}
+	cloned.FreePageHinting = true
+	cloned.FreePageReporting = true
+	return &cloned
+}
+
+func (d *FirecrackerDriver) UpdateBalloon(ctx context.Context, sandboxID string, amountMiB uint32) (*novitaboxv1.BalloonConfig, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if err := d.checkBalloonRuntimeLocked(sandboxID); err != nil {
+		return nil, err
+	}
+	if err := d.client.UpdateBalloon(ctx, amountMiB); err != nil {
+		return nil, d.withLogTail(fmt.Errorf("update firecracker balloon: %w", err))
+	}
+	return d.getBalloonLocked(ctx)
+}
+
+func (d *FirecrackerDriver) GetBalloon(ctx context.Context, sandboxID string) (*novitaboxv1.BalloonConfig, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if err := d.checkBalloonRuntimeLocked(sandboxID); err != nil {
+		return nil, err
+	}
+	return d.getBalloonLocked(ctx)
+}
+
+func (d *FirecrackerDriver) GetBalloonStats(ctx context.Context, sandboxID string) (*novitaboxv1.BalloonStats, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if err := d.checkBalloonRuntimeLocked(sandboxID); err != nil {
+		return nil, err
+	}
+	stats, err := d.client.GetBalloonStats(ctx)
+	if err != nil {
+		return nil, d.withLogTail(fmt.Errorf("get firecracker balloon statistics: %w", err))
+	}
+	return balloonStatsToProto(stats), nil
+}
+
+func (d *FirecrackerDriver) UpdateBalloonStats(ctx context.Context, sandboxID string, intervalSeconds uint32) (*novitaboxv1.BalloonConfig, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if err := d.checkBalloonRuntimeLocked(sandboxID); err != nil {
+		return nil, err
+	}
+	if err := d.client.UpdateBalloonStats(ctx, intervalSeconds); err != nil {
+		return nil, d.withLogTail(fmt.Errorf("update firecracker balloon statistics: %w", err))
+	}
+	return d.getBalloonLocked(ctx)
+}
+
+func (d *FirecrackerDriver) StartBalloonHinting(ctx context.Context, sandboxID string, acknowledgeOnStop bool) (*novitaboxv1.BalloonHintingStatus, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if err := d.checkBalloonRuntimeLocked(sandboxID); err != nil {
+		return nil, err
+	}
+	if err := d.client.StartBalloonHinting(ctx, acknowledgeOnStop); err != nil {
+		return nil, d.withLogTail(fmt.Errorf("start firecracker balloon hinting: %w", err))
+	}
+	return d.getBalloonHintingLocked(ctx)
+}
+
+func (d *FirecrackerDriver) StopBalloonHinting(ctx context.Context, sandboxID string) (*novitaboxv1.BalloonHintingStatus, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if err := d.checkBalloonRuntimeLocked(sandboxID); err != nil {
+		return nil, err
+	}
+	if err := d.client.StopBalloonHinting(ctx); err != nil {
+		return nil, d.withLogTail(fmt.Errorf("stop firecracker balloon hinting: %w", err))
+	}
+	return d.getBalloonHintingLocked(ctx)
+}
+
+func (d *FirecrackerDriver) GetBalloonHinting(ctx context.Context, sandboxID string) (*novitaboxv1.BalloonHintingStatus, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if err := d.checkBalloonRuntimeLocked(sandboxID); err != nil {
+		return nil, err
+	}
+	return d.getBalloonHintingLocked(ctx)
+}
+
+func (d *FirecrackerDriver) checkBalloonRuntimeLocked(sandboxID string) error {
+	if err := d.checkSandboxLocked(sandboxID); err != nil {
+		return err
+	}
+	if d.client == nil {
+		return errors.New("firecracker api client is not available")
+	}
+	if err := d.checkProcessAliveLocked(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *FirecrackerDriver) getBalloonLocked(ctx context.Context) (*novitaboxv1.BalloonConfig, error) {
+	config, err := d.client.GetBalloon(ctx)
+	if err != nil {
+		return nil, d.withLogTail(fmt.Errorf("get firecracker balloon: %w", err))
+	}
+	return balloonConfigToProto(config), nil
+}
+
+func (d *FirecrackerDriver) getBalloonHintingLocked(ctx context.Context) (*novitaboxv1.BalloonHintingStatus, error) {
+	status, err := d.client.GetBalloonHinting(ctx)
+	if err != nil {
+		return nil, d.withLogTail(fmt.Errorf("get firecracker balloon hinting: %w", err))
+	}
+	return &novitaboxv1.BalloonHintingStatus{
+		State:    balloonHintingState(status.HostCmd, status.GuestCmd),
+		HostCmd:  status.HostCmd,
+		GuestCmd: status.GuestCmd,
+	}, nil
+}
+
+func balloonHintingState(hostCmd uint32, guestCmd *uint32) string {
+	switch hostCmd {
+	case 0:
+		return "stopped"
+	case 1:
+		return "completed"
+	default:
+		if guestCmd != nil && *guestCmd == hostCmd {
+			return "running"
+		}
+		return "starting"
+	}
+}
+
+func balloonConfigToProto(config *firecrackerBalloonConfig) *novitaboxv1.BalloonConfig {
+	return &novitaboxv1.BalloonConfig{
+		AmountMib:             config.AmountMiB,
+		DeflateOnOom:          config.DeflateOnOOM,
+		StatsPollingIntervalS: config.StatsPollingIntervalS,
+		FreePageHinting:       config.FreePageHinting,
+		FreePageReporting:     config.FreePageReporting,
+	}
+}
+
+func balloonStatsToProto(stats *firecrackerBalloonStats) *novitaboxv1.BalloonStats {
+	return &novitaboxv1.BalloonStats{
+		TargetMib:          stats.TargetMiB,
+		ActualMib:          stats.ActualMiB,
+		SwapIn:             stats.SwapIn,
+		SwapOut:            stats.SwapOut,
+		MajorFaults:        stats.MajorFaults,
+		MinorFaults:        stats.MinorFaults,
+		FreeMemory:         stats.FreeMemory,
+		TotalMemory:        stats.TotalMemory,
+		AvailableMemory:    stats.AvailableMemory,
+		DiskCaches:         stats.DiskCaches,
+		HugetlbAllocations: stats.HugetlbAllocations,
+		HugetlbFailures:    stats.HugetlbFailures,
+		SharedMemory:       stats.SharedMemory,
+		UnevictableMemory:  stats.UnevictableMemory,
+		OomKill:            stats.OOMKill,
+		AllocStall:         stats.AllocStall,
+		AsyncScan:          stats.AsyncScan,
+		DirectScan:         stats.DirectScan,
+		AsyncReclaim:       stats.AsyncReclaim,
+		DirectReclaim:      stats.DirectReclaim,
+	}
+}
+
 func (d *FirecrackerDriver) startFirecrackerLocked(launch *firecrackerLaunch) (string, error) {
 	logPath := launch.logPath
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
@@ -619,6 +834,15 @@ func (d *FirecrackerDriver) startFirecrackerLocked(launch *firecrackerLaunch) (s
 }
 
 func (d *FirecrackerDriver) prepareFirecrackerLaunch(spec *novitaboxv1.RuntimeSpec, sandboxDir string) (*firecrackerLaunch, error) {
+	metricsHostPath := filepath.Join(sandboxDir, "firecracker-metrics.json")
+	metricsFile, err := os.OpenFile(metricsHostPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("create firecracker metrics file: %w", err)
+	}
+	if err := metricsFile.Close(); err != nil {
+		return nil, fmt.Errorf("close firecracker metrics file: %w", err)
+	}
+
 	jailerSpec, useJailer, err := d.effectiveJailerSpec(spec)
 	if err != nil {
 		return nil, err
@@ -629,9 +853,11 @@ func (d *FirecrackerDriver) prepareFirecrackerLaunch(spec *novitaboxv1.RuntimeSp
 			return nil, fmt.Errorf("remove stale firecracker api socket: %w", err)
 		}
 		return &firecrackerLaunch{
-			cmd:       firecrackerCommand(d.cfg.Firecracker.BinaryPath, apiSocket, spec.GetNetwork()),
-			apiSocket: apiSocket,
-			logPath:   filepath.Join(sandboxDir, "firecracker.log"),
+			cmd:             firecrackerCommand(d.cfg.Firecracker.BinaryPath, apiSocket, spec.GetNetwork()),
+			apiSocket:       apiSocket,
+			logPath:         filepath.Join(sandboxDir, "firecracker.log"),
+			metricsHostPath: metricsHostPath,
+			metricsPath:     metricsHostPath,
 		}, nil
 	}
 
@@ -665,10 +891,12 @@ func (d *FirecrackerDriver) prepareFirecrackerLaunch(spec *novitaboxv1.RuntimeSp
 	jailer.apiLink = apiSocket
 
 	return &firecrackerLaunch{
-		cmd:       firecrackerJailerNetworkCommand(d.cfg.Firecracker.BinaryPath, jailerSpec, spec.GetSandboxId(), jailerGuestAPISocket, spec.GetNetwork()),
-		apiSocket: apiSocket,
-		logPath:   filepath.Join(sandboxDir, "firecracker.log"),
-		jailer:    jailer,
+		cmd:             firecrackerJailerNetworkCommand(d.cfg.Firecracker.BinaryPath, jailerSpec, spec.GetSandboxId(), jailerGuestAPISocket, spec.GetNetwork()),
+		apiSocket:       apiSocket,
+		logPath:         filepath.Join(sandboxDir, "firecracker.log"),
+		metricsHostPath: metricsHostPath,
+		metricsPath:     "/metrics.json",
+		jailer:          jailer,
 	}, nil
 }
 

--- a/internal/boxshim/runtime/firecracker_api.go
+++ b/internal/boxshim/runtime/firecracker_api.go
@@ -11,12 +11,18 @@ import (
 )
 
 const (
-	firecrackerPathMachineConfig  = "/machine-config"
-	firecrackerPathBootSource     = "/boot-source"
-	firecrackerPathActions        = "/actions"
-	firecrackerPathVM             = "/vm"
-	firecrackerPathSnapshotLoad   = "/snapshot/load"
-	firecrackerPathSnapshotCreate = "/snapshot/create"
+	firecrackerPathMachineConfig       = "/machine-config"
+	firecrackerPathBootSource          = "/boot-source"
+	firecrackerPathActions             = "/actions"
+	firecrackerPathVM                  = "/vm"
+	firecrackerPathBalloon             = "/balloon"
+	firecrackerPathBalloonStats        = "/balloon/statistics"
+	firecrackerPathBalloonHinting      = "/balloon/hinting/status"
+	firecrackerPathBalloonHintingStart = "/balloon/hinting/start"
+	firecrackerPathBalloonHintingStop  = "/balloon/hinting/stop"
+	firecrackerPathMetrics             = "/metrics"
+	firecrackerPathSnapshotLoad        = "/snapshot/load"
+	firecrackerPathSnapshotCreate      = "/snapshot/create"
 )
 
 func firecrackerDrivePath(driveID string) string {
@@ -29,12 +35,14 @@ func firecrackerNetworkInterfacePath(ifaceID string) string {
 
 type firecrackerClient struct {
 	socketPath string
+	baseURL    string
 	httpClient *http.Client
 }
 
 func newFirecrackerClient(socketPath string) *firecrackerClient {
 	return &firecrackerClient{
 		socketPath: socketPath,
+		baseURL:    "http://unix",
 		httpClient: &http.Client{
 			Transport: &http.Transport{
 				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
@@ -61,6 +69,10 @@ func (c *firecrackerClient) PutNetworkInterface(ctx context.Context, req firecra
 	return c.put(ctx, firecrackerNetworkInterfacePath(req.IfaceID), req)
 }
 
+func (c *firecrackerClient) PutMetrics(ctx context.Context, path string) error {
+	return c.put(ctx, firecrackerPathMetrics, firecrackerMetricsConfig{MetricsPath: path})
+}
+
 func (c *firecrackerClient) StartInstance(ctx context.Context) error {
 	return c.put(ctx, firecrackerPathActions, firecrackerActionRequest{ActionType: "InstanceStart"})
 }
@@ -81,15 +93,63 @@ func (c *firecrackerClient) LoadSnapshot(ctx context.Context, req firecrackerSna
 	return c.put(ctx, firecrackerPathSnapshotLoad, req)
 }
 
+func (c *firecrackerClient) PutBalloon(ctx context.Context, req firecrackerBalloonConfig) error {
+	return c.put(ctx, firecrackerPathBalloon, req)
+}
+
+func (c *firecrackerClient) UpdateBalloon(ctx context.Context, amountMiB uint32) error {
+	return c.patch(ctx, firecrackerPathBalloon, firecrackerBalloonUpdate{AmountMiB: amountMiB})
+}
+
+func (c *firecrackerClient) GetBalloon(ctx context.Context) (*firecrackerBalloonConfig, error) {
+	var out firecrackerBalloonConfig
+	if err := c.get(ctx, firecrackerPathBalloon, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *firecrackerClient) GetBalloonStats(ctx context.Context) (*firecrackerBalloonStats, error) {
+	var out firecrackerBalloonStats
+	if err := c.get(ctx, firecrackerPathBalloonStats, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *firecrackerClient) UpdateBalloonStats(ctx context.Context, intervalSeconds uint32) error {
+	return c.patch(ctx, firecrackerPathBalloonStats, firecrackerBalloonStatsUpdate{StatsPollingIntervalS: intervalSeconds})
+}
+
+func (c *firecrackerClient) StartBalloonHinting(ctx context.Context, acknowledgeOnStop bool) error {
+	return c.patch(ctx, firecrackerPathBalloonHintingStart, firecrackerBalloonHintingConfig{AcknowledgeOnStop: acknowledgeOnStop})
+}
+
+func (c *firecrackerClient) StopBalloonHinting(ctx context.Context) error {
+	return c.patch(ctx, firecrackerPathBalloonHintingStop, nil)
+}
+
+func (c *firecrackerClient) GetBalloonHinting(ctx context.Context) (*firecrackerBalloonHintingStatus, error) {
+	var out firecrackerBalloonHintingStatus
+	if err := c.get(ctx, firecrackerPathBalloonHinting, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
 func (c *firecrackerClient) put(ctx context.Context, path string, body any) error {
-	return c.do(ctx, http.MethodPut, path, body)
+	return c.do(ctx, http.MethodPut, path, body, nil)
 }
 
 func (c *firecrackerClient) patch(ctx context.Context, path string, body any) error {
-	return c.do(ctx, http.MethodPatch, path, body)
+	return c.do(ctx, http.MethodPatch, path, body, nil)
 }
 
-func (c *firecrackerClient) do(ctx context.Context, method string, path string, body any) error {
+func (c *firecrackerClient) get(ctx context.Context, path string, out any) error {
+	return c.do(ctx, http.MethodGet, path, nil, out)
+}
+
+func (c *firecrackerClient) do(ctx context.Context, method string, path string, body any, out any) error {
 	var r io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -99,7 +159,7 @@ func (c *firecrackerClient) do(ctx context.Context, method string, path string, 
 		r = bytes.NewReader(data)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, "http://unix"+path, r)
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, r)
 	if err != nil {
 		return fmt.Errorf("create firecracker request: %w", err)
 	}
@@ -114,6 +174,12 @@ func (c *firecrackerClient) do(ctx context.Context, method string, path string, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if out == nil || resp.StatusCode == http.StatusNoContent {
+			return nil
+		}
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return fmt.Errorf("decode firecracker response: %w", err)
+		}
 		return nil
 	}
 
@@ -144,6 +210,10 @@ type firecrackerNetworkInterface struct {
 	GuestMAC    string `json:"guest_mac,omitempty"`
 }
 
+type firecrackerMetricsConfig struct {
+	MetricsPath string `json:"metrics_path"`
+}
+
 type firecrackerActionRequest struct {
 	ActionType string `json:"action_type"`
 }
@@ -168,4 +238,52 @@ type firecrackerSnapshotLoadRequest struct {
 	MemBackend          firecrackerMemBackend `json:"mem_backend"`
 	ResumeVM            bool                  `json:"resume_vm"`
 	EnableDiffSnapshots bool                  `json:"enable_diff_snapshots"`
+}
+
+type firecrackerBalloonConfig struct {
+	AmountMiB             uint32 `json:"amount_mib"`
+	DeflateOnOOM          bool   `json:"deflate_on_oom"`
+	StatsPollingIntervalS uint32 `json:"stats_polling_interval_s"`
+	FreePageHinting       bool   `json:"free_page_hinting"`
+	FreePageReporting     bool   `json:"free_page_reporting"`
+}
+
+type firecrackerBalloonUpdate struct {
+	AmountMiB uint32 `json:"amount_mib"`
+}
+
+type firecrackerBalloonStatsUpdate struct {
+	StatsPollingIntervalS uint32 `json:"stats_polling_interval_s"`
+}
+
+type firecrackerBalloonHintingConfig struct {
+	AcknowledgeOnStop bool `json:"acknowledge_on_stop"`
+}
+
+type firecrackerBalloonHintingStatus struct {
+	HostCmd  uint32  `json:"host_cmd"`
+	GuestCmd *uint32 `json:"guest_cmd"`
+}
+
+type firecrackerBalloonStats struct {
+	TargetMiB          uint32 `json:"target_mib"`
+	ActualMiB          uint32 `json:"actual_mib"`
+	SwapIn             uint64 `json:"swap_in"`
+	SwapOut            uint64 `json:"swap_out"`
+	MajorFaults        uint64 `json:"major_faults"`
+	MinorFaults        uint64 `json:"minor_faults"`
+	FreeMemory         uint64 `json:"free_memory"`
+	TotalMemory        uint64 `json:"total_memory"`
+	AvailableMemory    uint64 `json:"available_memory"`
+	DiskCaches         uint64 `json:"disk_caches"`
+	HugetlbAllocations uint64 `json:"hugetlb_allocations"`
+	HugetlbFailures    uint64 `json:"hugetlb_failures"`
+	SharedMemory       uint64 `json:"shared_memory"`
+	UnevictableMemory  uint64 `json:"unevictable_memory"`
+	OOMKill            uint64 `json:"oom_kill"`
+	AllocStall         uint64 `json:"alloc_stall"`
+	AsyncScan          uint64 `json:"async_scan"`
+	DirectScan         uint64 `json:"direct_scan"`
+	AsyncReclaim       uint64 `json:"async_reclaim"`
+	DirectReclaim      uint64 `json:"direct_reclaim"`
 }

--- a/internal/boxshim/runtime/firecracker_test.go
+++ b/internal/boxshim/runtime/firecracker_test.go
@@ -1,7 +1,11 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -79,6 +83,159 @@ func TestBootArgsDoNotOverrideNetworkIPArg(t *testing.T) {
 	if !strings.Contains(got, "ip=10.0.0.2::10.0.0.1:255.255.255.0::eth0:off") {
 		t.Fatalf("boot args = %q, want existing ip arg", got)
 	}
+}
+
+func TestEffectiveBalloonSpecEnablesAllFeatures(t *testing.T) {
+	got := effectiveBalloonSpec(&novitaboxv1.BalloonSpec{AmountMib: 256})
+	if got.GetAmountMib() != 256 {
+		t.Fatalf("amount_mib = %d, want 256", got.GetAmountMib())
+	}
+	if !got.GetDeflateOnOom() {
+		t.Fatal("deflate_on_oom = false, want true")
+	}
+	if got.GetStatsPollingIntervalS() != 1 {
+		t.Fatalf("stats_polling_interval_s = %d, want 1", got.GetStatsPollingIntervalS())
+	}
+	if !got.GetFreePageHinting() {
+		t.Fatal("free_page_hinting = false, want true")
+	}
+	if !got.GetFreePageReporting() {
+		t.Fatal("free_page_reporting = false, want true")
+	}
+}
+
+func TestFirecrackerBalloonAPI(t *testing.T) {
+	client := newFirecrackerClient("unused")
+	client.baseURL = "http://firecracker.test"
+	client.httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		var body []byte
+		var err error
+		if r.Body != nil {
+			body, err = io.ReadAll(r.Body)
+			if err != nil {
+				return nil, err
+			}
+		}
+		newResponse := func(status int, payload any) *http.Response {
+			var data []byte
+			if payload != nil {
+				data, _ = json.Marshal(payload)
+			}
+			return &http.Response{
+				StatusCode: status,
+				Status:     http.StatusText(status),
+				Body:       io.NopCloser(bytes.NewReader(data)),
+				Header:     make(http.Header),
+				Request:    r,
+			}
+		}
+		switch r.Method + " " + r.URL.Path {
+		case "PUT /balloon":
+			var req firecrackerBalloonConfig
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Fatalf("decode balloon config: %v", err)
+			}
+			if req.AmountMiB != 0 || !req.DeflateOnOOM || req.StatsPollingIntervalS != 1 || !req.FreePageHinting || !req.FreePageReporting {
+				t.Errorf("balloon config = %#v", req)
+			}
+			return newResponse(http.StatusNoContent, nil), nil
+		case "PATCH /balloon":
+			var req firecrackerBalloonUpdate
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Fatalf("decode balloon update: %v", err)
+			}
+			if req.AmountMiB != 256 {
+				t.Errorf("balloon amount = %d, want 256", req.AmountMiB)
+			}
+			return newResponse(http.StatusNoContent, nil), nil
+		case "GET /balloon":
+			return newResponse(http.StatusOK, firecrackerBalloonConfig{AmountMiB: 256, DeflateOnOOM: true, StatsPollingIntervalS: 1, FreePageHinting: true, FreePageReporting: true}), nil
+		case "GET /balloon/statistics":
+			return newResponse(http.StatusOK, firecrackerBalloonStats{TargetMiB: 256, ActualMiB: 128, AvailableMemory: 1024}), nil
+		case "PATCH /balloon/statistics":
+			var req firecrackerBalloonStatsUpdate
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Fatalf("decode stats update: %v", err)
+			}
+			if req.StatsPollingIntervalS != 2 {
+				t.Errorf("stats interval = %d, want 2", req.StatsPollingIntervalS)
+			}
+			return newResponse(http.StatusNoContent, nil), nil
+		case "PATCH /balloon/hinting/start":
+			var req firecrackerBalloonHintingConfig
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Fatalf("decode hinting start: %v", err)
+			}
+			if !req.AcknowledgeOnStop {
+				t.Error("acknowledge_on_stop = false, want true")
+			}
+			return newResponse(http.StatusNoContent, nil), nil
+		case "PATCH /balloon/hinting/stop":
+			return newResponse(http.StatusNoContent, nil), nil
+		case "GET /balloon/hinting/status":
+			guestCmd := uint32(2)
+			return newResponse(http.StatusOK, firecrackerBalloonHintingStatus{HostCmd: 2, GuestCmd: &guestCmd}), nil
+		default:
+			return newResponse(http.StatusNotFound, nil), nil
+		}
+	})
+	ctx := context.Background()
+	if err := client.PutBalloon(ctx, firecrackerBalloonConfig{DeflateOnOOM: true, StatsPollingIntervalS: 1, FreePageHinting: true, FreePageReporting: true}); err != nil {
+		t.Fatalf("PutBalloon() error = %v", err)
+	}
+	if err := client.UpdateBalloon(ctx, 256); err != nil {
+		t.Fatalf("UpdateBalloon() error = %v", err)
+	}
+	config, err := client.GetBalloon(ctx)
+	if err != nil || config.AmountMiB != 256 {
+		t.Fatalf("GetBalloon() = %#v, %v", config, err)
+	}
+	stats, err := client.GetBalloonStats(ctx)
+	if err != nil || stats.ActualMiB != 128 {
+		t.Fatalf("GetBalloonStats() = %#v, %v", stats, err)
+	}
+	if err := client.UpdateBalloonStats(ctx, 2); err != nil {
+		t.Fatalf("UpdateBalloonStats() error = %v", err)
+	}
+	if err := client.StartBalloonHinting(ctx, true); err != nil {
+		t.Fatalf("StartBalloonHinting() error = %v", err)
+	}
+	if err := client.StopBalloonHinting(ctx); err != nil {
+		t.Fatalf("StopBalloonHinting() error = %v", err)
+	}
+	hinting, err := client.GetBalloonHinting(ctx)
+	if err != nil || hinting.HostCmd != 2 || hinting.GuestCmd == nil || *hinting.GuestCmd != 2 {
+		t.Fatalf("GetBalloonHinting() = %#v, %v", hinting, err)
+	}
+}
+
+func TestBalloonHintingState(t *testing.T) {
+	runningCmd := uint32(2)
+	otherCmd := uint32(1)
+	tests := []struct {
+		name     string
+		hostCmd  uint32
+		guestCmd *uint32
+		want     string
+	}{
+		{name: "stopped", hostCmd: 0, want: "stopped"},
+		{name: "completed", hostCmd: 1, guestCmd: &otherCmd, want: "completed"},
+		{name: "starting", hostCmd: 2, guestCmd: &otherCmd, want: "starting"},
+		{name: "running", hostCmd: 2, guestCmd: &runningCmd, want: "running"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := balloonHintingState(tt.hostCmd, tt.guestCmd); got != tt.want {
+				t.Fatalf("balloonHintingState(%d, %v) = %q, want %q", tt.hostCmd, tt.guestCmd, got, tt.want)
+			}
+		})
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
 }
 
 func TestWaitPostStartAliveDetectsExitedProcess(t *testing.T) {

--- a/internal/boxshim/runtime/gvisor.go
+++ b/internal/boxshim/runtime/gvisor.go
@@ -129,6 +129,34 @@ func (d *GVisorDriver) Capabilities(context.Context, novitaboxv1.RuntimeType) (*
 	return gvisorCapabilities(), nil
 }
 
+func (d *GVisorDriver) UpdateBalloon(context.Context, string, uint32) (*novitaboxv1.BalloonConfig, error) {
+	return nil, errors.New("balloon is not supported by this runtime")
+}
+
+func (d *GVisorDriver) GetBalloon(context.Context, string) (*novitaboxv1.BalloonConfig, error) {
+	return nil, errors.New("balloon is not supported by this runtime")
+}
+
+func (d *GVisorDriver) GetBalloonStats(context.Context, string) (*novitaboxv1.BalloonStats, error) {
+	return nil, errors.New("balloon is not supported by this runtime")
+}
+
+func (d *GVisorDriver) UpdateBalloonStats(context.Context, string, uint32) (*novitaboxv1.BalloonConfig, error) {
+	return nil, errors.New("balloon is not supported by this runtime")
+}
+
+func (d *GVisorDriver) StartBalloonHinting(context.Context, string, bool) (*novitaboxv1.BalloonHintingStatus, error) {
+	return nil, errors.New("balloon hinting is not supported by this runtime")
+}
+
+func (d *GVisorDriver) StopBalloonHinting(context.Context, string) (*novitaboxv1.BalloonHintingStatus, error) {
+	return nil, errors.New("balloon hinting is not supported by this runtime")
+}
+
+func (d *GVisorDriver) GetBalloonHinting(context.Context, string) (*novitaboxv1.BalloonHintingStatus, error) {
+	return nil, errors.New("balloon hinting is not supported by this runtime")
+}
+
 func (d *GVisorDriver) start(ctx context.Context, spec *novitaboxv1.RuntimeSpec, action string) (*novitaboxv1.RuntimeInfo, error) {
 	spec, err := normalizeSpec(spec)
 	if err != nil {

--- a/internal/boxshim/runtime/stub.go
+++ b/internal/boxshim/runtime/stub.go
@@ -144,6 +144,34 @@ func (d *StubDriver) Capabilities(_ context.Context, runtimeType novitaboxv1.Run
 	return defaultCapabilities(runtimeType), nil
 }
 
+func (d *StubDriver) UpdateBalloon(context.Context, string, uint32) (*novitaboxv1.BalloonConfig, error) {
+	return nil, errors.New("balloon is not supported by this runtime")
+}
+
+func (d *StubDriver) GetBalloon(context.Context, string) (*novitaboxv1.BalloonConfig, error) {
+	return nil, errors.New("balloon is not supported by this runtime")
+}
+
+func (d *StubDriver) GetBalloonStats(context.Context, string) (*novitaboxv1.BalloonStats, error) {
+	return nil, errors.New("balloon is not supported by this runtime")
+}
+
+func (d *StubDriver) UpdateBalloonStats(context.Context, string, uint32) (*novitaboxv1.BalloonConfig, error) {
+	return nil, errors.New("balloon is not supported by this runtime")
+}
+
+func (d *StubDriver) StartBalloonHinting(context.Context, string, bool) (*novitaboxv1.BalloonHintingStatus, error) {
+	return nil, errors.New("balloon hinting is not supported by this runtime")
+}
+
+func (d *StubDriver) StopBalloonHinting(context.Context, string) (*novitaboxv1.BalloonHintingStatus, error) {
+	return nil, errors.New("balloon hinting is not supported by this runtime")
+}
+
+func (d *StubDriver) GetBalloonHinting(context.Context, string) (*novitaboxv1.BalloonHintingStatus, error) {
+	return nil, errors.New("balloon hinting is not supported by this runtime")
+}
+
 func (d *StubDriver) transition(sandboxID string, action string, state novitaboxv1.RuntimeState) (*novitaboxv1.RuntimeInfo, error) {
 	if sandboxID == "" {
 		return nil, errors.New("sandbox_id is required")

--- a/internal/boxshim/runtime/unsupported.go
+++ b/internal/boxshim/runtime/unsupported.go
@@ -51,3 +51,31 @@ func (d *UnsupportedDriver) Status(context.Context, string) (*novitaboxv1.Runtim
 func (d *UnsupportedDriver) Capabilities(context.Context, novitaboxv1.RuntimeType) (*novitaboxv1.RuntimeCapabilities, error) {
 	return nil, d.err
 }
+
+func (d *UnsupportedDriver) UpdateBalloon(context.Context, string, uint32) (*novitaboxv1.BalloonConfig, error) {
+	return nil, d.err
+}
+
+func (d *UnsupportedDriver) GetBalloon(context.Context, string) (*novitaboxv1.BalloonConfig, error) {
+	return nil, d.err
+}
+
+func (d *UnsupportedDriver) GetBalloonStats(context.Context, string) (*novitaboxv1.BalloonStats, error) {
+	return nil, d.err
+}
+
+func (d *UnsupportedDriver) UpdateBalloonStats(context.Context, string, uint32) (*novitaboxv1.BalloonConfig, error) {
+	return nil, d.err
+}
+
+func (d *UnsupportedDriver) StartBalloonHinting(context.Context, string, bool) (*novitaboxv1.BalloonHintingStatus, error) {
+	return nil, d.err
+}
+
+func (d *UnsupportedDriver) StopBalloonHinting(context.Context, string) (*novitaboxv1.BalloonHintingStatus, error) {
+	return nil, d.err
+}
+
+func (d *UnsupportedDriver) GetBalloonHinting(context.Context, string) (*novitaboxv1.BalloonHintingStatus, error) {
+	return nil, d.err
+}

--- a/internal/boxshim/server/server.go
+++ b/internal/boxshim/server/server.go
@@ -170,3 +170,31 @@ func (s *runtimeService) Status(ctx context.Context, req *novitaboxv1.StatusRequ
 func (s *runtimeService) Capabilities(ctx context.Context, req *novitaboxv1.CapabilitiesRequest) (*novitaboxv1.RuntimeCapabilities, error) {
 	return s.driver.Capabilities(ctx, req.GetRuntimeType())
 }
+
+func (s *runtimeService) UpdateBalloon(ctx context.Context, req *novitaboxv1.UpdateBalloonRequest) (*novitaboxv1.BalloonConfig, error) {
+	return s.driver.UpdateBalloon(ctx, req.GetSandboxId(), req.GetAmountMib())
+}
+
+func (s *runtimeService) GetBalloon(ctx context.Context, req *novitaboxv1.GetBalloonRequest) (*novitaboxv1.BalloonConfig, error) {
+	return s.driver.GetBalloon(ctx, req.GetSandboxId())
+}
+
+func (s *runtimeService) GetBalloonStats(ctx context.Context, req *novitaboxv1.GetBalloonStatsRequest) (*novitaboxv1.BalloonStats, error) {
+	return s.driver.GetBalloonStats(ctx, req.GetSandboxId())
+}
+
+func (s *runtimeService) UpdateBalloonStats(ctx context.Context, req *novitaboxv1.UpdateBalloonStatsRequest) (*novitaboxv1.BalloonConfig, error) {
+	return s.driver.UpdateBalloonStats(ctx, req.GetSandboxId(), req.GetStatsPollingIntervalS())
+}
+
+func (s *runtimeService) StartBalloonHinting(ctx context.Context, req *novitaboxv1.StartBalloonHintingRequest) (*novitaboxv1.BalloonHintingStatus, error) {
+	return s.driver.StartBalloonHinting(ctx, req.GetSandboxId(), req.GetAcknowledgeOnStop())
+}
+
+func (s *runtimeService) StopBalloonHinting(ctx context.Context, req *novitaboxv1.StopBalloonHintingRequest) (*novitaboxv1.BalloonHintingStatus, error) {
+	return s.driver.StopBalloonHinting(ctx, req.GetSandboxId())
+}
+
+func (s *runtimeService) GetBalloonHinting(ctx context.Context, req *novitaboxv1.GetBalloonHintingRequest) (*novitaboxv1.BalloonHintingStatus, error) {
+	return s.driver.GetBalloonHinting(ctx, req.GetSandboxId())
+}

--- a/internal/pb/novitabox/v1/boxlet.pb.go
+++ b/internal/pb/novitabox/v1/boxlet.pb.go
@@ -534,6 +534,338 @@ func (x *ListSandboxesResponse) GetSandboxes() []*SandboxInfo {
 	return nil
 }
 
+type UpdateSandboxBalloonRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	AmountMib     uint32                 `protobuf:"varint,2,opt,name=amount_mib,json=amountMib,proto3" json:"amount_mib,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateSandboxBalloonRequest) Reset() {
+	*x = UpdateSandboxBalloonRequest{}
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateSandboxBalloonRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateSandboxBalloonRequest) ProtoMessage() {}
+
+func (x *UpdateSandboxBalloonRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateSandboxBalloonRequest.ProtoReflect.Descriptor instead.
+func (*UpdateSandboxBalloonRequest) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *UpdateSandboxBalloonRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+func (x *UpdateSandboxBalloonRequest) GetAmountMib() uint32 {
+	if x != nil {
+		return x.AmountMib
+	}
+	return 0
+}
+
+type GetSandboxBalloonRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSandboxBalloonRequest) Reset() {
+	*x = GetSandboxBalloonRequest{}
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSandboxBalloonRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSandboxBalloonRequest) ProtoMessage() {}
+
+func (x *GetSandboxBalloonRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSandboxBalloonRequest.ProtoReflect.Descriptor instead.
+func (*GetSandboxBalloonRequest) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *GetSandboxBalloonRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+type GetSandboxBalloonStatsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSandboxBalloonStatsRequest) Reset() {
+	*x = GetSandboxBalloonStatsRequest{}
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSandboxBalloonStatsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSandboxBalloonStatsRequest) ProtoMessage() {}
+
+func (x *GetSandboxBalloonStatsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSandboxBalloonStatsRequest.ProtoReflect.Descriptor instead.
+func (*GetSandboxBalloonStatsRequest) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *GetSandboxBalloonStatsRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+type UpdateSandboxBalloonStatsRequest struct {
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId             string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	StatsPollingIntervalS uint32                 `protobuf:"varint,2,opt,name=stats_polling_interval_s,json=statsPollingIntervalS,proto3" json:"stats_polling_interval_s,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *UpdateSandboxBalloonStatsRequest) Reset() {
+	*x = UpdateSandboxBalloonStatsRequest{}
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateSandboxBalloonStatsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateSandboxBalloonStatsRequest) ProtoMessage() {}
+
+func (x *UpdateSandboxBalloonStatsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateSandboxBalloonStatsRequest.ProtoReflect.Descriptor instead.
+func (*UpdateSandboxBalloonStatsRequest) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *UpdateSandboxBalloonStatsRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+func (x *UpdateSandboxBalloonStatsRequest) GetStatsPollingIntervalS() uint32 {
+	if x != nil {
+		return x.StatsPollingIntervalS
+	}
+	return 0
+}
+
+type StartSandboxBalloonHintingRequest struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId         string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	AcknowledgeOnStop bool                   `protobuf:"varint,3,opt,name=acknowledge_on_stop,json=acknowledgeOnStop,proto3" json:"acknowledge_on_stop,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *StartSandboxBalloonHintingRequest) Reset() {
+	*x = StartSandboxBalloonHintingRequest{}
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StartSandboxBalloonHintingRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StartSandboxBalloonHintingRequest) ProtoMessage() {}
+
+func (x *StartSandboxBalloonHintingRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StartSandboxBalloonHintingRequest.ProtoReflect.Descriptor instead.
+func (*StartSandboxBalloonHintingRequest) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *StartSandboxBalloonHintingRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+func (x *StartSandboxBalloonHintingRequest) GetAcknowledgeOnStop() bool {
+	if x != nil {
+		return x.AcknowledgeOnStop
+	}
+	return false
+}
+
+type StopSandboxBalloonHintingRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StopSandboxBalloonHintingRequest) Reset() {
+	*x = StopSandboxBalloonHintingRequest{}
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StopSandboxBalloonHintingRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StopSandboxBalloonHintingRequest) ProtoMessage() {}
+
+func (x *StopSandboxBalloonHintingRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StopSandboxBalloonHintingRequest.ProtoReflect.Descriptor instead.
+func (*StopSandboxBalloonHintingRequest) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *StopSandboxBalloonHintingRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+type GetSandboxBalloonHintingRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSandboxBalloonHintingRequest) Reset() {
+	*x = GetSandboxBalloonHintingRequest{}
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSandboxBalloonHintingRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSandboxBalloonHintingRequest) ProtoMessage() {}
+
+func (x *GetSandboxBalloonHintingRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSandboxBalloonHintingRequest.ProtoReflect.Descriptor instead.
+func (*GetSandboxBalloonHintingRequest) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *GetSandboxBalloonHintingRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
 type CreateTemplateRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	TemplateId    string                 `protobuf:"bytes,1,opt,name=template_id,json=templateId,proto3" json:"template_id,omitempty"`
@@ -551,7 +883,7 @@ type CreateTemplateRequest struct {
 
 func (x *CreateTemplateRequest) Reset() {
 	*x = CreateTemplateRequest{}
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[10]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -563,7 +895,7 @@ func (x *CreateTemplateRequest) String() string {
 func (*CreateTemplateRequest) ProtoMessage() {}
 
 func (x *CreateTemplateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[10]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -576,7 +908,7 @@ func (x *CreateTemplateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTemplateRequest.ProtoReflect.Descriptor instead.
 func (*CreateTemplateRequest) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{10}
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *CreateTemplateRequest) GetTemplateId() string {
@@ -654,7 +986,7 @@ type TemplateBuildStep struct {
 
 func (x *TemplateBuildStep) Reset() {
 	*x = TemplateBuildStep{}
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[11]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -666,7 +998,7 @@ func (x *TemplateBuildStep) String() string {
 func (*TemplateBuildStep) ProtoMessage() {}
 
 func (x *TemplateBuildStep) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[11]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -679,7 +1011,7 @@ func (x *TemplateBuildStep) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TemplateBuildStep.ProtoReflect.Descriptor instead.
 func (*TemplateBuildStep) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{11}
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *TemplateBuildStep) GetType() string {
@@ -719,7 +1051,7 @@ type DeleteTemplateRequest struct {
 
 func (x *DeleteTemplateRequest) Reset() {
 	*x = DeleteTemplateRequest{}
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[12]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -731,7 +1063,7 @@ func (x *DeleteTemplateRequest) String() string {
 func (*DeleteTemplateRequest) ProtoMessage() {}
 
 func (x *DeleteTemplateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[12]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -744,7 +1076,7 @@ func (x *DeleteTemplateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteTemplateRequest.ProtoReflect.Descriptor instead.
 func (*DeleteTemplateRequest) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{12}
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *DeleteTemplateRequest) GetTemplateId() string {
@@ -763,7 +1095,7 @@ type GetTemplateRequest struct {
 
 func (x *GetTemplateRequest) Reset() {
 	*x = GetTemplateRequest{}
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[13]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -775,7 +1107,7 @@ func (x *GetTemplateRequest) String() string {
 func (*GetTemplateRequest) ProtoMessage() {}
 
 func (x *GetTemplateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[13]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -788,7 +1120,7 @@ func (x *GetTemplateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTemplateRequest.ProtoReflect.Descriptor instead.
 func (*GetTemplateRequest) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{13}
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *GetTemplateRequest) GetTemplateId() string {
@@ -807,7 +1139,7 @@ type ListTemplatesRequest struct {
 
 func (x *ListTemplatesRequest) Reset() {
 	*x = ListTemplatesRequest{}
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[14]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -819,7 +1151,7 @@ func (x *ListTemplatesRequest) String() string {
 func (*ListTemplatesRequest) ProtoMessage() {}
 
 func (x *ListTemplatesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[14]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -832,7 +1164,7 @@ func (x *ListTemplatesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTemplatesRequest.ProtoReflect.Descriptor instead.
 func (*ListTemplatesRequest) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{14}
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ListTemplatesRequest) GetLabelSelector() map[string]string {
@@ -851,7 +1183,7 @@ type ListTemplatesResponse struct {
 
 func (x *ListTemplatesResponse) Reset() {
 	*x = ListTemplatesResponse{}
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[15]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -863,7 +1195,7 @@ func (x *ListTemplatesResponse) String() string {
 func (*ListTemplatesResponse) ProtoMessage() {}
 
 func (x *ListTemplatesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[15]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -876,7 +1208,7 @@ func (x *ListTemplatesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTemplatesResponse.ProtoReflect.Descriptor instead.
 func (*ListTemplatesResponse) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{15}
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ListTemplatesResponse) GetTemplates() []*TemplateInfo {
@@ -897,7 +1229,7 @@ type CreateImageRequest struct {
 
 func (x *CreateImageRequest) Reset() {
 	*x = CreateImageRequest{}
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[16]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -909,7 +1241,7 @@ func (x *CreateImageRequest) String() string {
 func (*CreateImageRequest) ProtoMessage() {}
 
 func (x *CreateImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[16]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -922,7 +1254,7 @@ func (x *CreateImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateImageRequest.ProtoReflect.Descriptor instead.
 func (*CreateImageRequest) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{16}
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *CreateImageRequest) GetImageId() string {
@@ -955,7 +1287,7 @@ type DeleteImageRequest struct {
 
 func (x *DeleteImageRequest) Reset() {
 	*x = DeleteImageRequest{}
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[17]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -967,7 +1299,7 @@ func (x *DeleteImageRequest) String() string {
 func (*DeleteImageRequest) ProtoMessage() {}
 
 func (x *DeleteImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[17]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -980,7 +1312,7 @@ func (x *DeleteImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteImageRequest.ProtoReflect.Descriptor instead.
 func (*DeleteImageRequest) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{17}
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *DeleteImageRequest) GetImageId() string {
@@ -999,7 +1331,7 @@ type GetImageRequest struct {
 
 func (x *GetImageRequest) Reset() {
 	*x = GetImageRequest{}
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[18]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1011,7 +1343,7 @@ func (x *GetImageRequest) String() string {
 func (*GetImageRequest) ProtoMessage() {}
 
 func (x *GetImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[18]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1024,7 +1356,7 @@ func (x *GetImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetImageRequest.ProtoReflect.Descriptor instead.
 func (*GetImageRequest) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{18}
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetImageRequest) GetImageId() string {
@@ -1043,7 +1375,7 @@ type ListImagesRequest struct {
 
 func (x *ListImagesRequest) Reset() {
 	*x = ListImagesRequest{}
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[19]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1055,7 +1387,7 @@ func (x *ListImagesRequest) String() string {
 func (*ListImagesRequest) ProtoMessage() {}
 
 func (x *ListImagesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[19]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1068,7 +1400,7 @@ func (x *ListImagesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListImagesRequest.ProtoReflect.Descriptor instead.
 func (*ListImagesRequest) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{19}
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ListImagesRequest) GetLabelSelector() map[string]string {
@@ -1087,7 +1419,7 @@ type ListImagesResponse struct {
 
 func (x *ListImagesResponse) Reset() {
 	*x = ListImagesResponse{}
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[20]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1099,7 +1431,7 @@ func (x *ListImagesResponse) String() string {
 func (*ListImagesResponse) ProtoMessage() {}
 
 func (x *ListImagesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[20]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1112,7 +1444,7 @@ func (x *ListImagesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListImagesResponse.ProtoReflect.Descriptor instead.
 func (*ListImagesResponse) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{20}
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ListImagesResponse) GetImages() []*ImageInfo {
@@ -1130,7 +1462,7 @@ type NodeStatusRequest struct {
 
 func (x *NodeStatusRequest) Reset() {
 	*x = NodeStatusRequest{}
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[21]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1142,7 +1474,7 @@ func (x *NodeStatusRequest) String() string {
 func (*NodeStatusRequest) ProtoMessage() {}
 
 func (x *NodeStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[21]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1155,7 +1487,7 @@ func (x *NodeStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NodeStatusRequest.ProtoReflect.Descriptor instead.
 func (*NodeStatusRequest) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{21}
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{28}
 }
 
 type NodeStatusInfo struct {
@@ -1170,7 +1502,7 @@ type NodeStatusInfo struct {
 
 func (x *NodeStatusInfo) Reset() {
 	*x = NodeStatusInfo{}
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[22]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1182,7 +1514,7 @@ func (x *NodeStatusInfo) String() string {
 func (*NodeStatusInfo) ProtoMessage() {}
 
 func (x *NodeStatusInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[22]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1195,7 +1527,7 @@ func (x *NodeStatusInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NodeStatusInfo.ProtoReflect.Descriptor instead.
 func (*NodeStatusInfo) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{22}
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *NodeStatusInfo) GetNodeId() string {
@@ -1234,7 +1566,7 @@ type ListRuntimesRequest struct {
 
 func (x *ListRuntimesRequest) Reset() {
 	*x = ListRuntimesRequest{}
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[23]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1246,7 +1578,7 @@ func (x *ListRuntimesRequest) String() string {
 func (*ListRuntimesRequest) ProtoMessage() {}
 
 func (x *ListRuntimesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[23]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1259,7 +1591,7 @@ func (x *ListRuntimesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRuntimesRequest.ProtoReflect.Descriptor instead.
 func (*ListRuntimesRequest) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{23}
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{30}
 }
 
 type RuntimeSummary struct {
@@ -1272,7 +1604,7 @@ type RuntimeSummary struct {
 
 func (x *RuntimeSummary) Reset() {
 	*x = RuntimeSummary{}
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[24]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1284,7 +1616,7 @@ func (x *RuntimeSummary) String() string {
 func (*RuntimeSummary) ProtoMessage() {}
 
 func (x *RuntimeSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[24]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1297,7 +1629,7 @@ func (x *RuntimeSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuntimeSummary.ProtoReflect.Descriptor instead.
 func (*RuntimeSummary) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{24}
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *RuntimeSummary) GetRuntimeType() RuntimeType {
@@ -1323,7 +1655,7 @@ type ListRuntimesResponse struct {
 
 func (x *ListRuntimesResponse) Reset() {
 	*x = ListRuntimesResponse{}
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[25]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1335,7 +1667,7 @@ func (x *ListRuntimesResponse) String() string {
 func (*ListRuntimesResponse) ProtoMessage() {}
 
 func (x *ListRuntimesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[25]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1348,7 +1680,7 @@ func (x *ListRuntimesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRuntimesResponse.ProtoReflect.Descriptor instead.
 func (*ListRuntimesResponse) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{25}
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *ListRuntimesResponse) GetRuntimes() []*RuntimeSummary {
@@ -1367,7 +1699,7 @@ type GetRuntimeCapabilitiesRequest struct {
 
 func (x *GetRuntimeCapabilitiesRequest) Reset() {
 	*x = GetRuntimeCapabilitiesRequest{}
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[26]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1379,7 +1711,7 @@ func (x *GetRuntimeCapabilitiesRequest) String() string {
 func (*GetRuntimeCapabilitiesRequest) ProtoMessage() {}
 
 func (x *GetRuntimeCapabilitiesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_boxlet_proto_msgTypes[26]
+	mi := &file_novitabox_v1_boxlet_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1392,7 +1724,7 @@ func (x *GetRuntimeCapabilitiesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRuntimeCapabilitiesRequest.ProtoReflect.Descriptor instead.
 func (*GetRuntimeCapabilitiesRequest) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{26}
+	return file_novitabox_v1_boxlet_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *GetRuntimeCapabilitiesRequest) GetRuntimeType() RuntimeType {
@@ -1454,7 +1786,33 @@ const file_novitabox_v1_boxlet_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"P\n" +
 	"\x15ListSandboxesResponse\x127\n" +
-	"\tsandboxes\x18\x01 \x03(\v2\x19.novitabox.v1.SandboxInfoR\tsandboxes\"\xaf\x03\n" +
+	"\tsandboxes\x18\x01 \x03(\v2\x19.novitabox.v1.SandboxInfoR\tsandboxes\"[\n" +
+	"\x1bUpdateSandboxBalloonRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x1d\n" +
+	"\n" +
+	"amount_mib\x18\x02 \x01(\rR\tamountMib\"9\n" +
+	"\x18GetSandboxBalloonRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\">\n" +
+	"\x1dGetSandboxBalloonStatsRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"z\n" +
+	" UpdateSandboxBalloonStatsRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x127\n" +
+	"\x18stats_polling_interval_s\x18\x02 \x01(\rR\x15statsPollingIntervalS\"\x84\x01\n" +
+	"!StartSandboxBalloonHintingRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12.\n" +
+	"\x13acknowledge_on_stop\x18\x03 \x01(\bR\x11acknowledgeOnStopJ\x04\b\x02\x10\x03R\n" +
+	"interval_s\"A\n" +
+	" StopSandboxBalloonHintingRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"@\n" +
+	"\x1fGetSandboxBalloonHintingRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"\xaf\x03\n" +
 	"\x15CreateTemplateRequest\x12\x1f\n" +
 	"\vtemplate_id\x18\x01 \x01(\tR\n" +
 	"templateId\x12\x1d\n" +
@@ -1524,7 +1882,7 @@ const file_novitabox_v1_boxlet_proto_rawDesc = "" +
 	"\x14ListRuntimesResponse\x128\n" +
 	"\bruntimes\x18\x01 \x03(\v2\x1c.novitabox.v1.RuntimeSummaryR\bruntimes\"]\n" +
 	"\x1dGetRuntimeCapabilitiesRequest\x12<\n" +
-	"\fruntime_type\x18\x01 \x01(\x0e2\x19.novitabox.v1.RuntimeTypeR\vruntimeType2\xdc\x05\n" +
+	"\fruntime_type\x18\x01 \x01(\x0e2\x19.novitabox.v1.RuntimeTypeR\vruntimeType2\xb6\v\n" +
 	"\x14BoxletSandboxService\x12N\n" +
 	"\rCreateSandbox\x12\".novitabox.v1.CreateSandboxRequest\x1a\x19.novitabox.v1.SandboxInfo\x12M\n" +
 	"\fPauseSandbox\x12!.novitabox.v1.PauseSandboxRequest\x1a\x1a.novitabox.v1.SnapshotInfo\x12N\n" +
@@ -1535,7 +1893,14 @@ const file_novitabox_v1_boxlet_proto_rawDesc = "" +
 	"\rRebootSandbox\x12\".novitabox.v1.RebootSandboxRequest\x1a\x19.novitabox.v1.SandboxInfo\x12H\n" +
 	"\n" +
 	"GetSandbox\x12\x1f.novitabox.v1.GetSandboxRequest\x1a\x19.novitabox.v1.SandboxInfo\x12X\n" +
-	"\rListSandboxes\x12\".novitabox.v1.ListSandboxesRequest\x1a#.novitabox.v1.ListSandboxesResponse2\x88\x05\n" +
+	"\rListSandboxes\x12\".novitabox.v1.ListSandboxesRequest\x1a#.novitabox.v1.ListSandboxesResponse\x12^\n" +
+	"\x14UpdateSandboxBalloon\x12).novitabox.v1.UpdateSandboxBalloonRequest\x1a\x1b.novitabox.v1.BalloonConfig\x12X\n" +
+	"\x11GetSandboxBalloon\x12&.novitabox.v1.GetSandboxBalloonRequest\x1a\x1b.novitabox.v1.BalloonConfig\x12a\n" +
+	"\x16GetSandboxBalloonStats\x12+.novitabox.v1.GetSandboxBalloonStatsRequest\x1a\x1a.novitabox.v1.BalloonStats\x12h\n" +
+	"\x19UpdateSandboxBalloonStats\x12..novitabox.v1.UpdateSandboxBalloonStatsRequest\x1a\x1b.novitabox.v1.BalloonConfig\x12q\n" +
+	"\x1aStartSandboxBalloonHinting\x12/.novitabox.v1.StartSandboxBalloonHintingRequest\x1a\".novitabox.v1.BalloonHintingStatus\x12o\n" +
+	"\x19StopSandboxBalloonHinting\x12..novitabox.v1.StopSandboxBalloonHintingRequest\x1a\".novitabox.v1.BalloonHintingStatus\x12m\n" +
+	"\x18GetSandboxBalloonHinting\x12-.novitabox.v1.GetSandboxBalloonHintingRequest\x1a\".novitabox.v1.BalloonHintingStatus2\x88\x05\n" +
 	"\x15BoxletArtifactService\x12Q\n" +
 	"\x0eCreateTemplate\x12#.novitabox.v1.CreateTemplateRequest\x1a\x1a.novitabox.v1.TemplateInfo\x12M\n" +
 	"\x0eDeleteTemplate\x12#.novitabox.v1.DeleteTemplateRequest\x1a\x16.google.protobuf.Empty\x12K\n" +
@@ -1564,72 +1929,82 @@ func file_novitabox_v1_boxlet_proto_rawDescGZIP() []byte {
 	return file_novitabox_v1_boxlet_proto_rawDescData
 }
 
-var file_novitabox_v1_boxlet_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
+var file_novitabox_v1_boxlet_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
 var file_novitabox_v1_boxlet_proto_goTypes = []any{
-	(*CreateSandboxRequest)(nil),          // 0: novitabox.v1.CreateSandboxRequest
-	(*PauseSandboxRequest)(nil),           // 1: novitabox.v1.PauseSandboxRequest
-	(*ResumeSandboxRequest)(nil),          // 2: novitabox.v1.ResumeSandboxRequest
-	(*KillSandboxRequest)(nil),            // 3: novitabox.v1.KillSandboxRequest
-	(*StartSandboxRequest)(nil),           // 4: novitabox.v1.StartSandboxRequest
-	(*StopSandboxRequest)(nil),            // 5: novitabox.v1.StopSandboxRequest
-	(*RebootSandboxRequest)(nil),          // 6: novitabox.v1.RebootSandboxRequest
-	(*GetSandboxRequest)(nil),             // 7: novitabox.v1.GetSandboxRequest
-	(*ListSandboxesRequest)(nil),          // 8: novitabox.v1.ListSandboxesRequest
-	(*ListSandboxesResponse)(nil),         // 9: novitabox.v1.ListSandboxesResponse
-	(*CreateTemplateRequest)(nil),         // 10: novitabox.v1.CreateTemplateRequest
-	(*TemplateBuildStep)(nil),             // 11: novitabox.v1.TemplateBuildStep
-	(*DeleteTemplateRequest)(nil),         // 12: novitabox.v1.DeleteTemplateRequest
-	(*GetTemplateRequest)(nil),            // 13: novitabox.v1.GetTemplateRequest
-	(*ListTemplatesRequest)(nil),          // 14: novitabox.v1.ListTemplatesRequest
-	(*ListTemplatesResponse)(nil),         // 15: novitabox.v1.ListTemplatesResponse
-	(*CreateImageRequest)(nil),            // 16: novitabox.v1.CreateImageRequest
-	(*DeleteImageRequest)(nil),            // 17: novitabox.v1.DeleteImageRequest
-	(*GetImageRequest)(nil),               // 18: novitabox.v1.GetImageRequest
-	(*ListImagesRequest)(nil),             // 19: novitabox.v1.ListImagesRequest
-	(*ListImagesResponse)(nil),            // 20: novitabox.v1.ListImagesResponse
-	(*NodeStatusRequest)(nil),             // 21: novitabox.v1.NodeStatusRequest
-	(*NodeStatusInfo)(nil),                // 22: novitabox.v1.NodeStatusInfo
-	(*ListRuntimesRequest)(nil),           // 23: novitabox.v1.ListRuntimesRequest
-	(*RuntimeSummary)(nil),                // 24: novitabox.v1.RuntimeSummary
-	(*ListRuntimesResponse)(nil),          // 25: novitabox.v1.ListRuntimesResponse
-	(*GetRuntimeCapabilitiesRequest)(nil), // 26: novitabox.v1.GetRuntimeCapabilitiesRequest
-	nil,                                   // 27: novitabox.v1.CreateSandboxRequest.LabelsEntry
-	nil,                                   // 28: novitabox.v1.CreateSandboxRequest.AnnotationsEntry
-	nil,                                   // 29: novitabox.v1.ListSandboxesRequest.LabelSelectorEntry
-	nil,                                   // 30: novitabox.v1.CreateTemplateRequest.LabelsEntry
-	nil,                                   // 31: novitabox.v1.TemplateBuildStep.EnvVarsEntry
-	nil,                                   // 32: novitabox.v1.ListTemplatesRequest.LabelSelectorEntry
-	nil,                                   // 33: novitabox.v1.CreateImageRequest.LabelsEntry
-	nil,                                   // 34: novitabox.v1.ListImagesRequest.LabelSelectorEntry
-	(RuntimeType)(0),                      // 35: novitabox.v1.RuntimeType
-	(*RuntimeSpec)(nil),                   // 36: novitabox.v1.RuntimeSpec
-	(*SandboxInfo)(nil),                   // 37: novitabox.v1.SandboxInfo
-	(*TemplateInfo)(nil),                  // 38: novitabox.v1.TemplateInfo
-	(*ImageInfo)(nil),                     // 39: novitabox.v1.ImageInfo
-	(*RuntimeCapabilities)(nil),           // 40: novitabox.v1.RuntimeCapabilities
-	(*SnapshotInfo)(nil),                  // 41: novitabox.v1.SnapshotInfo
-	(*emptypb.Empty)(nil),                 // 42: google.protobuf.Empty
+	(*CreateSandboxRequest)(nil),              // 0: novitabox.v1.CreateSandboxRequest
+	(*PauseSandboxRequest)(nil),               // 1: novitabox.v1.PauseSandboxRequest
+	(*ResumeSandboxRequest)(nil),              // 2: novitabox.v1.ResumeSandboxRequest
+	(*KillSandboxRequest)(nil),                // 3: novitabox.v1.KillSandboxRequest
+	(*StartSandboxRequest)(nil),               // 4: novitabox.v1.StartSandboxRequest
+	(*StopSandboxRequest)(nil),                // 5: novitabox.v1.StopSandboxRequest
+	(*RebootSandboxRequest)(nil),              // 6: novitabox.v1.RebootSandboxRequest
+	(*GetSandboxRequest)(nil),                 // 7: novitabox.v1.GetSandboxRequest
+	(*ListSandboxesRequest)(nil),              // 8: novitabox.v1.ListSandboxesRequest
+	(*ListSandboxesResponse)(nil),             // 9: novitabox.v1.ListSandboxesResponse
+	(*UpdateSandboxBalloonRequest)(nil),       // 10: novitabox.v1.UpdateSandboxBalloonRequest
+	(*GetSandboxBalloonRequest)(nil),          // 11: novitabox.v1.GetSandboxBalloonRequest
+	(*GetSandboxBalloonStatsRequest)(nil),     // 12: novitabox.v1.GetSandboxBalloonStatsRequest
+	(*UpdateSandboxBalloonStatsRequest)(nil),  // 13: novitabox.v1.UpdateSandboxBalloonStatsRequest
+	(*StartSandboxBalloonHintingRequest)(nil), // 14: novitabox.v1.StartSandboxBalloonHintingRequest
+	(*StopSandboxBalloonHintingRequest)(nil),  // 15: novitabox.v1.StopSandboxBalloonHintingRequest
+	(*GetSandboxBalloonHintingRequest)(nil),   // 16: novitabox.v1.GetSandboxBalloonHintingRequest
+	(*CreateTemplateRequest)(nil),             // 17: novitabox.v1.CreateTemplateRequest
+	(*TemplateBuildStep)(nil),                 // 18: novitabox.v1.TemplateBuildStep
+	(*DeleteTemplateRequest)(nil),             // 19: novitabox.v1.DeleteTemplateRequest
+	(*GetTemplateRequest)(nil),                // 20: novitabox.v1.GetTemplateRequest
+	(*ListTemplatesRequest)(nil),              // 21: novitabox.v1.ListTemplatesRequest
+	(*ListTemplatesResponse)(nil),             // 22: novitabox.v1.ListTemplatesResponse
+	(*CreateImageRequest)(nil),                // 23: novitabox.v1.CreateImageRequest
+	(*DeleteImageRequest)(nil),                // 24: novitabox.v1.DeleteImageRequest
+	(*GetImageRequest)(nil),                   // 25: novitabox.v1.GetImageRequest
+	(*ListImagesRequest)(nil),                 // 26: novitabox.v1.ListImagesRequest
+	(*ListImagesResponse)(nil),                // 27: novitabox.v1.ListImagesResponse
+	(*NodeStatusRequest)(nil),                 // 28: novitabox.v1.NodeStatusRequest
+	(*NodeStatusInfo)(nil),                    // 29: novitabox.v1.NodeStatusInfo
+	(*ListRuntimesRequest)(nil),               // 30: novitabox.v1.ListRuntimesRequest
+	(*RuntimeSummary)(nil),                    // 31: novitabox.v1.RuntimeSummary
+	(*ListRuntimesResponse)(nil),              // 32: novitabox.v1.ListRuntimesResponse
+	(*GetRuntimeCapabilitiesRequest)(nil),     // 33: novitabox.v1.GetRuntimeCapabilitiesRequest
+	nil,                                       // 34: novitabox.v1.CreateSandboxRequest.LabelsEntry
+	nil,                                       // 35: novitabox.v1.CreateSandboxRequest.AnnotationsEntry
+	nil,                                       // 36: novitabox.v1.ListSandboxesRequest.LabelSelectorEntry
+	nil,                                       // 37: novitabox.v1.CreateTemplateRequest.LabelsEntry
+	nil,                                       // 38: novitabox.v1.TemplateBuildStep.EnvVarsEntry
+	nil,                                       // 39: novitabox.v1.ListTemplatesRequest.LabelSelectorEntry
+	nil,                                       // 40: novitabox.v1.CreateImageRequest.LabelsEntry
+	nil,                                       // 41: novitabox.v1.ListImagesRequest.LabelSelectorEntry
+	(RuntimeType)(0),                          // 42: novitabox.v1.RuntimeType
+	(*RuntimeSpec)(nil),                       // 43: novitabox.v1.RuntimeSpec
+	(*SandboxInfo)(nil),                       // 44: novitabox.v1.SandboxInfo
+	(*TemplateInfo)(nil),                      // 45: novitabox.v1.TemplateInfo
+	(*ImageInfo)(nil),                         // 46: novitabox.v1.ImageInfo
+	(*RuntimeCapabilities)(nil),               // 47: novitabox.v1.RuntimeCapabilities
+	(*SnapshotInfo)(nil),                      // 48: novitabox.v1.SnapshotInfo
+	(*emptypb.Empty)(nil),                     // 49: google.protobuf.Empty
+	(*BalloonConfig)(nil),                     // 50: novitabox.v1.BalloonConfig
+	(*BalloonStats)(nil),                      // 51: novitabox.v1.BalloonStats
+	(*BalloonHintingStatus)(nil),              // 52: novitabox.v1.BalloonHintingStatus
 }
 var file_novitabox_v1_boxlet_proto_depIdxs = []int32{
-	35, // 0: novitabox.v1.CreateSandboxRequest.runtime_type:type_name -> novitabox.v1.RuntimeType
-	36, // 1: novitabox.v1.CreateSandboxRequest.runtime_spec:type_name -> novitabox.v1.RuntimeSpec
-	27, // 2: novitabox.v1.CreateSandboxRequest.labels:type_name -> novitabox.v1.CreateSandboxRequest.LabelsEntry
-	28, // 3: novitabox.v1.CreateSandboxRequest.annotations:type_name -> novitabox.v1.CreateSandboxRequest.AnnotationsEntry
-	29, // 4: novitabox.v1.ListSandboxesRequest.label_selector:type_name -> novitabox.v1.ListSandboxesRequest.LabelSelectorEntry
-	37, // 5: novitabox.v1.ListSandboxesResponse.sandboxes:type_name -> novitabox.v1.SandboxInfo
-	11, // 6: novitabox.v1.CreateTemplateRequest.steps:type_name -> novitabox.v1.TemplateBuildStep
-	30, // 7: novitabox.v1.CreateTemplateRequest.labels:type_name -> novitabox.v1.CreateTemplateRequest.LabelsEntry
-	31, // 8: novitabox.v1.TemplateBuildStep.env_vars:type_name -> novitabox.v1.TemplateBuildStep.EnvVarsEntry
-	32, // 9: novitabox.v1.ListTemplatesRequest.label_selector:type_name -> novitabox.v1.ListTemplatesRequest.LabelSelectorEntry
-	38, // 10: novitabox.v1.ListTemplatesResponse.templates:type_name -> novitabox.v1.TemplateInfo
-	33, // 11: novitabox.v1.CreateImageRequest.labels:type_name -> novitabox.v1.CreateImageRequest.LabelsEntry
-	34, // 12: novitabox.v1.ListImagesRequest.label_selector:type_name -> novitabox.v1.ListImagesRequest.LabelSelectorEntry
-	39, // 13: novitabox.v1.ListImagesResponse.images:type_name -> novitabox.v1.ImageInfo
-	35, // 14: novitabox.v1.NodeStatusInfo.runtime_types:type_name -> novitabox.v1.RuntimeType
-	35, // 15: novitabox.v1.RuntimeSummary.runtime_type:type_name -> novitabox.v1.RuntimeType
-	40, // 16: novitabox.v1.RuntimeSummary.capabilities:type_name -> novitabox.v1.RuntimeCapabilities
-	24, // 17: novitabox.v1.ListRuntimesResponse.runtimes:type_name -> novitabox.v1.RuntimeSummary
-	35, // 18: novitabox.v1.GetRuntimeCapabilitiesRequest.runtime_type:type_name -> novitabox.v1.RuntimeType
+	42, // 0: novitabox.v1.CreateSandboxRequest.runtime_type:type_name -> novitabox.v1.RuntimeType
+	43, // 1: novitabox.v1.CreateSandboxRequest.runtime_spec:type_name -> novitabox.v1.RuntimeSpec
+	34, // 2: novitabox.v1.CreateSandboxRequest.labels:type_name -> novitabox.v1.CreateSandboxRequest.LabelsEntry
+	35, // 3: novitabox.v1.CreateSandboxRequest.annotations:type_name -> novitabox.v1.CreateSandboxRequest.AnnotationsEntry
+	36, // 4: novitabox.v1.ListSandboxesRequest.label_selector:type_name -> novitabox.v1.ListSandboxesRequest.LabelSelectorEntry
+	44, // 5: novitabox.v1.ListSandboxesResponse.sandboxes:type_name -> novitabox.v1.SandboxInfo
+	18, // 6: novitabox.v1.CreateTemplateRequest.steps:type_name -> novitabox.v1.TemplateBuildStep
+	37, // 7: novitabox.v1.CreateTemplateRequest.labels:type_name -> novitabox.v1.CreateTemplateRequest.LabelsEntry
+	38, // 8: novitabox.v1.TemplateBuildStep.env_vars:type_name -> novitabox.v1.TemplateBuildStep.EnvVarsEntry
+	39, // 9: novitabox.v1.ListTemplatesRequest.label_selector:type_name -> novitabox.v1.ListTemplatesRequest.LabelSelectorEntry
+	45, // 10: novitabox.v1.ListTemplatesResponse.templates:type_name -> novitabox.v1.TemplateInfo
+	40, // 11: novitabox.v1.CreateImageRequest.labels:type_name -> novitabox.v1.CreateImageRequest.LabelsEntry
+	41, // 12: novitabox.v1.ListImagesRequest.label_selector:type_name -> novitabox.v1.ListImagesRequest.LabelSelectorEntry
+	46, // 13: novitabox.v1.ListImagesResponse.images:type_name -> novitabox.v1.ImageInfo
+	42, // 14: novitabox.v1.NodeStatusInfo.runtime_types:type_name -> novitabox.v1.RuntimeType
+	42, // 15: novitabox.v1.RuntimeSummary.runtime_type:type_name -> novitabox.v1.RuntimeType
+	47, // 16: novitabox.v1.RuntimeSummary.capabilities:type_name -> novitabox.v1.RuntimeCapabilities
+	31, // 17: novitabox.v1.ListRuntimesResponse.runtimes:type_name -> novitabox.v1.RuntimeSummary
+	42, // 18: novitabox.v1.GetRuntimeCapabilitiesRequest.runtime_type:type_name -> novitabox.v1.RuntimeType
 	0,  // 19: novitabox.v1.BoxletSandboxService.CreateSandbox:input_type -> novitabox.v1.CreateSandboxRequest
 	1,  // 20: novitabox.v1.BoxletSandboxService.PauseSandbox:input_type -> novitabox.v1.PauseSandboxRequest
 	2,  // 21: novitabox.v1.BoxletSandboxService.ResumeSandbox:input_type -> novitabox.v1.ResumeSandboxRequest
@@ -1639,39 +2014,53 @@ var file_novitabox_v1_boxlet_proto_depIdxs = []int32{
 	6,  // 25: novitabox.v1.BoxletSandboxService.RebootSandbox:input_type -> novitabox.v1.RebootSandboxRequest
 	7,  // 26: novitabox.v1.BoxletSandboxService.GetSandbox:input_type -> novitabox.v1.GetSandboxRequest
 	8,  // 27: novitabox.v1.BoxletSandboxService.ListSandboxes:input_type -> novitabox.v1.ListSandboxesRequest
-	10, // 28: novitabox.v1.BoxletArtifactService.CreateTemplate:input_type -> novitabox.v1.CreateTemplateRequest
-	12, // 29: novitabox.v1.BoxletArtifactService.DeleteTemplate:input_type -> novitabox.v1.DeleteTemplateRequest
-	13, // 30: novitabox.v1.BoxletArtifactService.GetTemplate:input_type -> novitabox.v1.GetTemplateRequest
-	14, // 31: novitabox.v1.BoxletArtifactService.ListTemplates:input_type -> novitabox.v1.ListTemplatesRequest
-	16, // 32: novitabox.v1.BoxletArtifactService.CreateImage:input_type -> novitabox.v1.CreateImageRequest
-	17, // 33: novitabox.v1.BoxletArtifactService.DeleteImage:input_type -> novitabox.v1.DeleteImageRequest
-	18, // 34: novitabox.v1.BoxletArtifactService.GetImage:input_type -> novitabox.v1.GetImageRequest
-	19, // 35: novitabox.v1.BoxletArtifactService.ListImages:input_type -> novitabox.v1.ListImagesRequest
-	21, // 36: novitabox.v1.BoxletNodeService.NodeStatus:input_type -> novitabox.v1.NodeStatusRequest
-	23, // 37: novitabox.v1.BoxletNodeService.ListRuntimes:input_type -> novitabox.v1.ListRuntimesRequest
-	26, // 38: novitabox.v1.BoxletNodeService.GetRuntimeCapabilities:input_type -> novitabox.v1.GetRuntimeCapabilitiesRequest
-	37, // 39: novitabox.v1.BoxletSandboxService.CreateSandbox:output_type -> novitabox.v1.SandboxInfo
-	41, // 40: novitabox.v1.BoxletSandboxService.PauseSandbox:output_type -> novitabox.v1.SnapshotInfo
-	37, // 41: novitabox.v1.BoxletSandboxService.ResumeSandbox:output_type -> novitabox.v1.SandboxInfo
-	42, // 42: novitabox.v1.BoxletSandboxService.KillSandbox:output_type -> google.protobuf.Empty
-	37, // 43: novitabox.v1.BoxletSandboxService.StartSandbox:output_type -> novitabox.v1.SandboxInfo
-	37, // 44: novitabox.v1.BoxletSandboxService.StopSandbox:output_type -> novitabox.v1.SandboxInfo
-	37, // 45: novitabox.v1.BoxletSandboxService.RebootSandbox:output_type -> novitabox.v1.SandboxInfo
-	37, // 46: novitabox.v1.BoxletSandboxService.GetSandbox:output_type -> novitabox.v1.SandboxInfo
-	9,  // 47: novitabox.v1.BoxletSandboxService.ListSandboxes:output_type -> novitabox.v1.ListSandboxesResponse
-	38, // 48: novitabox.v1.BoxletArtifactService.CreateTemplate:output_type -> novitabox.v1.TemplateInfo
-	42, // 49: novitabox.v1.BoxletArtifactService.DeleteTemplate:output_type -> google.protobuf.Empty
-	38, // 50: novitabox.v1.BoxletArtifactService.GetTemplate:output_type -> novitabox.v1.TemplateInfo
-	15, // 51: novitabox.v1.BoxletArtifactService.ListTemplates:output_type -> novitabox.v1.ListTemplatesResponse
-	39, // 52: novitabox.v1.BoxletArtifactService.CreateImage:output_type -> novitabox.v1.ImageInfo
-	42, // 53: novitabox.v1.BoxletArtifactService.DeleteImage:output_type -> google.protobuf.Empty
-	39, // 54: novitabox.v1.BoxletArtifactService.GetImage:output_type -> novitabox.v1.ImageInfo
-	20, // 55: novitabox.v1.BoxletArtifactService.ListImages:output_type -> novitabox.v1.ListImagesResponse
-	22, // 56: novitabox.v1.BoxletNodeService.NodeStatus:output_type -> novitabox.v1.NodeStatusInfo
-	25, // 57: novitabox.v1.BoxletNodeService.ListRuntimes:output_type -> novitabox.v1.ListRuntimesResponse
-	40, // 58: novitabox.v1.BoxletNodeService.GetRuntimeCapabilities:output_type -> novitabox.v1.RuntimeCapabilities
-	39, // [39:59] is the sub-list for method output_type
-	19, // [19:39] is the sub-list for method input_type
+	10, // 28: novitabox.v1.BoxletSandboxService.UpdateSandboxBalloon:input_type -> novitabox.v1.UpdateSandboxBalloonRequest
+	11, // 29: novitabox.v1.BoxletSandboxService.GetSandboxBalloon:input_type -> novitabox.v1.GetSandboxBalloonRequest
+	12, // 30: novitabox.v1.BoxletSandboxService.GetSandboxBalloonStats:input_type -> novitabox.v1.GetSandboxBalloonStatsRequest
+	13, // 31: novitabox.v1.BoxletSandboxService.UpdateSandboxBalloonStats:input_type -> novitabox.v1.UpdateSandboxBalloonStatsRequest
+	14, // 32: novitabox.v1.BoxletSandboxService.StartSandboxBalloonHinting:input_type -> novitabox.v1.StartSandboxBalloonHintingRequest
+	15, // 33: novitabox.v1.BoxletSandboxService.StopSandboxBalloonHinting:input_type -> novitabox.v1.StopSandboxBalloonHintingRequest
+	16, // 34: novitabox.v1.BoxletSandboxService.GetSandboxBalloonHinting:input_type -> novitabox.v1.GetSandboxBalloonHintingRequest
+	17, // 35: novitabox.v1.BoxletArtifactService.CreateTemplate:input_type -> novitabox.v1.CreateTemplateRequest
+	19, // 36: novitabox.v1.BoxletArtifactService.DeleteTemplate:input_type -> novitabox.v1.DeleteTemplateRequest
+	20, // 37: novitabox.v1.BoxletArtifactService.GetTemplate:input_type -> novitabox.v1.GetTemplateRequest
+	21, // 38: novitabox.v1.BoxletArtifactService.ListTemplates:input_type -> novitabox.v1.ListTemplatesRequest
+	23, // 39: novitabox.v1.BoxletArtifactService.CreateImage:input_type -> novitabox.v1.CreateImageRequest
+	24, // 40: novitabox.v1.BoxletArtifactService.DeleteImage:input_type -> novitabox.v1.DeleteImageRequest
+	25, // 41: novitabox.v1.BoxletArtifactService.GetImage:input_type -> novitabox.v1.GetImageRequest
+	26, // 42: novitabox.v1.BoxletArtifactService.ListImages:input_type -> novitabox.v1.ListImagesRequest
+	28, // 43: novitabox.v1.BoxletNodeService.NodeStatus:input_type -> novitabox.v1.NodeStatusRequest
+	30, // 44: novitabox.v1.BoxletNodeService.ListRuntimes:input_type -> novitabox.v1.ListRuntimesRequest
+	33, // 45: novitabox.v1.BoxletNodeService.GetRuntimeCapabilities:input_type -> novitabox.v1.GetRuntimeCapabilitiesRequest
+	44, // 46: novitabox.v1.BoxletSandboxService.CreateSandbox:output_type -> novitabox.v1.SandboxInfo
+	48, // 47: novitabox.v1.BoxletSandboxService.PauseSandbox:output_type -> novitabox.v1.SnapshotInfo
+	44, // 48: novitabox.v1.BoxletSandboxService.ResumeSandbox:output_type -> novitabox.v1.SandboxInfo
+	49, // 49: novitabox.v1.BoxletSandboxService.KillSandbox:output_type -> google.protobuf.Empty
+	44, // 50: novitabox.v1.BoxletSandboxService.StartSandbox:output_type -> novitabox.v1.SandboxInfo
+	44, // 51: novitabox.v1.BoxletSandboxService.StopSandbox:output_type -> novitabox.v1.SandboxInfo
+	44, // 52: novitabox.v1.BoxletSandboxService.RebootSandbox:output_type -> novitabox.v1.SandboxInfo
+	44, // 53: novitabox.v1.BoxletSandboxService.GetSandbox:output_type -> novitabox.v1.SandboxInfo
+	9,  // 54: novitabox.v1.BoxletSandboxService.ListSandboxes:output_type -> novitabox.v1.ListSandboxesResponse
+	50, // 55: novitabox.v1.BoxletSandboxService.UpdateSandboxBalloon:output_type -> novitabox.v1.BalloonConfig
+	50, // 56: novitabox.v1.BoxletSandboxService.GetSandboxBalloon:output_type -> novitabox.v1.BalloonConfig
+	51, // 57: novitabox.v1.BoxletSandboxService.GetSandboxBalloonStats:output_type -> novitabox.v1.BalloonStats
+	50, // 58: novitabox.v1.BoxletSandboxService.UpdateSandboxBalloonStats:output_type -> novitabox.v1.BalloonConfig
+	52, // 59: novitabox.v1.BoxletSandboxService.StartSandboxBalloonHinting:output_type -> novitabox.v1.BalloonHintingStatus
+	52, // 60: novitabox.v1.BoxletSandboxService.StopSandboxBalloonHinting:output_type -> novitabox.v1.BalloonHintingStatus
+	52, // 61: novitabox.v1.BoxletSandboxService.GetSandboxBalloonHinting:output_type -> novitabox.v1.BalloonHintingStatus
+	45, // 62: novitabox.v1.BoxletArtifactService.CreateTemplate:output_type -> novitabox.v1.TemplateInfo
+	49, // 63: novitabox.v1.BoxletArtifactService.DeleteTemplate:output_type -> google.protobuf.Empty
+	45, // 64: novitabox.v1.BoxletArtifactService.GetTemplate:output_type -> novitabox.v1.TemplateInfo
+	22, // 65: novitabox.v1.BoxletArtifactService.ListTemplates:output_type -> novitabox.v1.ListTemplatesResponse
+	46, // 66: novitabox.v1.BoxletArtifactService.CreateImage:output_type -> novitabox.v1.ImageInfo
+	49, // 67: novitabox.v1.BoxletArtifactService.DeleteImage:output_type -> google.protobuf.Empty
+	46, // 68: novitabox.v1.BoxletArtifactService.GetImage:output_type -> novitabox.v1.ImageInfo
+	27, // 69: novitabox.v1.BoxletArtifactService.ListImages:output_type -> novitabox.v1.ListImagesResponse
+	29, // 70: novitabox.v1.BoxletNodeService.NodeStatus:output_type -> novitabox.v1.NodeStatusInfo
+	32, // 71: novitabox.v1.BoxletNodeService.ListRuntimes:output_type -> novitabox.v1.ListRuntimesResponse
+	47, // 72: novitabox.v1.BoxletNodeService.GetRuntimeCapabilities:output_type -> novitabox.v1.RuntimeCapabilities
+	46, // [46:73] is the sub-list for method output_type
+	19, // [19:46] is the sub-list for method input_type
 	19, // [19:19] is the sub-list for extension type_name
 	19, // [19:19] is the sub-list for extension extendee
 	0,  // [0:19] is the sub-list for field type_name
@@ -1689,7 +2078,7 @@ func file_novitabox_v1_boxlet_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_novitabox_v1_boxlet_proto_rawDesc), len(file_novitabox_v1_boxlet_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   35,
+			NumMessages:   42,
 			NumExtensions: 0,
 			NumServices:   3,
 		},

--- a/internal/pb/novitabox/v1/boxlet_grpc.pb.go
+++ b/internal/pb/novitabox/v1/boxlet_grpc.pb.go
@@ -20,15 +20,22 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	BoxletSandboxService_CreateSandbox_FullMethodName = "/novitabox.v1.BoxletSandboxService/CreateSandbox"
-	BoxletSandboxService_PauseSandbox_FullMethodName  = "/novitabox.v1.BoxletSandboxService/PauseSandbox"
-	BoxletSandboxService_ResumeSandbox_FullMethodName = "/novitabox.v1.BoxletSandboxService/ResumeSandbox"
-	BoxletSandboxService_KillSandbox_FullMethodName   = "/novitabox.v1.BoxletSandboxService/KillSandbox"
-	BoxletSandboxService_StartSandbox_FullMethodName  = "/novitabox.v1.BoxletSandboxService/StartSandbox"
-	BoxletSandboxService_StopSandbox_FullMethodName   = "/novitabox.v1.BoxletSandboxService/StopSandbox"
-	BoxletSandboxService_RebootSandbox_FullMethodName = "/novitabox.v1.BoxletSandboxService/RebootSandbox"
-	BoxletSandboxService_GetSandbox_FullMethodName    = "/novitabox.v1.BoxletSandboxService/GetSandbox"
-	BoxletSandboxService_ListSandboxes_FullMethodName = "/novitabox.v1.BoxletSandboxService/ListSandboxes"
+	BoxletSandboxService_CreateSandbox_FullMethodName              = "/novitabox.v1.BoxletSandboxService/CreateSandbox"
+	BoxletSandboxService_PauseSandbox_FullMethodName               = "/novitabox.v1.BoxletSandboxService/PauseSandbox"
+	BoxletSandboxService_ResumeSandbox_FullMethodName              = "/novitabox.v1.BoxletSandboxService/ResumeSandbox"
+	BoxletSandboxService_KillSandbox_FullMethodName                = "/novitabox.v1.BoxletSandboxService/KillSandbox"
+	BoxletSandboxService_StartSandbox_FullMethodName               = "/novitabox.v1.BoxletSandboxService/StartSandbox"
+	BoxletSandboxService_StopSandbox_FullMethodName                = "/novitabox.v1.BoxletSandboxService/StopSandbox"
+	BoxletSandboxService_RebootSandbox_FullMethodName              = "/novitabox.v1.BoxletSandboxService/RebootSandbox"
+	BoxletSandboxService_GetSandbox_FullMethodName                 = "/novitabox.v1.BoxletSandboxService/GetSandbox"
+	BoxletSandboxService_ListSandboxes_FullMethodName              = "/novitabox.v1.BoxletSandboxService/ListSandboxes"
+	BoxletSandboxService_UpdateSandboxBalloon_FullMethodName       = "/novitabox.v1.BoxletSandboxService/UpdateSandboxBalloon"
+	BoxletSandboxService_GetSandboxBalloon_FullMethodName          = "/novitabox.v1.BoxletSandboxService/GetSandboxBalloon"
+	BoxletSandboxService_GetSandboxBalloonStats_FullMethodName     = "/novitabox.v1.BoxletSandboxService/GetSandboxBalloonStats"
+	BoxletSandboxService_UpdateSandboxBalloonStats_FullMethodName  = "/novitabox.v1.BoxletSandboxService/UpdateSandboxBalloonStats"
+	BoxletSandboxService_StartSandboxBalloonHinting_FullMethodName = "/novitabox.v1.BoxletSandboxService/StartSandboxBalloonHinting"
+	BoxletSandboxService_StopSandboxBalloonHinting_FullMethodName  = "/novitabox.v1.BoxletSandboxService/StopSandboxBalloonHinting"
+	BoxletSandboxService_GetSandboxBalloonHinting_FullMethodName   = "/novitabox.v1.BoxletSandboxService/GetSandboxBalloonHinting"
 )
 
 // BoxletSandboxServiceClient is the client API for BoxletSandboxService service.
@@ -44,6 +51,13 @@ type BoxletSandboxServiceClient interface {
 	RebootSandbox(ctx context.Context, in *RebootSandboxRequest, opts ...grpc.CallOption) (*SandboxInfo, error)
 	GetSandbox(ctx context.Context, in *GetSandboxRequest, opts ...grpc.CallOption) (*SandboxInfo, error)
 	ListSandboxes(ctx context.Context, in *ListSandboxesRequest, opts ...grpc.CallOption) (*ListSandboxesResponse, error)
+	UpdateSandboxBalloon(ctx context.Context, in *UpdateSandboxBalloonRequest, opts ...grpc.CallOption) (*BalloonConfig, error)
+	GetSandboxBalloon(ctx context.Context, in *GetSandboxBalloonRequest, opts ...grpc.CallOption) (*BalloonConfig, error)
+	GetSandboxBalloonStats(ctx context.Context, in *GetSandboxBalloonStatsRequest, opts ...grpc.CallOption) (*BalloonStats, error)
+	UpdateSandboxBalloonStats(ctx context.Context, in *UpdateSandboxBalloonStatsRequest, opts ...grpc.CallOption) (*BalloonConfig, error)
+	StartSandboxBalloonHinting(ctx context.Context, in *StartSandboxBalloonHintingRequest, opts ...grpc.CallOption) (*BalloonHintingStatus, error)
+	StopSandboxBalloonHinting(ctx context.Context, in *StopSandboxBalloonHintingRequest, opts ...grpc.CallOption) (*BalloonHintingStatus, error)
+	GetSandboxBalloonHinting(ctx context.Context, in *GetSandboxBalloonHintingRequest, opts ...grpc.CallOption) (*BalloonHintingStatus, error)
 }
 
 type boxletSandboxServiceClient struct {
@@ -144,6 +158,76 @@ func (c *boxletSandboxServiceClient) ListSandboxes(ctx context.Context, in *List
 	return out, nil
 }
 
+func (c *boxletSandboxServiceClient) UpdateSandboxBalloon(ctx context.Context, in *UpdateSandboxBalloonRequest, opts ...grpc.CallOption) (*BalloonConfig, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BalloonConfig)
+	err := c.cc.Invoke(ctx, BoxletSandboxService_UpdateSandboxBalloon_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *boxletSandboxServiceClient) GetSandboxBalloon(ctx context.Context, in *GetSandboxBalloonRequest, opts ...grpc.CallOption) (*BalloonConfig, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BalloonConfig)
+	err := c.cc.Invoke(ctx, BoxletSandboxService_GetSandboxBalloon_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *boxletSandboxServiceClient) GetSandboxBalloonStats(ctx context.Context, in *GetSandboxBalloonStatsRequest, opts ...grpc.CallOption) (*BalloonStats, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BalloonStats)
+	err := c.cc.Invoke(ctx, BoxletSandboxService_GetSandboxBalloonStats_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *boxletSandboxServiceClient) UpdateSandboxBalloonStats(ctx context.Context, in *UpdateSandboxBalloonStatsRequest, opts ...grpc.CallOption) (*BalloonConfig, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BalloonConfig)
+	err := c.cc.Invoke(ctx, BoxletSandboxService_UpdateSandboxBalloonStats_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *boxletSandboxServiceClient) StartSandboxBalloonHinting(ctx context.Context, in *StartSandboxBalloonHintingRequest, opts ...grpc.CallOption) (*BalloonHintingStatus, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BalloonHintingStatus)
+	err := c.cc.Invoke(ctx, BoxletSandboxService_StartSandboxBalloonHinting_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *boxletSandboxServiceClient) StopSandboxBalloonHinting(ctx context.Context, in *StopSandboxBalloonHintingRequest, opts ...grpc.CallOption) (*BalloonHintingStatus, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BalloonHintingStatus)
+	err := c.cc.Invoke(ctx, BoxletSandboxService_StopSandboxBalloonHinting_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *boxletSandboxServiceClient) GetSandboxBalloonHinting(ctx context.Context, in *GetSandboxBalloonHintingRequest, opts ...grpc.CallOption) (*BalloonHintingStatus, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BalloonHintingStatus)
+	err := c.cc.Invoke(ctx, BoxletSandboxService_GetSandboxBalloonHinting_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // BoxletSandboxServiceServer is the server API for BoxletSandboxService service.
 // All implementations must embed UnimplementedBoxletSandboxServiceServer
 // for forward compatibility.
@@ -157,6 +241,13 @@ type BoxletSandboxServiceServer interface {
 	RebootSandbox(context.Context, *RebootSandboxRequest) (*SandboxInfo, error)
 	GetSandbox(context.Context, *GetSandboxRequest) (*SandboxInfo, error)
 	ListSandboxes(context.Context, *ListSandboxesRequest) (*ListSandboxesResponse, error)
+	UpdateSandboxBalloon(context.Context, *UpdateSandboxBalloonRequest) (*BalloonConfig, error)
+	GetSandboxBalloon(context.Context, *GetSandboxBalloonRequest) (*BalloonConfig, error)
+	GetSandboxBalloonStats(context.Context, *GetSandboxBalloonStatsRequest) (*BalloonStats, error)
+	UpdateSandboxBalloonStats(context.Context, *UpdateSandboxBalloonStatsRequest) (*BalloonConfig, error)
+	StartSandboxBalloonHinting(context.Context, *StartSandboxBalloonHintingRequest) (*BalloonHintingStatus, error)
+	StopSandboxBalloonHinting(context.Context, *StopSandboxBalloonHintingRequest) (*BalloonHintingStatus, error)
+	GetSandboxBalloonHinting(context.Context, *GetSandboxBalloonHintingRequest) (*BalloonHintingStatus, error)
 	mustEmbedUnimplementedBoxletSandboxServiceServer()
 }
 
@@ -193,6 +284,27 @@ func (UnimplementedBoxletSandboxServiceServer) GetSandbox(context.Context, *GetS
 }
 func (UnimplementedBoxletSandboxServiceServer) ListSandboxes(context.Context, *ListSandboxesRequest) (*ListSandboxesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListSandboxes not implemented")
+}
+func (UnimplementedBoxletSandboxServiceServer) UpdateSandboxBalloon(context.Context, *UpdateSandboxBalloonRequest) (*BalloonConfig, error) {
+	return nil, status.Error(codes.Unimplemented, "method UpdateSandboxBalloon not implemented")
+}
+func (UnimplementedBoxletSandboxServiceServer) GetSandboxBalloon(context.Context, *GetSandboxBalloonRequest) (*BalloonConfig, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetSandboxBalloon not implemented")
+}
+func (UnimplementedBoxletSandboxServiceServer) GetSandboxBalloonStats(context.Context, *GetSandboxBalloonStatsRequest) (*BalloonStats, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetSandboxBalloonStats not implemented")
+}
+func (UnimplementedBoxletSandboxServiceServer) UpdateSandboxBalloonStats(context.Context, *UpdateSandboxBalloonStatsRequest) (*BalloonConfig, error) {
+	return nil, status.Error(codes.Unimplemented, "method UpdateSandboxBalloonStats not implemented")
+}
+func (UnimplementedBoxletSandboxServiceServer) StartSandboxBalloonHinting(context.Context, *StartSandboxBalloonHintingRequest) (*BalloonHintingStatus, error) {
+	return nil, status.Error(codes.Unimplemented, "method StartSandboxBalloonHinting not implemented")
+}
+func (UnimplementedBoxletSandboxServiceServer) StopSandboxBalloonHinting(context.Context, *StopSandboxBalloonHintingRequest) (*BalloonHintingStatus, error) {
+	return nil, status.Error(codes.Unimplemented, "method StopSandboxBalloonHinting not implemented")
+}
+func (UnimplementedBoxletSandboxServiceServer) GetSandboxBalloonHinting(context.Context, *GetSandboxBalloonHintingRequest) (*BalloonHintingStatus, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetSandboxBalloonHinting not implemented")
 }
 func (UnimplementedBoxletSandboxServiceServer) mustEmbedUnimplementedBoxletSandboxServiceServer() {}
 func (UnimplementedBoxletSandboxServiceServer) testEmbeddedByValue()                              {}
@@ -377,6 +489,132 @@ func _BoxletSandboxService_ListSandboxes_Handler(srv interface{}, ctx context.Co
 	return interceptor(ctx, in, info, handler)
 }
 
+func _BoxletSandboxService_UpdateSandboxBalloon_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateSandboxBalloonRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BoxletSandboxServiceServer).UpdateSandboxBalloon(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BoxletSandboxService_UpdateSandboxBalloon_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BoxletSandboxServiceServer).UpdateSandboxBalloon(ctx, req.(*UpdateSandboxBalloonRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BoxletSandboxService_GetSandboxBalloon_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetSandboxBalloonRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BoxletSandboxServiceServer).GetSandboxBalloon(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BoxletSandboxService_GetSandboxBalloon_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BoxletSandboxServiceServer).GetSandboxBalloon(ctx, req.(*GetSandboxBalloonRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BoxletSandboxService_GetSandboxBalloonStats_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetSandboxBalloonStatsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BoxletSandboxServiceServer).GetSandboxBalloonStats(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BoxletSandboxService_GetSandboxBalloonStats_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BoxletSandboxServiceServer).GetSandboxBalloonStats(ctx, req.(*GetSandboxBalloonStatsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BoxletSandboxService_UpdateSandboxBalloonStats_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateSandboxBalloonStatsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BoxletSandboxServiceServer).UpdateSandboxBalloonStats(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BoxletSandboxService_UpdateSandboxBalloonStats_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BoxletSandboxServiceServer).UpdateSandboxBalloonStats(ctx, req.(*UpdateSandboxBalloonStatsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BoxletSandboxService_StartSandboxBalloonHinting_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StartSandboxBalloonHintingRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BoxletSandboxServiceServer).StartSandboxBalloonHinting(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BoxletSandboxService_StartSandboxBalloonHinting_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BoxletSandboxServiceServer).StartSandboxBalloonHinting(ctx, req.(*StartSandboxBalloonHintingRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BoxletSandboxService_StopSandboxBalloonHinting_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StopSandboxBalloonHintingRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BoxletSandboxServiceServer).StopSandboxBalloonHinting(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BoxletSandboxService_StopSandboxBalloonHinting_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BoxletSandboxServiceServer).StopSandboxBalloonHinting(ctx, req.(*StopSandboxBalloonHintingRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BoxletSandboxService_GetSandboxBalloonHinting_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetSandboxBalloonHintingRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BoxletSandboxServiceServer).GetSandboxBalloonHinting(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BoxletSandboxService_GetSandboxBalloonHinting_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BoxletSandboxServiceServer).GetSandboxBalloonHinting(ctx, req.(*GetSandboxBalloonHintingRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // BoxletSandboxService_ServiceDesc is the grpc.ServiceDesc for BoxletSandboxService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -419,6 +657,34 @@ var BoxletSandboxService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListSandboxes",
 			Handler:    _BoxletSandboxService_ListSandboxes_Handler,
+		},
+		{
+			MethodName: "UpdateSandboxBalloon",
+			Handler:    _BoxletSandboxService_UpdateSandboxBalloon_Handler,
+		},
+		{
+			MethodName: "GetSandboxBalloon",
+			Handler:    _BoxletSandboxService_GetSandboxBalloon_Handler,
+		},
+		{
+			MethodName: "GetSandboxBalloonStats",
+			Handler:    _BoxletSandboxService_GetSandboxBalloonStats_Handler,
+		},
+		{
+			MethodName: "UpdateSandboxBalloonStats",
+			Handler:    _BoxletSandboxService_UpdateSandboxBalloonStats_Handler,
+		},
+		{
+			MethodName: "StartSandboxBalloonHinting",
+			Handler:    _BoxletSandboxService_StartSandboxBalloonHinting_Handler,
+		},
+		{
+			MethodName: "StopSandboxBalloonHinting",
+			Handler:    _BoxletSandboxService_StopSandboxBalloonHinting_Handler,
+		},
+		{
+			MethodName: "GetSandboxBalloonHinting",
+			Handler:    _BoxletSandboxService_GetSandboxBalloonHinting_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/internal/pb/novitabox/v1/boxshim.pb.go
+++ b/internal/pb/novitabox/v1/boxshim.pb.go
@@ -434,6 +434,338 @@ func (x *CapabilitiesRequest) GetRuntimeType() RuntimeType {
 	return RuntimeType_RUNTIME_TYPE_UNSPECIFIED
 }
 
+type UpdateBalloonRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	AmountMib     uint32                 `protobuf:"varint,2,opt,name=amount_mib,json=amountMib,proto3" json:"amount_mib,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateBalloonRequest) Reset() {
+	*x = UpdateBalloonRequest{}
+	mi := &file_novitabox_v1_boxshim_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateBalloonRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateBalloonRequest) ProtoMessage() {}
+
+func (x *UpdateBalloonRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_boxshim_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateBalloonRequest.ProtoReflect.Descriptor instead.
+func (*UpdateBalloonRequest) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_boxshim_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *UpdateBalloonRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+func (x *UpdateBalloonRequest) GetAmountMib() uint32 {
+	if x != nil {
+		return x.AmountMib
+	}
+	return 0
+}
+
+type GetBalloonRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetBalloonRequest) Reset() {
+	*x = GetBalloonRequest{}
+	mi := &file_novitabox_v1_boxshim_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetBalloonRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetBalloonRequest) ProtoMessage() {}
+
+func (x *GetBalloonRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_boxshim_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetBalloonRequest.ProtoReflect.Descriptor instead.
+func (*GetBalloonRequest) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_boxshim_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *GetBalloonRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+type GetBalloonStatsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetBalloonStatsRequest) Reset() {
+	*x = GetBalloonStatsRequest{}
+	mi := &file_novitabox_v1_boxshim_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetBalloonStatsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetBalloonStatsRequest) ProtoMessage() {}
+
+func (x *GetBalloonStatsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_boxshim_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetBalloonStatsRequest.ProtoReflect.Descriptor instead.
+func (*GetBalloonStatsRequest) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_boxshim_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *GetBalloonStatsRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+type UpdateBalloonStatsRequest struct {
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId             string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	StatsPollingIntervalS uint32                 `protobuf:"varint,2,opt,name=stats_polling_interval_s,json=statsPollingIntervalS,proto3" json:"stats_polling_interval_s,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *UpdateBalloonStatsRequest) Reset() {
+	*x = UpdateBalloonStatsRequest{}
+	mi := &file_novitabox_v1_boxshim_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateBalloonStatsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateBalloonStatsRequest) ProtoMessage() {}
+
+func (x *UpdateBalloonStatsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_boxshim_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateBalloonStatsRequest.ProtoReflect.Descriptor instead.
+func (*UpdateBalloonStatsRequest) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_boxshim_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *UpdateBalloonStatsRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+func (x *UpdateBalloonStatsRequest) GetStatsPollingIntervalS() uint32 {
+	if x != nil {
+		return x.StatsPollingIntervalS
+	}
+	return 0
+}
+
+type StartBalloonHintingRequest struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId         string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	AcknowledgeOnStop bool                   `protobuf:"varint,3,opt,name=acknowledge_on_stop,json=acknowledgeOnStop,proto3" json:"acknowledge_on_stop,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *StartBalloonHintingRequest) Reset() {
+	*x = StartBalloonHintingRequest{}
+	mi := &file_novitabox_v1_boxshim_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StartBalloonHintingRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StartBalloonHintingRequest) ProtoMessage() {}
+
+func (x *StartBalloonHintingRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_boxshim_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StartBalloonHintingRequest.ProtoReflect.Descriptor instead.
+func (*StartBalloonHintingRequest) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_boxshim_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *StartBalloonHintingRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+func (x *StartBalloonHintingRequest) GetAcknowledgeOnStop() bool {
+	if x != nil {
+		return x.AcknowledgeOnStop
+	}
+	return false
+}
+
+type StopBalloonHintingRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StopBalloonHintingRequest) Reset() {
+	*x = StopBalloonHintingRequest{}
+	mi := &file_novitabox_v1_boxshim_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StopBalloonHintingRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StopBalloonHintingRequest) ProtoMessage() {}
+
+func (x *StopBalloonHintingRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_boxshim_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StopBalloonHintingRequest.ProtoReflect.Descriptor instead.
+func (*StopBalloonHintingRequest) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_boxshim_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *StopBalloonHintingRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+type GetBalloonHintingRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetBalloonHintingRequest) Reset() {
+	*x = GetBalloonHintingRequest{}
+	mi := &file_novitabox_v1_boxshim_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetBalloonHintingRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetBalloonHintingRequest) ProtoMessage() {}
+
+func (x *GetBalloonHintingRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_boxshim_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetBalloonHintingRequest.ProtoReflect.Descriptor instead.
+func (*GetBalloonHintingRequest) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_boxshim_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *GetBalloonHintingRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
 var File_novitabox_v1_boxshim_proto protoreflect.FileDescriptor
 
 const file_novitabox_v1_boxshim_proto_rawDesc = "" +
@@ -463,7 +795,34 @@ const file_novitabox_v1_boxshim_proto_rawDesc = "" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"S\n" +
 	"\x13CapabilitiesRequest\x12<\n" +
-	"\fruntime_type\x18\x01 \x01(\x0e2\x19.novitabox.v1.RuntimeTypeR\vruntimeType2\xc2\x05\n" +
+	"\fruntime_type\x18\x01 \x01(\x0e2\x19.novitabox.v1.RuntimeTypeR\vruntimeType\"T\n" +
+	"\x14UpdateBalloonRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x1d\n" +
+	"\n" +
+	"amount_mib\x18\x02 \x01(\rR\tamountMib\"2\n" +
+	"\x11GetBalloonRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"7\n" +
+	"\x16GetBalloonStatsRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"s\n" +
+	"\x19UpdateBalloonStatsRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x127\n" +
+	"\x18stats_polling_interval_s\x18\x02 \x01(\rR\x15statsPollingIntervalS\"}\n" +
+	"\x1aStartBalloonHintingRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12.\n" +
+	"\x13acknowledge_on_stop\x18\x03 \x01(\bR\x11acknowledgeOnStopJ\x04\b\x02\x10\x03R\n" +
+	"interval_s\":\n" +
+	"\x19StopBalloonHintingRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"9\n" +
+	"\x18GetBalloonHintingRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId2\xba\n" +
+	"\n" +
 	"\aBoxShim\x12N\n" +
 	"\rCreateRuntime\x12\".novitabox.v1.CreateRuntimeRequest\x1a\x19.novitabox.v1.RuntimeInfo\x12L\n" +
 	"\fPauseRuntime\x12!.novitabox.v1.PauseRuntimeRequest\x1a\x19.novitabox.v1.RuntimeInfo\x12N\n" +
@@ -473,7 +832,15 @@ const file_novitabox_v1_boxshim_proto_rawDesc = "" +
 	"\vStopRuntime\x12 .novitabox.v1.StopRuntimeRequest\x1a\x19.novitabox.v1.RuntimeInfo\x12N\n" +
 	"\rRebootRuntime\x12\".novitabox.v1.RebootRuntimeRequest\x1a\x19.novitabox.v1.RuntimeInfo\x12@\n" +
 	"\x06Status\x12\x1b.novitabox.v1.StatusRequest\x1a\x19.novitabox.v1.RuntimeInfo\x12T\n" +
-	"\fCapabilities\x12!.novitabox.v1.CapabilitiesRequest\x1a!.novitabox.v1.RuntimeCapabilitiesBFZDgithub.com/novitalabs/NovitaBox/internal/pb/novitabox/v1;novitaboxv1b\x06proto3"
+	"\fCapabilities\x12!.novitabox.v1.CapabilitiesRequest\x1a!.novitabox.v1.RuntimeCapabilities\x12P\n" +
+	"\rUpdateBalloon\x12\".novitabox.v1.UpdateBalloonRequest\x1a\x1b.novitabox.v1.BalloonConfig\x12J\n" +
+	"\n" +
+	"GetBalloon\x12\x1f.novitabox.v1.GetBalloonRequest\x1a\x1b.novitabox.v1.BalloonConfig\x12S\n" +
+	"\x0fGetBalloonStats\x12$.novitabox.v1.GetBalloonStatsRequest\x1a\x1a.novitabox.v1.BalloonStats\x12Z\n" +
+	"\x12UpdateBalloonStats\x12'.novitabox.v1.UpdateBalloonStatsRequest\x1a\x1b.novitabox.v1.BalloonConfig\x12c\n" +
+	"\x13StartBalloonHinting\x12(.novitabox.v1.StartBalloonHintingRequest\x1a\".novitabox.v1.BalloonHintingStatus\x12a\n" +
+	"\x12StopBalloonHinting\x12'.novitabox.v1.StopBalloonHintingRequest\x1a\".novitabox.v1.BalloonHintingStatus\x12_\n" +
+	"\x11GetBalloonHinting\x12&.novitabox.v1.GetBalloonHintingRequest\x1a\".novitabox.v1.BalloonHintingStatusBFZDgithub.com/novitalabs/NovitaBox/internal/pb/novitabox/v1;novitaboxv1b\x06proto3"
 
 var (
 	file_novitabox_v1_boxshim_proto_rawDescOnce sync.Once
@@ -487,28 +854,38 @@ func file_novitabox_v1_boxshim_proto_rawDescGZIP() []byte {
 	return file_novitabox_v1_boxshim_proto_rawDescData
 }
 
-var file_novitabox_v1_boxshim_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_novitabox_v1_boxshim_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_novitabox_v1_boxshim_proto_goTypes = []any{
-	(*CreateRuntimeRequest)(nil), // 0: novitabox.v1.CreateRuntimeRequest
-	(*PauseRuntimeRequest)(nil),  // 1: novitabox.v1.PauseRuntimeRequest
-	(*ResumeRuntimeRequest)(nil), // 2: novitabox.v1.ResumeRuntimeRequest
-	(*KillRuntimeRequest)(nil),   // 3: novitabox.v1.KillRuntimeRequest
-	(*StartRuntimeRequest)(nil),  // 4: novitabox.v1.StartRuntimeRequest
-	(*StopRuntimeRequest)(nil),   // 5: novitabox.v1.StopRuntimeRequest
-	(*RebootRuntimeRequest)(nil), // 6: novitabox.v1.RebootRuntimeRequest
-	(*StatusRequest)(nil),        // 7: novitabox.v1.StatusRequest
-	(*CapabilitiesRequest)(nil),  // 8: novitabox.v1.CapabilitiesRequest
-	(*RuntimeSpec)(nil),          // 9: novitabox.v1.RuntimeSpec
-	(RuntimeType)(0),             // 10: novitabox.v1.RuntimeType
-	(*RuntimeInfo)(nil),          // 11: novitabox.v1.RuntimeInfo
-	(*emptypb.Empty)(nil),        // 12: google.protobuf.Empty
-	(*RuntimeCapabilities)(nil),  // 13: novitabox.v1.RuntimeCapabilities
+	(*CreateRuntimeRequest)(nil),       // 0: novitabox.v1.CreateRuntimeRequest
+	(*PauseRuntimeRequest)(nil),        // 1: novitabox.v1.PauseRuntimeRequest
+	(*ResumeRuntimeRequest)(nil),       // 2: novitabox.v1.ResumeRuntimeRequest
+	(*KillRuntimeRequest)(nil),         // 3: novitabox.v1.KillRuntimeRequest
+	(*StartRuntimeRequest)(nil),        // 4: novitabox.v1.StartRuntimeRequest
+	(*StopRuntimeRequest)(nil),         // 5: novitabox.v1.StopRuntimeRequest
+	(*RebootRuntimeRequest)(nil),       // 6: novitabox.v1.RebootRuntimeRequest
+	(*StatusRequest)(nil),              // 7: novitabox.v1.StatusRequest
+	(*CapabilitiesRequest)(nil),        // 8: novitabox.v1.CapabilitiesRequest
+	(*UpdateBalloonRequest)(nil),       // 9: novitabox.v1.UpdateBalloonRequest
+	(*GetBalloonRequest)(nil),          // 10: novitabox.v1.GetBalloonRequest
+	(*GetBalloonStatsRequest)(nil),     // 11: novitabox.v1.GetBalloonStatsRequest
+	(*UpdateBalloonStatsRequest)(nil),  // 12: novitabox.v1.UpdateBalloonStatsRequest
+	(*StartBalloonHintingRequest)(nil), // 13: novitabox.v1.StartBalloonHintingRequest
+	(*StopBalloonHintingRequest)(nil),  // 14: novitabox.v1.StopBalloonHintingRequest
+	(*GetBalloonHintingRequest)(nil),   // 15: novitabox.v1.GetBalloonHintingRequest
+	(*RuntimeSpec)(nil),                // 16: novitabox.v1.RuntimeSpec
+	(RuntimeType)(0),                   // 17: novitabox.v1.RuntimeType
+	(*RuntimeInfo)(nil),                // 18: novitabox.v1.RuntimeInfo
+	(*emptypb.Empty)(nil),              // 19: google.protobuf.Empty
+	(*RuntimeCapabilities)(nil),        // 20: novitabox.v1.RuntimeCapabilities
+	(*BalloonConfig)(nil),              // 21: novitabox.v1.BalloonConfig
+	(*BalloonStats)(nil),               // 22: novitabox.v1.BalloonStats
+	(*BalloonHintingStatus)(nil),       // 23: novitabox.v1.BalloonHintingStatus
 }
 var file_novitabox_v1_boxshim_proto_depIdxs = []int32{
-	9,  // 0: novitabox.v1.CreateRuntimeRequest.runtime_spec:type_name -> novitabox.v1.RuntimeSpec
-	9,  // 1: novitabox.v1.ResumeRuntimeRequest.runtime_spec:type_name -> novitabox.v1.RuntimeSpec
-	9,  // 2: novitabox.v1.StartRuntimeRequest.runtime_spec:type_name -> novitabox.v1.RuntimeSpec
-	10, // 3: novitabox.v1.CapabilitiesRequest.runtime_type:type_name -> novitabox.v1.RuntimeType
+	16, // 0: novitabox.v1.CreateRuntimeRequest.runtime_spec:type_name -> novitabox.v1.RuntimeSpec
+	16, // 1: novitabox.v1.ResumeRuntimeRequest.runtime_spec:type_name -> novitabox.v1.RuntimeSpec
+	16, // 2: novitabox.v1.StartRuntimeRequest.runtime_spec:type_name -> novitabox.v1.RuntimeSpec
+	17, // 3: novitabox.v1.CapabilitiesRequest.runtime_type:type_name -> novitabox.v1.RuntimeType
 	0,  // 4: novitabox.v1.BoxShim.CreateRuntime:input_type -> novitabox.v1.CreateRuntimeRequest
 	1,  // 5: novitabox.v1.BoxShim.PauseRuntime:input_type -> novitabox.v1.PauseRuntimeRequest
 	2,  // 6: novitabox.v1.BoxShim.ResumeRuntime:input_type -> novitabox.v1.ResumeRuntimeRequest
@@ -518,17 +895,31 @@ var file_novitabox_v1_boxshim_proto_depIdxs = []int32{
 	6,  // 10: novitabox.v1.BoxShim.RebootRuntime:input_type -> novitabox.v1.RebootRuntimeRequest
 	7,  // 11: novitabox.v1.BoxShim.Status:input_type -> novitabox.v1.StatusRequest
 	8,  // 12: novitabox.v1.BoxShim.Capabilities:input_type -> novitabox.v1.CapabilitiesRequest
-	11, // 13: novitabox.v1.BoxShim.CreateRuntime:output_type -> novitabox.v1.RuntimeInfo
-	11, // 14: novitabox.v1.BoxShim.PauseRuntime:output_type -> novitabox.v1.RuntimeInfo
-	11, // 15: novitabox.v1.BoxShim.ResumeRuntime:output_type -> novitabox.v1.RuntimeInfo
-	12, // 16: novitabox.v1.BoxShim.KillRuntime:output_type -> google.protobuf.Empty
-	11, // 17: novitabox.v1.BoxShim.StartRuntime:output_type -> novitabox.v1.RuntimeInfo
-	11, // 18: novitabox.v1.BoxShim.StopRuntime:output_type -> novitabox.v1.RuntimeInfo
-	11, // 19: novitabox.v1.BoxShim.RebootRuntime:output_type -> novitabox.v1.RuntimeInfo
-	11, // 20: novitabox.v1.BoxShim.Status:output_type -> novitabox.v1.RuntimeInfo
-	13, // 21: novitabox.v1.BoxShim.Capabilities:output_type -> novitabox.v1.RuntimeCapabilities
-	13, // [13:22] is the sub-list for method output_type
-	4,  // [4:13] is the sub-list for method input_type
+	9,  // 13: novitabox.v1.BoxShim.UpdateBalloon:input_type -> novitabox.v1.UpdateBalloonRequest
+	10, // 14: novitabox.v1.BoxShim.GetBalloon:input_type -> novitabox.v1.GetBalloonRequest
+	11, // 15: novitabox.v1.BoxShim.GetBalloonStats:input_type -> novitabox.v1.GetBalloonStatsRequest
+	12, // 16: novitabox.v1.BoxShim.UpdateBalloonStats:input_type -> novitabox.v1.UpdateBalloonStatsRequest
+	13, // 17: novitabox.v1.BoxShim.StartBalloonHinting:input_type -> novitabox.v1.StartBalloonHintingRequest
+	14, // 18: novitabox.v1.BoxShim.StopBalloonHinting:input_type -> novitabox.v1.StopBalloonHintingRequest
+	15, // 19: novitabox.v1.BoxShim.GetBalloonHinting:input_type -> novitabox.v1.GetBalloonHintingRequest
+	18, // 20: novitabox.v1.BoxShim.CreateRuntime:output_type -> novitabox.v1.RuntimeInfo
+	18, // 21: novitabox.v1.BoxShim.PauseRuntime:output_type -> novitabox.v1.RuntimeInfo
+	18, // 22: novitabox.v1.BoxShim.ResumeRuntime:output_type -> novitabox.v1.RuntimeInfo
+	19, // 23: novitabox.v1.BoxShim.KillRuntime:output_type -> google.protobuf.Empty
+	18, // 24: novitabox.v1.BoxShim.StartRuntime:output_type -> novitabox.v1.RuntimeInfo
+	18, // 25: novitabox.v1.BoxShim.StopRuntime:output_type -> novitabox.v1.RuntimeInfo
+	18, // 26: novitabox.v1.BoxShim.RebootRuntime:output_type -> novitabox.v1.RuntimeInfo
+	18, // 27: novitabox.v1.BoxShim.Status:output_type -> novitabox.v1.RuntimeInfo
+	20, // 28: novitabox.v1.BoxShim.Capabilities:output_type -> novitabox.v1.RuntimeCapabilities
+	21, // 29: novitabox.v1.BoxShim.UpdateBalloon:output_type -> novitabox.v1.BalloonConfig
+	21, // 30: novitabox.v1.BoxShim.GetBalloon:output_type -> novitabox.v1.BalloonConfig
+	22, // 31: novitabox.v1.BoxShim.GetBalloonStats:output_type -> novitabox.v1.BalloonStats
+	21, // 32: novitabox.v1.BoxShim.UpdateBalloonStats:output_type -> novitabox.v1.BalloonConfig
+	23, // 33: novitabox.v1.BoxShim.StartBalloonHinting:output_type -> novitabox.v1.BalloonHintingStatus
+	23, // 34: novitabox.v1.BoxShim.StopBalloonHinting:output_type -> novitabox.v1.BalloonHintingStatus
+	23, // 35: novitabox.v1.BoxShim.GetBalloonHinting:output_type -> novitabox.v1.BalloonHintingStatus
+	20, // [20:36] is the sub-list for method output_type
+	4,  // [4:20] is the sub-list for method input_type
 	4,  // [4:4] is the sub-list for extension type_name
 	4,  // [4:4] is the sub-list for extension extendee
 	0,  // [0:4] is the sub-list for field type_name
@@ -546,7 +937,7 @@ func file_novitabox_v1_boxshim_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_novitabox_v1_boxshim_proto_rawDesc), len(file_novitabox_v1_boxshim_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   9,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/pb/novitabox/v1/boxshim_grpc.pb.go
+++ b/internal/pb/novitabox/v1/boxshim_grpc.pb.go
@@ -20,15 +20,22 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	BoxShim_CreateRuntime_FullMethodName = "/novitabox.v1.BoxShim/CreateRuntime"
-	BoxShim_PauseRuntime_FullMethodName  = "/novitabox.v1.BoxShim/PauseRuntime"
-	BoxShim_ResumeRuntime_FullMethodName = "/novitabox.v1.BoxShim/ResumeRuntime"
-	BoxShim_KillRuntime_FullMethodName   = "/novitabox.v1.BoxShim/KillRuntime"
-	BoxShim_StartRuntime_FullMethodName  = "/novitabox.v1.BoxShim/StartRuntime"
-	BoxShim_StopRuntime_FullMethodName   = "/novitabox.v1.BoxShim/StopRuntime"
-	BoxShim_RebootRuntime_FullMethodName = "/novitabox.v1.BoxShim/RebootRuntime"
-	BoxShim_Status_FullMethodName        = "/novitabox.v1.BoxShim/Status"
-	BoxShim_Capabilities_FullMethodName  = "/novitabox.v1.BoxShim/Capabilities"
+	BoxShim_CreateRuntime_FullMethodName       = "/novitabox.v1.BoxShim/CreateRuntime"
+	BoxShim_PauseRuntime_FullMethodName        = "/novitabox.v1.BoxShim/PauseRuntime"
+	BoxShim_ResumeRuntime_FullMethodName       = "/novitabox.v1.BoxShim/ResumeRuntime"
+	BoxShim_KillRuntime_FullMethodName         = "/novitabox.v1.BoxShim/KillRuntime"
+	BoxShim_StartRuntime_FullMethodName        = "/novitabox.v1.BoxShim/StartRuntime"
+	BoxShim_StopRuntime_FullMethodName         = "/novitabox.v1.BoxShim/StopRuntime"
+	BoxShim_RebootRuntime_FullMethodName       = "/novitabox.v1.BoxShim/RebootRuntime"
+	BoxShim_Status_FullMethodName              = "/novitabox.v1.BoxShim/Status"
+	BoxShim_Capabilities_FullMethodName        = "/novitabox.v1.BoxShim/Capabilities"
+	BoxShim_UpdateBalloon_FullMethodName       = "/novitabox.v1.BoxShim/UpdateBalloon"
+	BoxShim_GetBalloon_FullMethodName          = "/novitabox.v1.BoxShim/GetBalloon"
+	BoxShim_GetBalloonStats_FullMethodName     = "/novitabox.v1.BoxShim/GetBalloonStats"
+	BoxShim_UpdateBalloonStats_FullMethodName  = "/novitabox.v1.BoxShim/UpdateBalloonStats"
+	BoxShim_StartBalloonHinting_FullMethodName = "/novitabox.v1.BoxShim/StartBalloonHinting"
+	BoxShim_StopBalloonHinting_FullMethodName  = "/novitabox.v1.BoxShim/StopBalloonHinting"
+	BoxShim_GetBalloonHinting_FullMethodName   = "/novitabox.v1.BoxShim/GetBalloonHinting"
 )
 
 // BoxShimClient is the client API for BoxShim service.
@@ -44,6 +51,13 @@ type BoxShimClient interface {
 	RebootRuntime(ctx context.Context, in *RebootRuntimeRequest, opts ...grpc.CallOption) (*RuntimeInfo, error)
 	Status(ctx context.Context, in *StatusRequest, opts ...grpc.CallOption) (*RuntimeInfo, error)
 	Capabilities(ctx context.Context, in *CapabilitiesRequest, opts ...grpc.CallOption) (*RuntimeCapabilities, error)
+	UpdateBalloon(ctx context.Context, in *UpdateBalloonRequest, opts ...grpc.CallOption) (*BalloonConfig, error)
+	GetBalloon(ctx context.Context, in *GetBalloonRequest, opts ...grpc.CallOption) (*BalloonConfig, error)
+	GetBalloonStats(ctx context.Context, in *GetBalloonStatsRequest, opts ...grpc.CallOption) (*BalloonStats, error)
+	UpdateBalloonStats(ctx context.Context, in *UpdateBalloonStatsRequest, opts ...grpc.CallOption) (*BalloonConfig, error)
+	StartBalloonHinting(ctx context.Context, in *StartBalloonHintingRequest, opts ...grpc.CallOption) (*BalloonHintingStatus, error)
+	StopBalloonHinting(ctx context.Context, in *StopBalloonHintingRequest, opts ...grpc.CallOption) (*BalloonHintingStatus, error)
+	GetBalloonHinting(ctx context.Context, in *GetBalloonHintingRequest, opts ...grpc.CallOption) (*BalloonHintingStatus, error)
 }
 
 type boxShimClient struct {
@@ -144,6 +158,76 @@ func (c *boxShimClient) Capabilities(ctx context.Context, in *CapabilitiesReques
 	return out, nil
 }
 
+func (c *boxShimClient) UpdateBalloon(ctx context.Context, in *UpdateBalloonRequest, opts ...grpc.CallOption) (*BalloonConfig, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BalloonConfig)
+	err := c.cc.Invoke(ctx, BoxShim_UpdateBalloon_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *boxShimClient) GetBalloon(ctx context.Context, in *GetBalloonRequest, opts ...grpc.CallOption) (*BalloonConfig, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BalloonConfig)
+	err := c.cc.Invoke(ctx, BoxShim_GetBalloon_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *boxShimClient) GetBalloonStats(ctx context.Context, in *GetBalloonStatsRequest, opts ...grpc.CallOption) (*BalloonStats, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BalloonStats)
+	err := c.cc.Invoke(ctx, BoxShim_GetBalloonStats_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *boxShimClient) UpdateBalloonStats(ctx context.Context, in *UpdateBalloonStatsRequest, opts ...grpc.CallOption) (*BalloonConfig, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BalloonConfig)
+	err := c.cc.Invoke(ctx, BoxShim_UpdateBalloonStats_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *boxShimClient) StartBalloonHinting(ctx context.Context, in *StartBalloonHintingRequest, opts ...grpc.CallOption) (*BalloonHintingStatus, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BalloonHintingStatus)
+	err := c.cc.Invoke(ctx, BoxShim_StartBalloonHinting_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *boxShimClient) StopBalloonHinting(ctx context.Context, in *StopBalloonHintingRequest, opts ...grpc.CallOption) (*BalloonHintingStatus, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BalloonHintingStatus)
+	err := c.cc.Invoke(ctx, BoxShim_StopBalloonHinting_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *boxShimClient) GetBalloonHinting(ctx context.Context, in *GetBalloonHintingRequest, opts ...grpc.CallOption) (*BalloonHintingStatus, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BalloonHintingStatus)
+	err := c.cc.Invoke(ctx, BoxShim_GetBalloonHinting_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // BoxShimServer is the server API for BoxShim service.
 // All implementations must embed UnimplementedBoxShimServer
 // for forward compatibility.
@@ -157,6 +241,13 @@ type BoxShimServer interface {
 	RebootRuntime(context.Context, *RebootRuntimeRequest) (*RuntimeInfo, error)
 	Status(context.Context, *StatusRequest) (*RuntimeInfo, error)
 	Capabilities(context.Context, *CapabilitiesRequest) (*RuntimeCapabilities, error)
+	UpdateBalloon(context.Context, *UpdateBalloonRequest) (*BalloonConfig, error)
+	GetBalloon(context.Context, *GetBalloonRequest) (*BalloonConfig, error)
+	GetBalloonStats(context.Context, *GetBalloonStatsRequest) (*BalloonStats, error)
+	UpdateBalloonStats(context.Context, *UpdateBalloonStatsRequest) (*BalloonConfig, error)
+	StartBalloonHinting(context.Context, *StartBalloonHintingRequest) (*BalloonHintingStatus, error)
+	StopBalloonHinting(context.Context, *StopBalloonHintingRequest) (*BalloonHintingStatus, error)
+	GetBalloonHinting(context.Context, *GetBalloonHintingRequest) (*BalloonHintingStatus, error)
 	mustEmbedUnimplementedBoxShimServer()
 }
 
@@ -193,6 +284,27 @@ func (UnimplementedBoxShimServer) Status(context.Context, *StatusRequest) (*Runt
 }
 func (UnimplementedBoxShimServer) Capabilities(context.Context, *CapabilitiesRequest) (*RuntimeCapabilities, error) {
 	return nil, status.Error(codes.Unimplemented, "method Capabilities not implemented")
+}
+func (UnimplementedBoxShimServer) UpdateBalloon(context.Context, *UpdateBalloonRequest) (*BalloonConfig, error) {
+	return nil, status.Error(codes.Unimplemented, "method UpdateBalloon not implemented")
+}
+func (UnimplementedBoxShimServer) GetBalloon(context.Context, *GetBalloonRequest) (*BalloonConfig, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetBalloon not implemented")
+}
+func (UnimplementedBoxShimServer) GetBalloonStats(context.Context, *GetBalloonStatsRequest) (*BalloonStats, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetBalloonStats not implemented")
+}
+func (UnimplementedBoxShimServer) UpdateBalloonStats(context.Context, *UpdateBalloonStatsRequest) (*BalloonConfig, error) {
+	return nil, status.Error(codes.Unimplemented, "method UpdateBalloonStats not implemented")
+}
+func (UnimplementedBoxShimServer) StartBalloonHinting(context.Context, *StartBalloonHintingRequest) (*BalloonHintingStatus, error) {
+	return nil, status.Error(codes.Unimplemented, "method StartBalloonHinting not implemented")
+}
+func (UnimplementedBoxShimServer) StopBalloonHinting(context.Context, *StopBalloonHintingRequest) (*BalloonHintingStatus, error) {
+	return nil, status.Error(codes.Unimplemented, "method StopBalloonHinting not implemented")
+}
+func (UnimplementedBoxShimServer) GetBalloonHinting(context.Context, *GetBalloonHintingRequest) (*BalloonHintingStatus, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetBalloonHinting not implemented")
 }
 func (UnimplementedBoxShimServer) mustEmbedUnimplementedBoxShimServer() {}
 func (UnimplementedBoxShimServer) testEmbeddedByValue()                 {}
@@ -377,6 +489,132 @@ func _BoxShim_Capabilities_Handler(srv interface{}, ctx context.Context, dec fun
 	return interceptor(ctx, in, info, handler)
 }
 
+func _BoxShim_UpdateBalloon_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateBalloonRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BoxShimServer).UpdateBalloon(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BoxShim_UpdateBalloon_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BoxShimServer).UpdateBalloon(ctx, req.(*UpdateBalloonRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BoxShim_GetBalloon_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetBalloonRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BoxShimServer).GetBalloon(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BoxShim_GetBalloon_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BoxShimServer).GetBalloon(ctx, req.(*GetBalloonRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BoxShim_GetBalloonStats_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetBalloonStatsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BoxShimServer).GetBalloonStats(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BoxShim_GetBalloonStats_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BoxShimServer).GetBalloonStats(ctx, req.(*GetBalloonStatsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BoxShim_UpdateBalloonStats_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateBalloonStatsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BoxShimServer).UpdateBalloonStats(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BoxShim_UpdateBalloonStats_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BoxShimServer).UpdateBalloonStats(ctx, req.(*UpdateBalloonStatsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BoxShim_StartBalloonHinting_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StartBalloonHintingRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BoxShimServer).StartBalloonHinting(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BoxShim_StartBalloonHinting_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BoxShimServer).StartBalloonHinting(ctx, req.(*StartBalloonHintingRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BoxShim_StopBalloonHinting_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StopBalloonHintingRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BoxShimServer).StopBalloonHinting(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BoxShim_StopBalloonHinting_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BoxShimServer).StopBalloonHinting(ctx, req.(*StopBalloonHintingRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BoxShim_GetBalloonHinting_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetBalloonHintingRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BoxShimServer).GetBalloonHinting(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BoxShim_GetBalloonHinting_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BoxShimServer).GetBalloonHinting(ctx, req.(*GetBalloonHintingRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // BoxShim_ServiceDesc is the grpc.ServiceDesc for BoxShim service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -419,6 +657,34 @@ var BoxShim_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Capabilities",
 			Handler:    _BoxShim_Capabilities_Handler,
+		},
+		{
+			MethodName: "UpdateBalloon",
+			Handler:    _BoxShim_UpdateBalloon_Handler,
+		},
+		{
+			MethodName: "GetBalloon",
+			Handler:    _BoxShim_GetBalloon_Handler,
+		},
+		{
+			MethodName: "GetBalloonStats",
+			Handler:    _BoxShim_GetBalloonStats_Handler,
+		},
+		{
+			MethodName: "UpdateBalloonStats",
+			Handler:    _BoxShim_UpdateBalloonStats_Handler,
+		},
+		{
+			MethodName: "StartBalloonHinting",
+			Handler:    _BoxShim_StartBalloonHinting_Handler,
+		},
+		{
+			MethodName: "StopBalloonHinting",
+			Handler:    _BoxShim_StopBalloonHinting_Handler,
+		},
+		{
+			MethodName: "GetBalloonHinting",
+			Handler:    _BoxShim_GetBalloonHinting_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/internal/pb/novitabox/v1/types.pb.go
+++ b/internal/pb/novitabox/v1/types.pb.go
@@ -647,6 +647,414 @@ func (x *MachineSpec) GetGpu() uint32 {
 	return 0
 }
 
+type BalloonSpec struct {
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	AmountMib             uint32                 `protobuf:"varint,1,opt,name=amount_mib,json=amountMib,proto3" json:"amount_mib,omitempty"`
+	DeflateOnOom          bool                   `protobuf:"varint,2,opt,name=deflate_on_oom,json=deflateOnOom,proto3" json:"deflate_on_oom,omitempty"`
+	StatsPollingIntervalS uint32                 `protobuf:"varint,3,opt,name=stats_polling_interval_s,json=statsPollingIntervalS,proto3" json:"stats_polling_interval_s,omitempty"`
+	FreePageHinting       bool                   `protobuf:"varint,4,opt,name=free_page_hinting,json=freePageHinting,proto3" json:"free_page_hinting,omitempty"`
+	FreePageReporting     bool                   `protobuf:"varint,5,opt,name=free_page_reporting,json=freePageReporting,proto3" json:"free_page_reporting,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *BalloonSpec) Reset() {
+	*x = BalloonSpec{}
+	mi := &file_novitabox_v1_types_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BalloonSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BalloonSpec) ProtoMessage() {}
+
+func (x *BalloonSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_types_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BalloonSpec.ProtoReflect.Descriptor instead.
+func (*BalloonSpec) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *BalloonSpec) GetAmountMib() uint32 {
+	if x != nil {
+		return x.AmountMib
+	}
+	return 0
+}
+
+func (x *BalloonSpec) GetDeflateOnOom() bool {
+	if x != nil {
+		return x.DeflateOnOom
+	}
+	return false
+}
+
+func (x *BalloonSpec) GetStatsPollingIntervalS() uint32 {
+	if x != nil {
+		return x.StatsPollingIntervalS
+	}
+	return 0
+}
+
+func (x *BalloonSpec) GetFreePageHinting() bool {
+	if x != nil {
+		return x.FreePageHinting
+	}
+	return false
+}
+
+func (x *BalloonSpec) GetFreePageReporting() bool {
+	if x != nil {
+		return x.FreePageReporting
+	}
+	return false
+}
+
+type BalloonConfig struct {
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	AmountMib             uint32                 `protobuf:"varint,1,opt,name=amount_mib,json=amountMib,proto3" json:"amount_mib,omitempty"`
+	DeflateOnOom          bool                   `protobuf:"varint,2,opt,name=deflate_on_oom,json=deflateOnOom,proto3" json:"deflate_on_oom,omitempty"`
+	StatsPollingIntervalS uint32                 `protobuf:"varint,3,opt,name=stats_polling_interval_s,json=statsPollingIntervalS,proto3" json:"stats_polling_interval_s,omitempty"`
+	FreePageHinting       bool                   `protobuf:"varint,4,opt,name=free_page_hinting,json=freePageHinting,proto3" json:"free_page_hinting,omitempty"`
+	FreePageReporting     bool                   `protobuf:"varint,5,opt,name=free_page_reporting,json=freePageReporting,proto3" json:"free_page_reporting,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *BalloonConfig) Reset() {
+	*x = BalloonConfig{}
+	mi := &file_novitabox_v1_types_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BalloonConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BalloonConfig) ProtoMessage() {}
+
+func (x *BalloonConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_types_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BalloonConfig.ProtoReflect.Descriptor instead.
+func (*BalloonConfig) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *BalloonConfig) GetAmountMib() uint32 {
+	if x != nil {
+		return x.AmountMib
+	}
+	return 0
+}
+
+func (x *BalloonConfig) GetDeflateOnOom() bool {
+	if x != nil {
+		return x.DeflateOnOom
+	}
+	return false
+}
+
+func (x *BalloonConfig) GetStatsPollingIntervalS() uint32 {
+	if x != nil {
+		return x.StatsPollingIntervalS
+	}
+	return 0
+}
+
+func (x *BalloonConfig) GetFreePageHinting() bool {
+	if x != nil {
+		return x.FreePageHinting
+	}
+	return false
+}
+
+func (x *BalloonConfig) GetFreePageReporting() bool {
+	if x != nil {
+		return x.FreePageReporting
+	}
+	return false
+}
+
+type BalloonStats struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	TargetMib          uint32                 `protobuf:"varint,1,opt,name=target_mib,json=targetMib,proto3" json:"target_mib,omitempty"`
+	ActualMib          uint32                 `protobuf:"varint,2,opt,name=actual_mib,json=actualMib,proto3" json:"actual_mib,omitempty"`
+	SwapIn             uint64                 `protobuf:"varint,3,opt,name=swap_in,json=swapIn,proto3" json:"swap_in,omitempty"`
+	SwapOut            uint64                 `protobuf:"varint,4,opt,name=swap_out,json=swapOut,proto3" json:"swap_out,omitempty"`
+	MajorFaults        uint64                 `protobuf:"varint,5,opt,name=major_faults,json=majorFaults,proto3" json:"major_faults,omitempty"`
+	MinorFaults        uint64                 `protobuf:"varint,6,opt,name=minor_faults,json=minorFaults,proto3" json:"minor_faults,omitempty"`
+	FreeMemory         uint64                 `protobuf:"varint,7,opt,name=free_memory,json=freeMemory,proto3" json:"free_memory,omitempty"`
+	TotalMemory        uint64                 `protobuf:"varint,8,opt,name=total_memory,json=totalMemory,proto3" json:"total_memory,omitempty"`
+	AvailableMemory    uint64                 `protobuf:"varint,9,opt,name=available_memory,json=availableMemory,proto3" json:"available_memory,omitempty"`
+	DiskCaches         uint64                 `protobuf:"varint,10,opt,name=disk_caches,json=diskCaches,proto3" json:"disk_caches,omitempty"`
+	HugetlbAllocations uint64                 `protobuf:"varint,11,opt,name=hugetlb_allocations,json=hugetlbAllocations,proto3" json:"hugetlb_allocations,omitempty"`
+	HugetlbFailures    uint64                 `protobuf:"varint,12,opt,name=hugetlb_failures,json=hugetlbFailures,proto3" json:"hugetlb_failures,omitempty"`
+	SharedMemory       uint64                 `protobuf:"varint,13,opt,name=shared_memory,json=sharedMemory,proto3" json:"shared_memory,omitempty"`
+	UnevictableMemory  uint64                 `protobuf:"varint,14,opt,name=unevictable_memory,json=unevictableMemory,proto3" json:"unevictable_memory,omitempty"`
+	OomKill            uint64                 `protobuf:"varint,15,opt,name=oom_kill,json=oomKill,proto3" json:"oom_kill,omitempty"`
+	AllocStall         uint64                 `protobuf:"varint,16,opt,name=alloc_stall,json=allocStall,proto3" json:"alloc_stall,omitempty"`
+	AsyncScan          uint64                 `protobuf:"varint,17,opt,name=async_scan,json=asyncScan,proto3" json:"async_scan,omitempty"`
+	DirectScan         uint64                 `protobuf:"varint,18,opt,name=direct_scan,json=directScan,proto3" json:"direct_scan,omitempty"`
+	AsyncReclaim       uint64                 `protobuf:"varint,19,opt,name=async_reclaim,json=asyncReclaim,proto3" json:"async_reclaim,omitempty"`
+	DirectReclaim      uint64                 `protobuf:"varint,20,opt,name=direct_reclaim,json=directReclaim,proto3" json:"direct_reclaim,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *BalloonStats) Reset() {
+	*x = BalloonStats{}
+	mi := &file_novitabox_v1_types_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BalloonStats) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BalloonStats) ProtoMessage() {}
+
+func (x *BalloonStats) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_types_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BalloonStats.ProtoReflect.Descriptor instead.
+func (*BalloonStats) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *BalloonStats) GetTargetMib() uint32 {
+	if x != nil {
+		return x.TargetMib
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetActualMib() uint32 {
+	if x != nil {
+		return x.ActualMib
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetSwapIn() uint64 {
+	if x != nil {
+		return x.SwapIn
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetSwapOut() uint64 {
+	if x != nil {
+		return x.SwapOut
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetMajorFaults() uint64 {
+	if x != nil {
+		return x.MajorFaults
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetMinorFaults() uint64 {
+	if x != nil {
+		return x.MinorFaults
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetFreeMemory() uint64 {
+	if x != nil {
+		return x.FreeMemory
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetTotalMemory() uint64 {
+	if x != nil {
+		return x.TotalMemory
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetAvailableMemory() uint64 {
+	if x != nil {
+		return x.AvailableMemory
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetDiskCaches() uint64 {
+	if x != nil {
+		return x.DiskCaches
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetHugetlbAllocations() uint64 {
+	if x != nil {
+		return x.HugetlbAllocations
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetHugetlbFailures() uint64 {
+	if x != nil {
+		return x.HugetlbFailures
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetSharedMemory() uint64 {
+	if x != nil {
+		return x.SharedMemory
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetUnevictableMemory() uint64 {
+	if x != nil {
+		return x.UnevictableMemory
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetOomKill() uint64 {
+	if x != nil {
+		return x.OomKill
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetAllocStall() uint64 {
+	if x != nil {
+		return x.AllocStall
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetAsyncScan() uint64 {
+	if x != nil {
+		return x.AsyncScan
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetDirectScan() uint64 {
+	if x != nil {
+		return x.DirectScan
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetAsyncReclaim() uint64 {
+	if x != nil {
+		return x.AsyncReclaim
+	}
+	return 0
+}
+
+func (x *BalloonStats) GetDirectReclaim() uint64 {
+	if x != nil {
+		return x.DirectReclaim
+	}
+	return 0
+}
+
+type BalloonHintingStatus struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	State         string                 `protobuf:"bytes,1,opt,name=state,proto3" json:"state,omitempty"`
+	HostCmd       uint32                 `protobuf:"varint,3,opt,name=host_cmd,json=hostCmd,proto3" json:"host_cmd,omitempty"`
+	GuestCmd      *uint32                `protobuf:"varint,4,opt,name=guest_cmd,json=guestCmd,proto3,oneof" json:"guest_cmd,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BalloonHintingStatus) Reset() {
+	*x = BalloonHintingStatus{}
+	mi := &file_novitabox_v1_types_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BalloonHintingStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BalloonHintingStatus) ProtoMessage() {}
+
+func (x *BalloonHintingStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_novitabox_v1_types_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BalloonHintingStatus.ProtoReflect.Descriptor instead.
+func (*BalloonHintingStatus) Descriptor() ([]byte, []int) {
+	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *BalloonHintingStatus) GetState() string {
+	if x != nil {
+		return x.State
+	}
+	return ""
+}
+
+func (x *BalloonHintingStatus) GetHostCmd() uint32 {
+	if x != nil {
+		return x.HostCmd
+	}
+	return 0
+}
+
+func (x *BalloonHintingStatus) GetGuestCmd() uint32 {
+	if x != nil && x.GuestCmd != nil {
+		return *x.GuestCmd
+	}
+	return 0
+}
+
 type KernelSpec struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	KernelPath    string                 `protobuf:"bytes,1,opt,name=kernel_path,json=kernelPath,proto3" json:"kernel_path,omitempty"`
@@ -658,7 +1066,7 @@ type KernelSpec struct {
 
 func (x *KernelSpec) Reset() {
 	*x = KernelSpec{}
-	mi := &file_novitabox_v1_types_proto_msgTypes[5]
+	mi := &file_novitabox_v1_types_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -670,7 +1078,7 @@ func (x *KernelSpec) String() string {
 func (*KernelSpec) ProtoMessage() {}
 
 func (x *KernelSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_types_proto_msgTypes[5]
+	mi := &file_novitabox_v1_types_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -683,7 +1091,7 @@ func (x *KernelSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KernelSpec.ProtoReflect.Descriptor instead.
 func (*KernelSpec) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{5}
+	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *KernelSpec) GetKernelPath() string {
@@ -718,7 +1126,7 @@ type RootfsSpec struct {
 
 func (x *RootfsSpec) Reset() {
 	*x = RootfsSpec{}
-	mi := &file_novitabox_v1_types_proto_msgTypes[6]
+	mi := &file_novitabox_v1_types_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -730,7 +1138,7 @@ func (x *RootfsSpec) String() string {
 func (*RootfsSpec) ProtoMessage() {}
 
 func (x *RootfsSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_types_proto_msgTypes[6]
+	mi := &file_novitabox_v1_types_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -743,7 +1151,7 @@ func (x *RootfsSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RootfsSpec.ProtoReflect.Descriptor instead.
 func (*RootfsSpec) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{6}
+	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *RootfsSpec) GetPath() string {
@@ -779,7 +1187,7 @@ type DriveSpec struct {
 
 func (x *DriveSpec) Reset() {
 	*x = DriveSpec{}
-	mi := &file_novitabox_v1_types_proto_msgTypes[7]
+	mi := &file_novitabox_v1_types_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -791,7 +1199,7 @@ func (x *DriveSpec) String() string {
 func (*DriveSpec) ProtoMessage() {}
 
 func (x *DriveSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_types_proto_msgTypes[7]
+	mi := &file_novitabox_v1_types_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -804,7 +1212,7 @@ func (x *DriveSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DriveSpec.ProtoReflect.Descriptor instead.
 func (*DriveSpec) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{7}
+	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *DriveSpec) GetDriveId() string {
@@ -846,7 +1254,7 @@ type SnapshotSpec struct {
 
 func (x *SnapshotSpec) Reset() {
 	*x = SnapshotSpec{}
-	mi := &file_novitabox_v1_types_proto_msgTypes[8]
+	mi := &file_novitabox_v1_types_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -858,7 +1266,7 @@ func (x *SnapshotSpec) String() string {
 func (*SnapshotSpec) ProtoMessage() {}
 
 func (x *SnapshotSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_types_proto_msgTypes[8]
+	mi := &file_novitabox_v1_types_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -871,7 +1279,7 @@ func (x *SnapshotSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SnapshotSpec.ProtoReflect.Descriptor instead.
 func (*SnapshotSpec) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{8}
+	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *SnapshotSpec) GetMemfilePath() string {
@@ -910,7 +1318,7 @@ type NetworkSpec struct {
 
 func (x *NetworkSpec) Reset() {
 	*x = NetworkSpec{}
-	mi := &file_novitabox_v1_types_proto_msgTypes[9]
+	mi := &file_novitabox_v1_types_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -922,7 +1330,7 @@ func (x *NetworkSpec) String() string {
 func (*NetworkSpec) ProtoMessage() {}
 
 func (x *NetworkSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_types_proto_msgTypes[9]
+	mi := &file_novitabox_v1_types_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -935,7 +1343,7 @@ func (x *NetworkSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkSpec.ProtoReflect.Descriptor instead.
 func (*NetworkSpec) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{9}
+	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *NetworkSpec) GetNamespaceName() string {
@@ -999,7 +1407,7 @@ type AgentSpec struct {
 
 func (x *AgentSpec) Reset() {
 	*x = AgentSpec{}
-	mi := &file_novitabox_v1_types_proto_msgTypes[10]
+	mi := &file_novitabox_v1_types_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1011,7 +1419,7 @@ func (x *AgentSpec) String() string {
 func (*AgentSpec) ProtoMessage() {}
 
 func (x *AgentSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_types_proto_msgTypes[10]
+	mi := &file_novitabox_v1_types_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1024,7 +1432,7 @@ func (x *AgentSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentSpec.ProtoReflect.Descriptor instead.
 func (*AgentSpec) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{10}
+	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *AgentSpec) GetType() string {
@@ -1069,7 +1477,7 @@ type JailerSpec struct {
 
 func (x *JailerSpec) Reset() {
 	*x = JailerSpec{}
-	mi := &file_novitabox_v1_types_proto_msgTypes[11]
+	mi := &file_novitabox_v1_types_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1081,7 +1489,7 @@ func (x *JailerSpec) String() string {
 func (*JailerSpec) ProtoMessage() {}
 
 func (x *JailerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_types_proto_msgTypes[11]
+	mi := &file_novitabox_v1_types_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1094,7 +1502,7 @@ func (x *JailerSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JailerSpec.ProtoReflect.Descriptor instead.
 func (*JailerSpec) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{11}
+	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *JailerSpec) GetEnabled() bool {
@@ -1151,6 +1559,7 @@ type RuntimeSpec struct {
 	Agent         *AgentSpec             `protobuf:"bytes,8,opt,name=agent,proto3" json:"agent,omitempty"`
 	Jailer        *JailerSpec            `protobuf:"bytes,9,opt,name=jailer,proto3" json:"jailer,omitempty"`
 	ExtraDrives   []*DriveSpec           `protobuf:"bytes,10,rep,name=extra_drives,json=extraDrives,proto3" json:"extra_drives,omitempty"`
+	Balloon       *BalloonSpec           `protobuf:"bytes,11,opt,name=balloon,proto3" json:"balloon,omitempty"`
 	Labels        map[string]string      `protobuf:"bytes,20,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Annotations   map[string]string      `protobuf:"bytes,21,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
@@ -1159,7 +1568,7 @@ type RuntimeSpec struct {
 
 func (x *RuntimeSpec) Reset() {
 	*x = RuntimeSpec{}
-	mi := &file_novitabox_v1_types_proto_msgTypes[12]
+	mi := &file_novitabox_v1_types_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1171,7 +1580,7 @@ func (x *RuntimeSpec) String() string {
 func (*RuntimeSpec) ProtoMessage() {}
 
 func (x *RuntimeSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_types_proto_msgTypes[12]
+	mi := &file_novitabox_v1_types_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1184,7 +1593,7 @@ func (x *RuntimeSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuntimeSpec.ProtoReflect.Descriptor instead.
 func (*RuntimeSpec) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{12}
+	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *RuntimeSpec) GetSandboxId() string {
@@ -1257,6 +1666,13 @@ func (x *RuntimeSpec) GetExtraDrives() []*DriveSpec {
 	return nil
 }
 
+func (x *RuntimeSpec) GetBalloon() *BalloonSpec {
+	if x != nil {
+		return x.Balloon
+	}
+	return nil
+}
+
 func (x *RuntimeSpec) GetLabels() map[string]string {
 	if x != nil {
 		return x.Labels
@@ -1286,7 +1702,7 @@ type RuntimeInfo struct {
 
 func (x *RuntimeInfo) Reset() {
 	*x = RuntimeInfo{}
-	mi := &file_novitabox_v1_types_proto_msgTypes[13]
+	mi := &file_novitabox_v1_types_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1298,7 +1714,7 @@ func (x *RuntimeInfo) String() string {
 func (*RuntimeInfo) ProtoMessage() {}
 
 func (x *RuntimeInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_types_proto_msgTypes[13]
+	mi := &file_novitabox_v1_types_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1311,7 +1727,7 @@ func (x *RuntimeInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuntimeInfo.ProtoReflect.Descriptor instead.
 func (*RuntimeInfo) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{13}
+	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *RuntimeInfo) GetSandboxId() string {
@@ -1379,6 +1795,7 @@ type RuntimeCapabilities struct {
 	HotplugNetwork    bool                   `protobuf:"varint,24,opt,name=hotplug_network,json=hotplugNetwork,proto3" json:"hotplug_network,omitempty"`
 	LiveResizeCpu     bool                   `protobuf:"varint,25,opt,name=live_resize_cpu,json=liveResizeCpu,proto3" json:"live_resize_cpu,omitempty"`
 	LiveResizeMemory  bool                   `protobuf:"varint,26,opt,name=live_resize_memory,json=liveResizeMemory,proto3" json:"live_resize_memory,omitempty"`
+	Balloon           bool                   `protobuf:"varint,27,opt,name=balloon,proto3" json:"balloon,omitempty"`
 	GracefulShutdown  bool                   `protobuf:"varint,30,opt,name=graceful_shutdown,json=gracefulShutdown,proto3" json:"graceful_shutdown,omitempty"`
 	SerialConsole     bool                   `protobuf:"varint,31,opt,name=serial_console,json=serialConsole,proto3" json:"serial_console,omitempty"`
 	Jailer            bool                   `protobuf:"varint,32,opt,name=jailer,proto3" json:"jailer,omitempty"`
@@ -1388,7 +1805,7 @@ type RuntimeCapabilities struct {
 
 func (x *RuntimeCapabilities) Reset() {
 	*x = RuntimeCapabilities{}
-	mi := &file_novitabox_v1_types_proto_msgTypes[14]
+	mi := &file_novitabox_v1_types_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1400,7 +1817,7 @@ func (x *RuntimeCapabilities) String() string {
 func (*RuntimeCapabilities) ProtoMessage() {}
 
 func (x *RuntimeCapabilities) ProtoReflect() protoreflect.Message {
-	mi := &file_novitabox_v1_types_proto_msgTypes[14]
+	mi := &file_novitabox_v1_types_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1413,7 +1830,7 @@ func (x *RuntimeCapabilities) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuntimeCapabilities.ProtoReflect.Descriptor instead.
 func (*RuntimeCapabilities) Descriptor() ([]byte, []int) {
-	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{14}
+	return file_novitabox_v1_types_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *RuntimeCapabilities) GetStartFromImage() bool {
@@ -1514,6 +1931,13 @@ func (x *RuntimeCapabilities) GetLiveResizeMemory() bool {
 	return false
 }
 
+func (x *RuntimeCapabilities) GetBalloon() bool {
+	if x != nil {
+		return x.Balloon
+	}
+	return false
+}
+
 func (x *RuntimeCapabilities) GetGracefulShutdown() bool {
 	if x != nil {
 		return x.GracefulShutdown
@@ -1599,7 +2023,57 @@ const file_novitabox_v1_types_proto_rawDesc = "" +
 	"\x04vcpu\x18\x01 \x01(\rR\x04vcpu\x12\x1b\n" +
 	"\tmemory_mb\x18\x02 \x01(\rR\bmemoryMb\x12\x1c\n" +
 	"\thugepages\x18\x03 \x01(\bR\thugepages\x12\x10\n" +
-	"\x03gpu\x18\x04 \x01(\rR\x03gpu\"k\n" +
+	"\x03gpu\x18\x04 \x01(\rR\x03gpu\"\xe7\x01\n" +
+	"\vBalloonSpec\x12\x1d\n" +
+	"\n" +
+	"amount_mib\x18\x01 \x01(\rR\tamountMib\x12$\n" +
+	"\x0edeflate_on_oom\x18\x02 \x01(\bR\fdeflateOnOom\x127\n" +
+	"\x18stats_polling_interval_s\x18\x03 \x01(\rR\x15statsPollingIntervalS\x12*\n" +
+	"\x11free_page_hinting\x18\x04 \x01(\bR\x0ffreePageHinting\x12.\n" +
+	"\x13free_page_reporting\x18\x05 \x01(\bR\x11freePageReporting\"\xe9\x01\n" +
+	"\rBalloonConfig\x12\x1d\n" +
+	"\n" +
+	"amount_mib\x18\x01 \x01(\rR\tamountMib\x12$\n" +
+	"\x0edeflate_on_oom\x18\x02 \x01(\bR\fdeflateOnOom\x127\n" +
+	"\x18stats_polling_interval_s\x18\x03 \x01(\rR\x15statsPollingIntervalS\x12*\n" +
+	"\x11free_page_hinting\x18\x04 \x01(\bR\x0ffreePageHinting\x12.\n" +
+	"\x13free_page_reporting\x18\x05 \x01(\bR\x11freePageReporting\"\xce\x05\n" +
+	"\fBalloonStats\x12\x1d\n" +
+	"\n" +
+	"target_mib\x18\x01 \x01(\rR\ttargetMib\x12\x1d\n" +
+	"\n" +
+	"actual_mib\x18\x02 \x01(\rR\tactualMib\x12\x17\n" +
+	"\aswap_in\x18\x03 \x01(\x04R\x06swapIn\x12\x19\n" +
+	"\bswap_out\x18\x04 \x01(\x04R\aswapOut\x12!\n" +
+	"\fmajor_faults\x18\x05 \x01(\x04R\vmajorFaults\x12!\n" +
+	"\fminor_faults\x18\x06 \x01(\x04R\vminorFaults\x12\x1f\n" +
+	"\vfree_memory\x18\a \x01(\x04R\n" +
+	"freeMemory\x12!\n" +
+	"\ftotal_memory\x18\b \x01(\x04R\vtotalMemory\x12)\n" +
+	"\x10available_memory\x18\t \x01(\x04R\x0favailableMemory\x12\x1f\n" +
+	"\vdisk_caches\x18\n" +
+	" \x01(\x04R\n" +
+	"diskCaches\x12/\n" +
+	"\x13hugetlb_allocations\x18\v \x01(\x04R\x12hugetlbAllocations\x12)\n" +
+	"\x10hugetlb_failures\x18\f \x01(\x04R\x0fhugetlbFailures\x12#\n" +
+	"\rshared_memory\x18\r \x01(\x04R\fsharedMemory\x12-\n" +
+	"\x12unevictable_memory\x18\x0e \x01(\x04R\x11unevictableMemory\x12\x19\n" +
+	"\boom_kill\x18\x0f \x01(\x04R\aoomKill\x12\x1f\n" +
+	"\valloc_stall\x18\x10 \x01(\x04R\n" +
+	"allocStall\x12\x1d\n" +
+	"\n" +
+	"async_scan\x18\x11 \x01(\x04R\tasyncScan\x12\x1f\n" +
+	"\vdirect_scan\x18\x12 \x01(\x04R\n" +
+	"directScan\x12#\n" +
+	"\rasync_reclaim\x18\x13 \x01(\x04R\fasyncReclaim\x12%\n" +
+	"\x0edirect_reclaim\x18\x14 \x01(\x04R\rdirectReclaim\"\x89\x01\n" +
+	"\x14BalloonHintingStatus\x12\x14\n" +
+	"\x05state\x18\x01 \x01(\tR\x05state\x12\x19\n" +
+	"\bhost_cmd\x18\x03 \x01(\rR\ahostCmd\x12 \n" +
+	"\tguest_cmd\x18\x04 \x01(\rH\x00R\bguestCmd\x88\x01\x01B\f\n" +
+	"\n" +
+	"_guest_cmdJ\x04\b\x02\x10\x03R\n" +
+	"interval_s\"k\n" +
 	"\n" +
 	"KernelSpec\x12\x1f\n" +
 	"\vkernel_path\x18\x01 \x01(\tR\n" +
@@ -1644,7 +2118,7 @@ const file_novitabox_v1_types_proto_rawDesc = "" +
 	"\x03gid\x18\x04 \x01(\tR\x03gid\x12\x1f\n" +
 	"\vcgroup_path\x18\x05 \x01(\tR\n" +
 	"cgroupPath\x12'\n" +
-	"\x0fseccomp_profile\x18\x06 \x01(\tR\x0eseccompProfile\"\x95\x06\n" +
+	"\x0fseccomp_profile\x18\x06 \x01(\tR\x0eseccompProfile\"\xca\x06\n" +
 	"\vRuntimeSpec\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12<\n" +
@@ -1657,7 +2131,8 @@ const file_novitabox_v1_types_proto_rawDesc = "" +
 	"\x05agent\x18\b \x01(\v2\x17.novitabox.v1.AgentSpecR\x05agent\x120\n" +
 	"\x06jailer\x18\t \x01(\v2\x18.novitabox.v1.JailerSpecR\x06jailer\x12:\n" +
 	"\fextra_drives\x18\n" +
-	" \x03(\v2\x17.novitabox.v1.DriveSpecR\vextraDrives\x12=\n" +
+	" \x03(\v2\x17.novitabox.v1.DriveSpecR\vextraDrives\x123\n" +
+	"\aballoon\x18\v \x01(\v2\x19.novitabox.v1.BalloonSpecR\aballoon\x12=\n" +
 	"\x06labels\x18\x14 \x03(\v2%.novitabox.v1.RuntimeSpec.LabelsEntryR\x06labels\x12L\n" +
 	"\vannotations\x18\x15 \x03(\v2*.novitabox.v1.RuntimeSpec.AnnotationsEntryR\vannotations\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
@@ -1674,7 +2149,7 @@ const file_novitabox_v1_types_proto_rawDesc = "" +
 	"\x03pid\x18\x04 \x01(\x03R\x03pid\x12(\n" +
 	"\x10shim_socket_path\x18\x05 \x01(\tR\x0eshimSocketPath\x12.\n" +
 	"\x13runtime_socket_path\x18\x06 \x01(\tR\x11runtimeSocketPath\x12#\n" +
-	"\rerror_message\x18\a \x01(\tR\ferrorMessage\"\xee\x04\n" +
+	"\rerror_message\x18\a \x01(\tR\ferrorMessage\"\x88\x05\n" +
 	"\x13RuntimeCapabilities\x12(\n" +
 	"\x10start_from_image\x18\x01 \x01(\bR\x0estartFromImage\x12.\n" +
 	"\x13start_from_template\x18\x02 \x01(\bR\x11startFromTemplate\x12.\n" +
@@ -1691,7 +2166,8 @@ const file_novitabox_v1_types_proto_rawDesc = "" +
 	"\fhotplug_disk\x18\x17 \x01(\bR\vhotplugDisk\x12'\n" +
 	"\x0fhotplug_network\x18\x18 \x01(\bR\x0ehotplugNetwork\x12&\n" +
 	"\x0flive_resize_cpu\x18\x19 \x01(\bR\rliveResizeCpu\x12,\n" +
-	"\x12live_resize_memory\x18\x1a \x01(\bR\x10liveResizeMemory\x12+\n" +
+	"\x12live_resize_memory\x18\x1a \x01(\bR\x10liveResizeMemory\x12\x18\n" +
+	"\aballoon\x18\x1b \x01(\bR\aballoon\x12+\n" +
 	"\x11graceful_shutdown\x18\x1e \x01(\bR\x10gracefulShutdown\x12%\n" +
 	"\x0eserial_console\x18\x1f \x01(\bR\rserialConsole\x12\x16\n" +
 	"\x06jailer\x18  \x01(\bR\x06jailer*\x8f\x03\n" +
@@ -1739,60 +2215,65 @@ func file_novitabox_v1_types_proto_rawDescGZIP() []byte {
 }
 
 var file_novitabox_v1_types_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_novitabox_v1_types_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_novitabox_v1_types_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_novitabox_v1_types_proto_goTypes = []any{
-	(SandboxState)(0),           // 0: novitabox.v1.SandboxState
-	(RuntimeType)(0),            // 1: novitabox.v1.RuntimeType
-	(RuntimeState)(0),           // 2: novitabox.v1.RuntimeState
-	(*SandboxInfo)(nil),         // 3: novitabox.v1.SandboxInfo
-	(*SnapshotInfo)(nil),        // 4: novitabox.v1.SnapshotInfo
-	(*TemplateInfo)(nil),        // 5: novitabox.v1.TemplateInfo
-	(*ImageInfo)(nil),           // 6: novitabox.v1.ImageInfo
-	(*MachineSpec)(nil),         // 7: novitabox.v1.MachineSpec
-	(*KernelSpec)(nil),          // 8: novitabox.v1.KernelSpec
-	(*RootfsSpec)(nil),          // 9: novitabox.v1.RootfsSpec
-	(*DriveSpec)(nil),           // 10: novitabox.v1.DriveSpec
-	(*SnapshotSpec)(nil),        // 11: novitabox.v1.SnapshotSpec
-	(*NetworkSpec)(nil),         // 12: novitabox.v1.NetworkSpec
-	(*AgentSpec)(nil),           // 13: novitabox.v1.AgentSpec
-	(*JailerSpec)(nil),          // 14: novitabox.v1.JailerSpec
-	(*RuntimeSpec)(nil),         // 15: novitabox.v1.RuntimeSpec
-	(*RuntimeInfo)(nil),         // 16: novitabox.v1.RuntimeInfo
-	(*RuntimeCapabilities)(nil), // 17: novitabox.v1.RuntimeCapabilities
-	nil,                         // 18: novitabox.v1.SandboxInfo.LabelsEntry
-	nil,                         // 19: novitabox.v1.SandboxInfo.AnnotationsEntry
-	nil,                         // 20: novitabox.v1.SnapshotInfo.LabelsEntry
-	nil,                         // 21: novitabox.v1.TemplateInfo.LabelsEntry
-	nil,                         // 22: novitabox.v1.ImageInfo.LabelsEntry
-	nil,                         // 23: novitabox.v1.RuntimeSpec.LabelsEntry
-	nil,                         // 24: novitabox.v1.RuntimeSpec.AnnotationsEntry
+	(SandboxState)(0),            // 0: novitabox.v1.SandboxState
+	(RuntimeType)(0),             // 1: novitabox.v1.RuntimeType
+	(RuntimeState)(0),            // 2: novitabox.v1.RuntimeState
+	(*SandboxInfo)(nil),          // 3: novitabox.v1.SandboxInfo
+	(*SnapshotInfo)(nil),         // 4: novitabox.v1.SnapshotInfo
+	(*TemplateInfo)(nil),         // 5: novitabox.v1.TemplateInfo
+	(*ImageInfo)(nil),            // 6: novitabox.v1.ImageInfo
+	(*MachineSpec)(nil),          // 7: novitabox.v1.MachineSpec
+	(*BalloonSpec)(nil),          // 8: novitabox.v1.BalloonSpec
+	(*BalloonConfig)(nil),        // 9: novitabox.v1.BalloonConfig
+	(*BalloonStats)(nil),         // 10: novitabox.v1.BalloonStats
+	(*BalloonHintingStatus)(nil), // 11: novitabox.v1.BalloonHintingStatus
+	(*KernelSpec)(nil),           // 12: novitabox.v1.KernelSpec
+	(*RootfsSpec)(nil),           // 13: novitabox.v1.RootfsSpec
+	(*DriveSpec)(nil),            // 14: novitabox.v1.DriveSpec
+	(*SnapshotSpec)(nil),         // 15: novitabox.v1.SnapshotSpec
+	(*NetworkSpec)(nil),          // 16: novitabox.v1.NetworkSpec
+	(*AgentSpec)(nil),            // 17: novitabox.v1.AgentSpec
+	(*JailerSpec)(nil),           // 18: novitabox.v1.JailerSpec
+	(*RuntimeSpec)(nil),          // 19: novitabox.v1.RuntimeSpec
+	(*RuntimeInfo)(nil),          // 20: novitabox.v1.RuntimeInfo
+	(*RuntimeCapabilities)(nil),  // 21: novitabox.v1.RuntimeCapabilities
+	nil,                          // 22: novitabox.v1.SandboxInfo.LabelsEntry
+	nil,                          // 23: novitabox.v1.SandboxInfo.AnnotationsEntry
+	nil,                          // 24: novitabox.v1.SnapshotInfo.LabelsEntry
+	nil,                          // 25: novitabox.v1.TemplateInfo.LabelsEntry
+	nil,                          // 26: novitabox.v1.ImageInfo.LabelsEntry
+	nil,                          // 27: novitabox.v1.RuntimeSpec.LabelsEntry
+	nil,                          // 28: novitabox.v1.RuntimeSpec.AnnotationsEntry
 }
 var file_novitabox_v1_types_proto_depIdxs = []int32{
 	0,  // 0: novitabox.v1.SandboxInfo.state:type_name -> novitabox.v1.SandboxState
 	1,  // 1: novitabox.v1.SandboxInfo.runtime_type:type_name -> novitabox.v1.RuntimeType
-	18, // 2: novitabox.v1.SandboxInfo.labels:type_name -> novitabox.v1.SandboxInfo.LabelsEntry
-	19, // 3: novitabox.v1.SandboxInfo.annotations:type_name -> novitabox.v1.SandboxInfo.AnnotationsEntry
-	20, // 4: novitabox.v1.SnapshotInfo.labels:type_name -> novitabox.v1.SnapshotInfo.LabelsEntry
-	21, // 5: novitabox.v1.TemplateInfo.labels:type_name -> novitabox.v1.TemplateInfo.LabelsEntry
-	22, // 6: novitabox.v1.ImageInfo.labels:type_name -> novitabox.v1.ImageInfo.LabelsEntry
+	22, // 2: novitabox.v1.SandboxInfo.labels:type_name -> novitabox.v1.SandboxInfo.LabelsEntry
+	23, // 3: novitabox.v1.SandboxInfo.annotations:type_name -> novitabox.v1.SandboxInfo.AnnotationsEntry
+	24, // 4: novitabox.v1.SnapshotInfo.labels:type_name -> novitabox.v1.SnapshotInfo.LabelsEntry
+	25, // 5: novitabox.v1.TemplateInfo.labels:type_name -> novitabox.v1.TemplateInfo.LabelsEntry
+	26, // 6: novitabox.v1.ImageInfo.labels:type_name -> novitabox.v1.ImageInfo.LabelsEntry
 	1,  // 7: novitabox.v1.RuntimeSpec.runtime_type:type_name -> novitabox.v1.RuntimeType
 	7,  // 8: novitabox.v1.RuntimeSpec.machine:type_name -> novitabox.v1.MachineSpec
-	8,  // 9: novitabox.v1.RuntimeSpec.kernel:type_name -> novitabox.v1.KernelSpec
-	9,  // 10: novitabox.v1.RuntimeSpec.rootfs:type_name -> novitabox.v1.RootfsSpec
-	11, // 11: novitabox.v1.RuntimeSpec.snapshot:type_name -> novitabox.v1.SnapshotSpec
-	12, // 12: novitabox.v1.RuntimeSpec.network:type_name -> novitabox.v1.NetworkSpec
-	13, // 13: novitabox.v1.RuntimeSpec.agent:type_name -> novitabox.v1.AgentSpec
-	14, // 14: novitabox.v1.RuntimeSpec.jailer:type_name -> novitabox.v1.JailerSpec
-	10, // 15: novitabox.v1.RuntimeSpec.extra_drives:type_name -> novitabox.v1.DriveSpec
-	23, // 16: novitabox.v1.RuntimeSpec.labels:type_name -> novitabox.v1.RuntimeSpec.LabelsEntry
-	24, // 17: novitabox.v1.RuntimeSpec.annotations:type_name -> novitabox.v1.RuntimeSpec.AnnotationsEntry
-	1,  // 18: novitabox.v1.RuntimeInfo.runtime_type:type_name -> novitabox.v1.RuntimeType
-	2,  // 19: novitabox.v1.RuntimeInfo.state:type_name -> novitabox.v1.RuntimeState
-	20, // [20:20] is the sub-list for method output_type
-	20, // [20:20] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	12, // 9: novitabox.v1.RuntimeSpec.kernel:type_name -> novitabox.v1.KernelSpec
+	13, // 10: novitabox.v1.RuntimeSpec.rootfs:type_name -> novitabox.v1.RootfsSpec
+	15, // 11: novitabox.v1.RuntimeSpec.snapshot:type_name -> novitabox.v1.SnapshotSpec
+	16, // 12: novitabox.v1.RuntimeSpec.network:type_name -> novitabox.v1.NetworkSpec
+	17, // 13: novitabox.v1.RuntimeSpec.agent:type_name -> novitabox.v1.AgentSpec
+	18, // 14: novitabox.v1.RuntimeSpec.jailer:type_name -> novitabox.v1.JailerSpec
+	14, // 15: novitabox.v1.RuntimeSpec.extra_drives:type_name -> novitabox.v1.DriveSpec
+	8,  // 16: novitabox.v1.RuntimeSpec.balloon:type_name -> novitabox.v1.BalloonSpec
+	27, // 17: novitabox.v1.RuntimeSpec.labels:type_name -> novitabox.v1.RuntimeSpec.LabelsEntry
+	28, // 18: novitabox.v1.RuntimeSpec.annotations:type_name -> novitabox.v1.RuntimeSpec.AnnotationsEntry
+	1,  // 19: novitabox.v1.RuntimeInfo.runtime_type:type_name -> novitabox.v1.RuntimeType
+	2,  // 20: novitabox.v1.RuntimeInfo.state:type_name -> novitabox.v1.RuntimeState
+	21, // [21:21] is the sub-list for method output_type
+	21, // [21:21] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_novitabox_v1_types_proto_init() }
@@ -1800,13 +2281,14 @@ func file_novitabox_v1_types_proto_init() {
 	if File_novitabox_v1_types_proto != nil {
 		return
 	}
+	file_novitabox_v1_types_proto_msgTypes[8].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_novitabox_v1_types_proto_rawDesc), len(file_novitabox_v1_types_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   22,
+			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/novitabox/v1/boxlet.proto
+++ b/proto/novitabox/v1/boxlet.proto
@@ -17,6 +17,13 @@ service BoxletSandboxService {
   rpc RebootSandbox(RebootSandboxRequest) returns (SandboxInfo);
   rpc GetSandbox(GetSandboxRequest) returns (SandboxInfo);
   rpc ListSandboxes(ListSandboxesRequest) returns (ListSandboxesResponse);
+  rpc UpdateSandboxBalloon(UpdateSandboxBalloonRequest) returns (BalloonConfig);
+  rpc GetSandboxBalloon(GetSandboxBalloonRequest) returns (BalloonConfig);
+  rpc GetSandboxBalloonStats(GetSandboxBalloonStatsRequest) returns (BalloonStats);
+  rpc UpdateSandboxBalloonStats(UpdateSandboxBalloonStatsRequest) returns (BalloonConfig);
+  rpc StartSandboxBalloonHinting(StartSandboxBalloonHintingRequest) returns (BalloonHintingStatus);
+  rpc StopSandboxBalloonHinting(StopSandboxBalloonHintingRequest) returns (BalloonHintingStatus);
+  rpc GetSandboxBalloonHinting(GetSandboxBalloonHintingRequest) returns (BalloonHintingStatus);
 }
 
 service BoxletArtifactService {
@@ -83,6 +90,39 @@ message ListSandboxesRequest {
 
 message ListSandboxesResponse {
   repeated SandboxInfo sandboxes = 1;
+}
+
+message UpdateSandboxBalloonRequest {
+  string sandbox_id = 1;
+  uint32 amount_mib = 2;
+}
+
+message GetSandboxBalloonRequest {
+  string sandbox_id = 1;
+}
+
+message GetSandboxBalloonStatsRequest {
+  string sandbox_id = 1;
+}
+
+message UpdateSandboxBalloonStatsRequest {
+  string sandbox_id = 1;
+  uint32 stats_polling_interval_s = 2;
+}
+
+message StartSandboxBalloonHintingRequest {
+  string sandbox_id = 1;
+  reserved 2;
+  reserved "interval_s";
+  bool acknowledge_on_stop = 3;
+}
+
+message StopSandboxBalloonHintingRequest {
+  string sandbox_id = 1;
+}
+
+message GetSandboxBalloonHintingRequest {
+  string sandbox_id = 1;
 }
 
 message CreateTemplateRequest {

--- a/proto/novitabox/v1/boxshim.proto
+++ b/proto/novitabox/v1/boxshim.proto
@@ -17,6 +17,13 @@ service BoxShim {
   rpc RebootRuntime(RebootRuntimeRequest) returns (RuntimeInfo);
   rpc Status(StatusRequest) returns (RuntimeInfo);
   rpc Capabilities(CapabilitiesRequest) returns (RuntimeCapabilities);
+  rpc UpdateBalloon(UpdateBalloonRequest) returns (BalloonConfig);
+  rpc GetBalloon(GetBalloonRequest) returns (BalloonConfig);
+  rpc GetBalloonStats(GetBalloonStatsRequest) returns (BalloonStats);
+  rpc UpdateBalloonStats(UpdateBalloonStatsRequest) returns (BalloonConfig);
+  rpc StartBalloonHinting(StartBalloonHintingRequest) returns (BalloonHintingStatus);
+  rpc StopBalloonHinting(StopBalloonHintingRequest) returns (BalloonHintingStatus);
+  rpc GetBalloonHinting(GetBalloonHintingRequest) returns (BalloonHintingStatus);
 }
 
 message CreateRuntimeRequest {
@@ -55,4 +62,37 @@ message StatusRequest {
 
 message CapabilitiesRequest {
   RuntimeType runtime_type = 1;
+}
+
+message UpdateBalloonRequest {
+  string sandbox_id = 1;
+  uint32 amount_mib = 2;
+}
+
+message GetBalloonRequest {
+  string sandbox_id = 1;
+}
+
+message GetBalloonStatsRequest {
+  string sandbox_id = 1;
+}
+
+message UpdateBalloonStatsRequest {
+  string sandbox_id = 1;
+  uint32 stats_polling_interval_s = 2;
+}
+
+message StartBalloonHintingRequest {
+  string sandbox_id = 1;
+  reserved 2;
+  reserved "interval_s";
+  bool acknowledge_on_stop = 3;
+}
+
+message StopBalloonHintingRequest {
+  string sandbox_id = 1;
+}
+
+message GetBalloonHintingRequest {
+  string sandbox_id = 1;
 }

--- a/proto/novitabox/v1/types.proto
+++ b/proto/novitabox/v1/types.proto
@@ -85,6 +85,53 @@ message MachineSpec {
   uint32 gpu = 4;
 }
 
+message BalloonSpec {
+  uint32 amount_mib = 1;
+  bool deflate_on_oom = 2;
+  uint32 stats_polling_interval_s = 3;
+  bool free_page_hinting = 4;
+  bool free_page_reporting = 5;
+}
+
+message BalloonConfig {
+  uint32 amount_mib = 1;
+  bool deflate_on_oom = 2;
+  uint32 stats_polling_interval_s = 3;
+  bool free_page_hinting = 4;
+  bool free_page_reporting = 5;
+}
+
+message BalloonStats {
+  uint32 target_mib = 1;
+  uint32 actual_mib = 2;
+  uint64 swap_in = 3;
+  uint64 swap_out = 4;
+  uint64 major_faults = 5;
+  uint64 minor_faults = 6;
+  uint64 free_memory = 7;
+  uint64 total_memory = 8;
+  uint64 available_memory = 9;
+  uint64 disk_caches = 10;
+  uint64 hugetlb_allocations = 11;
+  uint64 hugetlb_failures = 12;
+  uint64 shared_memory = 13;
+  uint64 unevictable_memory = 14;
+  uint64 oom_kill = 15;
+  uint64 alloc_stall = 16;
+  uint64 async_scan = 17;
+  uint64 direct_scan = 18;
+  uint64 async_reclaim = 19;
+  uint64 direct_reclaim = 20;
+}
+
+message BalloonHintingStatus {
+  string state = 1;
+  reserved 2;
+  reserved "interval_s";
+  uint32 host_cmd = 3;
+  optional uint32 guest_cmd = 4;
+}
+
 message KernelSpec {
   string kernel_path = 1;
   string init_path = 2;
@@ -147,6 +194,7 @@ message RuntimeSpec {
   AgentSpec agent = 8;
   JailerSpec jailer = 9;
   repeated DriveSpec extra_drives = 10;
+  BalloonSpec balloon = 11;
   map<string, string> labels = 20;
   map<string, string> annotations = 21;
 }
@@ -176,6 +224,7 @@ message RuntimeCapabilities {
   bool hotplug_network = 24;
   bool live_resize_cpu = 25;
   bool live_resize_memory = 26;
+  bool balloon = 27;
   bool graceful_shutdown = 30;
   bool serial_console = 31;
   bool jailer = 32;


### PR DESCRIPTION
  - add balloon configuration, statistics, and free-page hinting APIs
  - wire balloon RPCs through boxapi, boxlet, boxshim, and boxctl
  - configure Firecracker metrics and virtio-balloon defaults
  - report balloon capability and reject unsupported runtimes
  - add Firecracker balloon tests and API/CLI documentation