### PR TITLE
feat: add Firecracker balloon support and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ Install the latest release components without building from source:
 **Linux**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | RELEASE_VERSION=v0.0.2 sudo -E bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | RELEASE_VERSION=<release-version> sudo -E bash
 ```
 
 **macOS with Lima**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | RELEASE_VERSION=v0.0.2 bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | RELEASE_VERSION=<release-version> bash
 ```
 
 The release installer detects your operating system and CPU architecture, downloads the matching prebuilt components,
@@ -61,7 +61,7 @@ Linux installs configure local DNS and HTTPS proxy by default. On macOS, enable 
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | \
-  RELEASE_VERSION=v0.0.2 ENABLE_MAC_DNS=1 ENABLE_MAC_PROXY=1 bash
+  RELEASE_VERSION=<release-version> ENABLE_MAC_DNS=1 ENABLE_MAC_PROXY=1 bash
 ```
 
 After installation:
@@ -175,12 +175,12 @@ sudo systemctl restart caddy
 Build a gVisor template:
 
 ```bash
-/data/novitabox/boxctl \
-  --api http://127.0.0.1:8080 \
-  template build cuda-template \
-  --runtime gvisor \
-  --from-image nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubi8
+curl -sS -X POST http://127.0.0.1:8080/v3/templates \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"cuda-template","runtimeType":"gvisor"}'
 ```
+
+Use the returned `templateID` and `buildID` with the v2 template build endpoint. The current `boxctl template build` command has no `--runtime` flag and therefore uses the API default, Firecracker.
 
 #### Launch a sandbox
 
@@ -331,8 +331,8 @@ belongs to a running sandbox.
 - **API:** [HTTP API](docs/api/http.md), [Internal RPC](docs/api/RPC.md)
 - **Architecture:** [Overview](docs/architecture/overview.md), [Components](docs/architecture/components.md), [RuntimeSpec](docs/architecture/runtime.md), [Artifact Model](docs/architecture/artifact.md), [Network](docs/architecture/network.md), [Sandbox Lifecycle](docs/architecture/lifecycle.md), [File Layout](docs/architecture/file-layout.md), [Security Model](docs/architecture/security.md)
 - **CLI reference:** [Template](docs/cli/template.md), [Sandbox](docs/cli/sandbox.md), [Image](docs/cli/image.md), [Runtime and snapshot](docs/cli/others.md)
-- **Changelog:** [v0.0.3](docs/changelog/v0.0.3.md), [v0.0.1](docs/changelog/v0.0.1.md)
-- **Chinese docs:** [使用手册](docs/zh/usage.md), [Architecture overview](docs/zh/architecture/overview.md), [v0.0.3 changelog](docs/zh/changelog/v0.0.3.md), [v0.0.1 changelog](docs/zh/changelog/v0.0.1.md)
+- **Changelog:** [Unreleased](docs/changelog/unreleased.md), [v0.0.3](docs/changelog/v0.0.3.md), [v0.0.1](docs/changelog/v0.0.1.md)
+- **Chinese docs:** [文档首页](docs/zh/README.md), [使用手册](docs/zh/usage.md), [HTTP API](docs/zh/api/http.md), [CLI](docs/zh/cli/README.md), [架构概览](docs/zh/architecture/overview.md), [故障排查](docs/zh/troubleshooting.md), [未发布变更](docs/zh/changelog/unreleased.md)
 
 ---
 

--- a/docs/api/RPC.md
+++ b/docs/api/RPC.md
@@ -55,7 +55,7 @@ service BoxletNodeService {
 }
 ```
 
-`ListRuntimes` and `GetRuntimeCapabilities` report Firecracker, gVisor, and Cloud Hypervisor capabilities. Clients should check capabilities before assuming pause/resume, snapshot, GPU, or networking behavior.
+`ListRuntimes` and `GetRuntimeCapabilities` report Firecracker, gVisor, and Cloud Hypervisor capabilities. Clients should check capabilities before assuming pause/resume, snapshot, GPU, networking, or balloon behavior. The Firecracker boxshim supports balloon operations; the boxlet's static capability response still needs to synchronize the `balloon` field.
 
 ### BoxShim Service
 

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -97,7 +97,7 @@ Create from an image:
 ```bash
 curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes \
   -H 'Content-Type: application/json' \
-  -d '{"imageID":"img-xxxxxxxxxxxxxxxxxxxx"}'
+  -d '{"image_id":"img-xxxxxxxxxxxxxxxxxxxx"}'
 ```
 
 List sandboxes:
@@ -163,7 +163,7 @@ curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx/bal
 
 Hinting is a one-shot run, not a periodic task. Its status exposes Firecracker's `hostCmd` and optional `guestCmd`; command `0` is stopped, `1` is completed, and values greater than `1` identify a hinting run.
 
-Balloon endpoints return an unsupported/conflict response for gVisor and other runtimes. The guest kernel must include the virtio-balloon driver for reclamation, statistics, and free-page reporting to have an effect. Statistics include swap, fault, free/available memory, cache, HugeTLB, OOM, allocation stall, scan, and reclaim counters when the guest kernel exposes them.
+Balloon endpoints return an unsupported-runtime error for gVisor and other runtimes. The guest kernel must include the virtio-balloon driver for reclamation, statistics, and free-page reporting to have an effect. Statistics include swap, fault, free/available memory, cache, HugeTLB, OOM, allocation stall, scan, and reclaim counters when the guest kernel exposes them.
 
 Delete:
 

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -34,6 +34,7 @@ Responsibilities:
 
 - parent process of the runtime
 - start, stop, pause, resume, reboot, and kill runtime
+- expose Firecracker balloon configuration, statistics, and free-page hinting
 - expose status and capability RPC
 - survive NovitaBox restart
 - isolate runtime-specific details behind runtime drivers

--- a/docs/architecture/file-layout.md
+++ b/docs/architecture/file-layout.md
@@ -27,6 +27,7 @@ $ROOT/sandboxes/<sandbox_id>/
   shim.pid
   fc.sock
   firecracker.log
+  firecracker-metrics.json
   kernel -> $ROOT/vmlinux.bin
   snapshot/
 

--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -16,6 +16,15 @@ Extended maintenance operations:
 - poweron
 - reboot
 
+Firecracker balloon operations are online maintenance operations while the runtime is running:
+
+- update the balloon target without restarting the VM
+- read balloon statistics
+- change the statistics polling interval
+- start, inspect, and stop one-shot free-page hinting
+
+Balloon operations do not create a new sandbox lifecycle state. They fail if the Firecracker API socket or runtime process is unavailable, and they are not supported by gVisor.
+
 Lifecycle state machine:
 
 ```text

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -25,6 +25,7 @@ RuntimeSpec includes:
 - network configuration
 - agent configuration
 - jailer configuration
+- balloon configuration for runtimes that support virtio-balloon
 - labels and annotations
 
 Runtime-specific details should live in runtime driver options rather than leaking into the upper layers.
@@ -39,6 +40,7 @@ Firecracker is the default MicroVM runtime. It uses:
 - guest kernel
 - `memfile` and `snapfile` for template startup and pause/resume
 - tap networking inside a per-sandbox network namespace
+- virtio-balloon with live target updates, statistics, and free-page hinting/reporting
 
 Firecracker is the runtime to use when full VM snapshot behavior is required.
 
@@ -76,8 +78,11 @@ Each runtime exposes capabilities:
 - hotplug disk
 - live resize CPU
 - live resize memory
+- balloon
 - graceful shutdown
 - serial console
 - jailer
 
-Capabilities allow NovitaBox to degrade API behavior based on the selected runtime. For example, gVisor supports start from image/template and graceful shutdown, but does not currently support Firecracker-style pause/resume snapshots.
+Capabilities allow NovitaBox to degrade API behavior based on the selected runtime. For example, gVisor supports start from image/template and graceful shutdown, but does not currently support Firecracker-style pause/resume snapshots or balloon operations.
+
+The Firecracker boxshim driver reports `balloon=true`. The boxlet's static runtime capability helper still needs to synchronize that field, so the public runtime capability endpoint may temporarily report `balloon=false` even though a running Firecracker sandbox can serve balloon requests through its boxshim.

--- a/docs/changelog/unreleased.md
+++ b/docs/changelog/unreleased.md
@@ -1,0 +1,23 @@
+---
+title: Unreleased changes
+---
+
+# Unreleased Changes
+
+## Firecracker Balloon
+
+- Add `BalloonSpec`, `BalloonConfig`, `BalloonStats`, and `BalloonHintingStatus` to the runtime contract.
+- Configure a virtio-balloon device when Firecracker starts, with a default target of `0 MiB`.
+- Enable deflate-on-OOM, balloon statistics, free-page hinting, and free-page reporting by default.
+- Support live target updates, statistics polling interval updates, and one-shot free-page hinting.
+- Create and configure `firecracker-metrics.json` for runtime metrics.
+- Expose the feature through boxshim RPC, boxlet RPC, HTTP API, and `boxctl`.
+- Return an explicit unsupported-runtime error for gVisor, stub, and unsupported drivers.
+- Add Firecracker API and balloon state tests.
+
+## Known documentation/runtime differences
+
+- The Firecracker boxshim driver reports `balloon=true`.
+- The boxlet static Firecracker capability helper still needs to synchronize that field, so the public runtime capability endpoint may temporarily report `balloon=false` even though a running Firecracker sandbox can serve balloon requests.
+- The current `boxctl template create/build` commands do not expose a `--runtime` flag. Create a gVisor template through `POST /v3/templates` with `runtimeType: "gvisor"`, then start the returned v2 build.
+

--- a/docs/changelog/v0.0.3.md
+++ b/docs/changelog/v0.0.3.md
@@ -12,7 +12,7 @@ Adds gVisor runtime support and NVIDIA GPU support for local sandboxes.
 - Directory-rootfs templates, images, and sandboxes for gVisor.
 - `runtimeType: "gvisor"` template creation support.
 - `runtime_type: "gvisor"` sandbox creation support.
-- `--runtime gvisor` support in `boxctl template build` and `boxctl sandbox create`.
+- `--runtime gvisor` support in `boxctl sandbox create`; template creation supports `runtimeType: "gvisor"` through the native API.
 - `--gpu <count>` support for gVisor sandboxes.
 - NVIDIA GPU injection through runsc `nvproxy` and NVIDIA CDI.
 - NVIDIA driver library path and symlink setup for common CUDA/NVML workloads.

--- a/docs/cli/template.md
+++ b/docs/cli/template.md
@@ -19,7 +19,8 @@ Options:
 - `--template <template_id>`: choose a template id.
 - `--cpu <count>`: template CPU count.
 - `--memory <mb>`: template memory in MB.
-- `--runtime <runtime_type>`: runtime type for the template. Supported values include `firecracker` and `gvisor`.
+
+The current `boxctl template create` command does not expose a `--runtime` flag. It creates a template with the API default runtime, currently Firecracker. To create a gVisor template, create the template through `POST /v3/templates` with `{"runtimeType":"gvisor"}`, then start the build through the v2 build endpoint. See [HTTP API](../api/http.md).
 
 ## Build
 
@@ -48,7 +49,6 @@ Other options:
 - `--template <template_id>`: choose a template id.
 - `--cpu <count>`: template CPU count.
 - `--memory <mb>`: template memory in MB.
-- `--runtime <runtime_type>`: choose the runtime for the template.
 
 Examples:
 
@@ -60,13 +60,7 @@ boxctl template build python-template \
   --exec 'python3 --version'
 ```
 
-Build a gVisor template:
-
-```bash
-boxctl template build cuda-template \
-  --runtime gvisor \
-  --from-image nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubi8
-```
+To build a gVisor template, first create it with `runtimeType: "gvisor"` through the HTTP API, then call the returned v2 build endpoint. `boxctl template build` currently defaults to the API's Firecracker runtime because it has no runtime flag.
 
 Runtime notes:
 

--- a/docs/quick-start/boxctl.md
+++ b/docs/quick-start/boxctl.md
@@ -36,7 +36,7 @@ Build steps:
 - `--exec` splits the value by whitespace and executes it directly; it can be repeated.
 - `--start-cmd` and `--ready-cmd` are passed as template lifecycle commands.
 - `--template` can be used to choose a template id; otherwise one is generated.
-- `--runtime gvisor` builds a directory-rootfs gVisor template instead of a Firecracker snapshot template.
+- `boxctl template build` currently has no `--runtime` flag. It uses the API default, Firecracker. To build a gVisor directory-rootfs template, create the template through `POST /v3/templates` with `runtimeType: "gvisor"`, then call the returned v2 build endpoint. See [HTTP API](../api/http.md).
 
 Example:
 
@@ -50,12 +50,21 @@ Example:
 
 The response includes `templateID` and `buildID`. Save the `templateID` for sandbox creation.
 
-Build a gVisor template from an NVIDIA CUDA sample image:
+Build a gVisor template from an NVIDIA CUDA sample image by creating a gVisor template record first:
 
 ```bash
-/data/novitabox/boxctl template build cuda-template \
-  --runtime gvisor \
-  --from-image nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubi8
+curl -sS -X POST http://127.0.0.1:8080/v3/templates \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"cuda-template","runtimeType":"gvisor"}'
+```
+
+Use the returned `templateID` and `buildID` with:
+
+```bash
+curl -sS -X POST \
+  http://127.0.0.1:8080/v2/templates/<templateID>/builds/<buildID> \
+  -H 'Content-Type: application/json' \
+  -d '{"fromImage":"nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubi8"}'
 ```
 
 ## List and Inspect Templates
@@ -152,6 +161,33 @@ The sandbox subcommand exposes the same exec flow:
 /data/novitabox/boxctl sandbox rm sbx-xxxxxxxxxxxxxxxxxxxx
 /data/novitabox/boxctl sandbox kill sbx-xxxxxxxxxxxxxxxxxxxx
 ```
+
+## Firecracker Balloon
+
+Firecracker sandboxes create a virtio-balloon device with a target of `0 MiB`. The target can be changed without restarting the sandbox:
+
+```bash
+/data/novitabox/boxctl sandbox balloon set sbx-xxxxxxxxxxxxxxxxxxxx --amount-mib 1024
+/data/novitabox/boxctl sandbox balloon get sbx-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl sandbox balloon set sbx-xxxxxxxxxxxxxxxxxxxx --amount-mib 0
+```
+
+Read statistics and configure the polling interval:
+
+```bash
+/data/novitabox/boxctl sandbox balloon stats sbx-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl sandbox balloon stats-interval sbx-xxxxxxxxxxxxxxxxxxxx --interval-s 2
+```
+
+Manage one-shot free-page hinting:
+
+```bash
+/data/novitabox/boxctl sandbox balloon hinting start sbx-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl sandbox balloon hinting get sbx-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl sandbox balloon hinting stop sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+Balloon is Firecracker-only and requires a guest kernel with virtio-balloon support. gVisor returns an unsupported-runtime error.
 
 ## Images
 

--- a/docs/quick-start/cli.md
+++ b/docs/quick-start/cli.md
@@ -67,7 +67,7 @@ novita-sandbox-cli sbx kill sbx-xxxxxxxxxxxxxxxxxxxx
 ```
 
 When debugging NovitaBox itself, prefer `boxctl` because it exposes local-only commands and can directly select `--api` and `--proxy`.
- 
+
 ```bash
 /data/novitabox/boxctl sandbox list
 /data/novitabox/boxctl exec -it sbx-xxxxxxxxxxxxxxxxxxxx /bin/sh
@@ -76,6 +76,8 @@ When debugging NovitaBox itself, prefer `boxctl` because it exposes local-only c
 Runtime selection and GPU requests are local NovitaBox features exposed by `boxctl` and the native HTTP API:
 
 ```bash
-/data/novitabox/boxctl template build cuda-template --runtime gvisor --from-image nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubi8
+/data/novitabox/boxctl template build cuda-template --from-image nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubi8
 /data/novitabox/boxctl sandbox create --template tpl-xxxxxxxxxxxxxxxxxxxx --runtime gvisor --gpu 1
 ```
+
+`boxctl template build` currently uses the API default runtime, Firecracker. To create a gVisor template, use the native template API with `runtimeType: "gvisor"` before starting the build.

--- a/docs/quick-start/install.md
+++ b/docs/quick-start/install.md
@@ -9,7 +9,7 @@ The release installer downloads prebuilt NovitaBox components for the current op
 ### Linux
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | RELEASE_VERSION=v0.0.2 sudo -E bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | RELEASE_VERSION=<release-version> sudo -E bash
 ```
 
 Linux defaults:
@@ -26,7 +26,7 @@ ENABLE_CADDY=1
 ### macOS with Lima
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | RELEASE_VERSION=v0.0.2 bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | RELEASE_VERSION=<release-version> bash
 ```
 
 On macOS, the installer downloads:
@@ -40,7 +40,7 @@ Homebrew and Lima are installed automatically when missing. macOS host DNS and p
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | \
-  RELEASE_VERSION=v0.0.2 ENABLE_MAC_DNS=1 ENABLE_MAC_PROXY=1 bash
+  RELEASE_VERSION=<release-version> ENABLE_MAC_DNS=1 ENABLE_MAC_PROXY=1 bash
 ```
 
 ### Runtime Assets
@@ -54,7 +54,7 @@ RUNTIME_ASSET_VERSION=v0.0.1
 Override only when publishing new runtime assets:
 
 ```bash
-RELEASE_VERSION=v0.0.2 RUNTIME_ASSET_VERSION=v0.0.3 scripts/install-release.sh
+RELEASE_VERSION=<release-version> RUNTIME_ASSET_VERSION=<runtime-asset-version> scripts/install-release.sh
 ```
 
 gVisor support requires a `runsc` binary. The release installer can download it from the release assets when

--- a/docs/quick-start/sdk.md
+++ b/docs/quick-start/sdk.md
@@ -49,9 +49,11 @@ The same code runs in Novita production with your production API key and endpoin
 Runtime selection and GPU allocation are NovitaBox local control-plane options. Create those templates and sandboxes with `boxctl` or the native HTTP API, then use the SDK against the resulting template or sandbox:
 
 ```bash
-/data/novitabox/boxctl template build cuda-template --runtime gvisor --from-image nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubi8
+/data/novitabox/boxctl template build cuda-template --from-image nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubi8
 /data/novitabox/boxctl sandbox create --template tpl-xxxxxxxxxxxxxxxxxxxx --runtime gvisor --gpu 1
 ```
+
+The first command creates a Firecracker template because the current `boxctl template build` command has no runtime flag. For a gVisor template, use `POST /v3/templates` with `runtimeType: "gvisor"`, then start the returned v2 build. The sandbox command above shows the valid runtime selection flag for sandbox creation.
 
 ## Verify with boxctl
 

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -1,0 +1,38 @@
+# NovitaBox 中文文档
+
+这套文档以当前仓库代码为准，覆盖安装、运行时、artifact、网络、HTTP/RPC、CLI、GPU、Firecracker Balloon 和故障排查。
+
+## 快速入口
+
+- [完整使用手册](usage.md)：从安装到 template、sandbox、image、SDK 和排错的完整流程。
+- [安装与服务检查](quick-start/install.md)：Linux、macOS + Lima、运行时依赖和安装变量。
+- [HTTP API](api/http.md)：当前实际注册的 HTTP 路由、请求体和示例。
+- [RPC API](api/rpc.md)：boxapi、boxlet、boxshim 之间的 gRPC 边界。
+- [boxctl CLI](cli/README.md)：template、sandbox、image、runtime 和 balloon 命令。
+- [架构概览](architecture/overview.md)：组件关系和数据流。
+- [运行时与能力矩阵](architecture/runtime.md)：Firecracker、gVisor、Cloud Hypervisor 的实现差异。
+- [网络模型](architecture/network.md)：network namespace、veth、tap、路由和 NAT。
+- [Artifact 模型](architecture/artifact.md)：Image、Template、Snapshot 的区别。
+- [文件布局](architecture/file-layout.md)：`$ROOT` 下各类文件的位置和用途。
+- [生命周期](architecture/lifecycle.md)：sandbox 状态和各 runtime 支持情况。
+- [安全模型](architecture/security.md)：jailer、gVisor、GPU 和本地控制面边界。
+- [故障排查](troubleshooting.md)：template build、网络、KVM、GPU、balloon 和代理问题。
+
+## 当前实现重点
+
+- Firecracker MicroVM、full snapshot、pause/resume 和 jailer。
+- Firecracker virtio-balloon：动态回收目标、统计信息和 free-page hinting。
+- gVisor `runsc` directory-rootfs runtime。
+- gVisor NVIDIA GPU：`nvproxy`、CDI、设备和 driver library 注入。
+- template/image/sandbox artifact 管理。
+- 每 sandbox 独立 network namespace 和 host access IP。
+- `boxapi`、`boxlet`、`boxshim`、`boxd`、`boxproxy`、`boxctl` 完整链路。
+
+## 文档约定
+
+- 默认安装根目录按安装脚本使用 `/data/novitabox`；程序自身未通过安装脚本启动时，配置默认值是 `/var/lib/novitabox`。
+- `tpl-...`、`img-...`、`sbx-...` 都是示例 ID，需要替换为真实返回值。
+- gVisor 在 protobuf 中对应 `RUNTIME_TYPE_CONTAINER`，HTTP/CLI 对外使用 `gvisor`。
+- API 示例默认直连 `boxapi`：`http://127.0.0.1:8080`。
+- exec、shell 和 sandbox 服务代理默认经过 `boxproxy`：`http://127.0.0.1:8082`。
+

--- a/docs/zh/api/http.md
+++ b/docs/zh/api/http.md
@@ -1,0 +1,264 @@
+# HTTP API
+
+`boxapi` 默认监听 `127.0.0.1:8080`。当前实现同时保留兼容路由、v1 原生路由、v2 build 路由和 v3 template 创建路由。
+
+## 健康检查
+
+```bash
+curl -sS http://127.0.0.1:8080/health
+curl -sS http://127.0.0.1:8080/healthz
+```
+
+## Template
+
+### 创建 template 记录和 build ID
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/v3/templates \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name":"python-dev",
+    "templateID":"tpl-xxxxxxxxxxxxxxxxxxxx",
+    "cpuCount":2,
+    "memoryMB":2048,
+    "runtimeType":"firecracker"
+  }'
+```
+
+`runtimeType` 支持 `firecracker`、`gvisor` 和 `cloud-hypervisor`。省略时默认 `firecracker`。返回值包含 `templateID` 和 `buildID`。
+
+### 启动 build
+
+```bash
+curl -sS -X POST \
+  http://127.0.0.1:8080/v2/templates/tpl-xxxxxxxxxxxxxxxxxxxx/builds/build-id \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "fromImage":"ubuntu:22.04",
+    "startCmd":"/novitabox/init",
+    "readyCmd":"curl -fsS http://127.0.0.1:49983/health",
+    "steps":[
+      {"type":"RUN","args":["apt-get update && apt-get install -y python3"]},
+      {"type":"EXEC","args":["python3","--version"]}
+    ]
+  }'
+```
+
+- `RUN` 使用 shell 执行一个命令字符串。
+- `EXEC` 直接使用参数数组执行程序。
+- `fromImage` 和 `fromTemplate` 用于指定 build 来源。
+- Firecracker build 最终生成 `rootfs.ext4`、`memfile` 和 `snapfile`。
+- gVisor build 最终生成 directory rootfs，不创建 VM snapshot 文件。
+
+查询状态：
+
+```bash
+curl -sS \
+  http://127.0.0.1:8080/v2/templates/tpl-xxxxxxxxxxxxxxxxxxxx/builds/build-id/status
+```
+
+查询和删除：
+
+```bash
+curl -sS http://127.0.0.1:8080/templates
+curl -sS http://127.0.0.1:8080/templates/tpl-xxxxxxxxxxxxxxxxxxxx
+curl -i -X DELETE http://127.0.0.1:8080/templates/tpl-xxxxxxxxxxxxxxxxxxxx
+```
+
+### 创建 gVisor template
+
+当前 `boxctl template build` 没有 `--runtime` 参数。需要通过 v3 API 创建带 `runtimeType: "gvisor"` 的记录，然后调用 v2 build：
+
+```bash
+create_response=$(curl -sS -X POST http://127.0.0.1:8080/v3/templates \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"cuda-sample","runtimeType":"gvisor"}')
+
+echo "$create_response"
+```
+
+取得返回的 `templateID`、`buildID` 后执行：
+
+```bash
+curl -sS -X POST \
+  http://127.0.0.1:8080/v2/templates/<templateID>/builds/<buildID> \
+  -H 'Content-Type: application/json' \
+  -d '{"fromImage":"nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubi8"}'
+```
+
+## Sandbox
+
+从 template 创建：
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes \
+  -H 'Content-Type: application/json' \
+  -d '{"templateID":"tpl-xxxxxxxxxxxxxxxxxxxx","runtime_type":"firecracker"}'
+```
+
+从 image 创建：
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes \
+  -H 'Content-Type: application/json' \
+  -d '{"image_id":"img-xxxxxxxxxxxxxxxxxxxx","runtime_type":"gvisor","gpu":1}'
+```
+
+查询：
+
+```bash
+curl -sS http://127.0.0.1:8080/v1/sandboxes
+curl -sS http://127.0.0.1:8080/v1/sandboxes/sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+生命周期：
+
+```bash
+curl -X POST http://127.0.0.1:8080/v1/sandboxes/sbx-xxx/pause
+curl -X POST http://127.0.0.1:8080/v1/sandboxes/sbx-xxx/resume
+curl -X POST http://127.0.0.1:8080/v1/sandboxes/sbx-xxx/poweroff
+curl -X POST http://127.0.0.1:8080/v1/sandboxes/sbx-xxx/poweron
+curl -X POST http://127.0.0.1:8080/v1/sandboxes/sbx-xxx/reboot
+curl -X DELETE http://127.0.0.1:8080/v1/sandboxes/sbx-xxx
+```
+
+pause/resume 是 runtime capability。Firecracker 支持 VM snapshot pause/resume；gVisor 当前不支持 Firecracker 风格的 snapshot pause/resume。
+
+## Firecracker Balloon
+
+Firecracker sandbox 创建时会配置 virtio-balloon。默认 target 为 `0 MiB`，并启用：
+
+- `deflateOnOOM`
+- `statsPollingIntervalS = 1`
+- free-page hinting
+- free-page reporting
+
+设置回收目标：
+
+```bash
+curl -sS -X PATCH http://127.0.0.1:8080/v1/sandboxes/sbx-xxx/balloon \
+  -H 'Content-Type: application/json' \
+  -d '{"amountMiB":1024}'
+```
+
+`amountMiB` 是希望 balloon 从 guest 占用并归还给宿主机的目标内存量。设置为 `0` 表示让 balloon 完全 deflate，并不等同于修改 VM 启动时的总内存。
+
+读取配置和统计：
+
+```bash
+curl -sS http://127.0.0.1:8080/v1/sandboxes/sbx-xxx/balloon
+curl -sS http://127.0.0.1:8080/v1/sandboxes/sbx-xxx/balloon/statistics
+```
+
+调整统计轮询间隔：
+
+```bash
+curl -sS -X PATCH \
+  http://127.0.0.1:8080/v1/sandboxes/sbx-xxx/balloon/statistics \
+  -H 'Content-Type: application/json' \
+  -d '{"statsPollingIntervalS":2}'
+```
+
+free-page hinting 是一次性运行，不是周期任务：
+
+```bash
+curl -sS -X POST \
+  http://127.0.0.1:8080/v1/sandboxes/sbx-xxx/balloon/hinting/start \
+  -H 'Content-Type: application/json' \
+  -d '{"acknowledgeOnStop":true}'
+
+curl -sS http://127.0.0.1:8080/v1/sandboxes/sbx-xxx/balloon/hinting
+curl -sS -X POST http://127.0.0.1:8080/v1/sandboxes/sbx-xxx/balloon/hinting/stop
+```
+
+状态字段：
+
+- `state=stopped`：`hostCmd=0`。
+- `state=completed`：`hostCmd=1`。
+- `state=starting`：host 已发起命令，但 guest 尚未观察到同一命令。
+- `state=running`：`hostCmd` 和 `guestCmd` 指向同一次运行。
+
+Balloon 仅由 Firecracker driver 声明支持。gVisor、stub 和未实现的 runtime 会返回不支持错误。guest kernel 还必须启用 virtio-balloon，统计、回收和 page reporting 才会生效。
+
+## Image
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/v1/images \
+  -H 'Content-Type: application/json' \
+  -d '{"templateID":"tpl-xxx","imageID":"img-xxx","labels":{"env":"dev"}}'
+
+curl -sS http://127.0.0.1:8080/v1/images
+curl -sS http://127.0.0.1:8080/v1/images/img-xxx
+curl -X DELETE http://127.0.0.1:8080/v1/images/img-xxx
+```
+
+转换 template：
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/v1/templates/convert \
+  -H 'Content-Type: application/json' \
+  -d '{"templateID":"tpl-xxx","imageID":"img-xxx"}'
+```
+
+## Runtime 和能力
+
+```bash
+curl -sS http://127.0.0.1:8080/v1/runtimes
+curl -sS http://127.0.0.1:8080/v1/runtimes/firecracker
+curl -sS http://127.0.0.1:8080/v1/runtimes/firecracker/capabilities
+curl -sS http://127.0.0.1:8080/v1/runtimes/gvisor/capabilities
+```
+
+能力字段包括启动来源、pause/resume、snapshot、GPU、网络、在线调整、balloon、优雅关机、串口和 jailer。调用某个高级操作前应先查询 capability，而不是仅根据 runtime 名称猜测。
+
+## 当前路由汇总
+
+```text
+GET    /health
+GET    /healthz
+
+GET    /templates
+GET    /templates/{template_id}
+DELETE /templates/{template_id}
+GET    /templates/{template_id}/builds/{build_id}/status
+
+POST   /sandboxes
+GET    /sandboxes
+GET    /sandboxes/{sandbox_id}
+DELETE /sandboxes/{sandbox_id}
+POST   /sandboxes/{sandbox_id}/pause
+POST   /sandboxes/{sandbox_id}/connect
+POST   /sandboxes/{sandbox_id}/timeout
+
+POST   /v1/sandboxes
+GET    /v1/sandboxes
+GET    /v1/sandboxes/{sandbox_id}
+DELETE /v1/sandboxes/{sandbox_id}
+POST   /v1/sandboxes/{sandbox_id}/pause
+POST   /v1/sandboxes/{sandbox_id}/resume
+POST   /v1/sandboxes/{sandbox_id}/poweroff
+POST   /v1/sandboxes/{sandbox_id}/poweron
+POST   /v1/sandboxes/{sandbox_id}/reboot
+GET    /v1/sandboxes/{sandbox_id}/balloon
+PATCH  /v1/sandboxes/{sandbox_id}/balloon
+GET    /v1/sandboxes/{sandbox_id}/balloon/statistics
+PATCH  /v1/sandboxes/{sandbox_id}/balloon/statistics
+GET    /v1/sandboxes/{sandbox_id}/balloon/hinting
+POST   /v1/sandboxes/{sandbox_id}/balloon/hinting/start
+POST   /v1/sandboxes/{sandbox_id}/balloon/hinting/stop
+
+POST   /v1/templates/convert
+POST   /v1/images
+GET    /v1/images
+GET    /v1/images/{image_id}
+DELETE /v1/images/{image_id}
+GET    /v1/runtimes
+GET    /v1/runtimes/{runtime_type}
+GET    /v1/runtimes/{runtime_type}/capabilities
+
+GET    /v2/sandboxes
+POST   /v2/templates/{template_id}/builds/{build_id}
+GET    /v2/templates/{template_id}/builds/{build_id}/status
+POST   /v3/templates
+```
+

--- a/docs/zh/api/rpc.md
+++ b/docs/zh/api/rpc.md
@@ -1,0 +1,112 @@
+# RPC API
+
+NovitaBox 内部使用 gRPC 将控制面、节点 agent 和每 sandbox runtime supervisor 分开。
+
+```text
+boxapi
+  -> BoxletSandboxService / BoxletArtifactService / BoxletRuntimeService
+boxlet
+  -> 每个 sandbox 的 BoxShim
+boxshim
+  -> Firecracker API、runsc 或其他 runtime driver
+```
+
+## BoxletSandboxService
+
+负责 sandbox 生命周期：
+
+- `CreateSandbox`
+- `PauseSandbox`
+- `ResumeSandbox`
+- `KillSandbox`
+- `StartSandbox`
+- `StopSandbox`
+- `RebootSandbox`
+- `GetSandbox`
+- `ListSandboxes`
+
+Balloon RPC：
+
+- `UpdateSandboxBalloon`
+- `GetSandboxBalloon`
+- `GetSandboxBalloonStats`
+- `UpdateSandboxBalloonStats`
+- `StartSandboxBalloonHinting`
+- `StopSandboxBalloonHinting`
+- `GetSandboxBalloonHinting`
+
+boxlet 在转发 balloon 请求前会读取 sandbox runtime capability。只有 `balloon=true` 时才连接 boxshim 执行操作。
+
+## BoxletArtifactService
+
+负责 template、image 和 artifact：
+
+- 创建、查询、列出和删除 template。
+- 从 Docker image、template 或现有 artifact 物化 rootfs。
+- 构建 Firecracker snapshot template 或 gVisor directory-rootfs template。
+- template 转 image。
+- 创建、查询、列出和删除 image。
+
+## BoxletRuntimeService
+
+用于查询 runtime 信息和 capability。上层 API 应使用 capability 判断操作是否支持，例如：
+
+- `pause`
+- `resume`
+- `full_snapshot`
+- `gpu`
+- `tap_network`
+- `balloon`
+- `jailer`
+
+## BoxShim
+
+每个 sandbox 对应一个 shim socket。BoxShim RPC 包括：
+
+- `CreateRuntime`
+- `StartRuntime`
+- `ResumeRuntime`
+- `PauseRuntime`
+- `StopRuntime`
+- `KillRuntime`
+- `RebootRuntime`
+- `Status`
+- `Capabilities`
+- balloon 配置、统计和 hinting RPC
+
+Driver 接口要求所有 runtime 实现同一组方法。暂不支持某能力的 runtime 应返回明确错误，而不是静默忽略。
+
+## 核心消息
+
+`RuntimeSpec` 描述 runtime 启动所需信息：
+
+- sandbox ID 和 runtime type
+- CPU、内存、hugepages 和 GPU 数量
+- kernel、rootfs、snapshot、网络、agent 和 jailer
+- extra drives
+- balloon 初始配置
+- labels 和 annotations
+
+`RuntimeCapabilities` 是运行时能力协商契约。gVisor 在 protobuf 中使用 `RUNTIME_TYPE_CONTAINER`，HTTP 层将其规范化为 `gvisor`。
+
+`BalloonStats` 包括 target/actual MiB，以及 swap、page fault、free/available memory、cache、HugeTLB、OOM、scan 和 reclaim 等 guest 统计字段。字段是否有有效值取决于 guest kernel 是否上报。
+
+## 生成代码
+
+修改以下 proto 后，需要同步生成 Go 文件：
+
+```text
+proto/novitabox/v1/types.proto
+proto/novitabox/v1/boxlet.proto
+proto/novitabox/v1/boxshim.proto
+```
+
+生成结果位于：
+
+```text
+internal/pb/novitabox/v1/*.pb.go
+internal/pb/novitabox/v1/*_grpc.pb.go
+```
+
+不要只修改生成文件；消息和 RPC 的源定义应始终以 `.proto` 为准。
+

--- a/docs/zh/architecture/artifact.md
+++ b/docs/zh/architecture/artifact.md
@@ -1,0 +1,50 @@
+# Artifact 模型
+
+## Image
+
+只包含 rootfs 状态：
+
+```text
+Firecracker Image = rootfs.ext4 + metadata
+gVisor Image      = rootfs directory + metadata
+```
+
+Image 不携带运行时内存，更适合迁移、复制和长期存储。
+
+## Template
+
+保存选定 runtime 的快速启动状态：
+
+```text
+Firecracker Template = rootfs.ext4 + memfile + snapfile + metadata
+gVisor Template      = rootfs directory + metadata
+```
+
+Firecracker template 通过 full snapshot 快速恢复 VM；gVisor template 本质是准备完成的 OCI directory rootfs。
+
+## Snapshot
+
+Snapshot 是 pause 产生的 sandbox-bound 状态：
+
+```text
+Firecracker Snapshot = sandbox rootfs.ext4 + memfile + snapfile + metadata
+```
+
+它属于 sandbox 生命周期，不是面向用户的通用转换 artifact。gVisor 当前不支持这种 pause/resume snapshot。
+
+## 转换关系
+
+```text
+Docker/OCI image -> Template
+Template -> Sandbox
+Template -> Image
+Image -> Sandbox
+Firecracker Sandbox --pause--> Snapshot --resume--> Sandbox
+```
+
+Firecracker template 转 image 会丢弃内存和 snapshot 文件。gVisor template 转 image 会复制 directory rootfs。
+
+## CoW 和文件系统
+
+NovitaBox 优先使用 reflink 复制大文件和目录，以减少 template、image、sandbox 之间的复制成本。安装脚本推荐 Btrfs；如果底层文件系统不支持 reflink，相关路径可能退化为普通复制，空间和耗时都会增加。
+

--- a/docs/zh/architecture/components.md
+++ b/docs/zh/architecture/components.md
@@ -1,0 +1,63 @@
+# 组件职责
+
+## boxapi
+
+HTTP 控制面入口，默认监听 `127.0.0.1:8080`。
+
+- 注册兼容 API 和 NovitaBox 原生 API。
+- 校验 JSON 请求并统一返回错误。
+- 维护 template build 等控制面元数据。
+- 调用 boxlet gRPC 执行节点操作。
+- 暴露 runtime capability、image、template 和 sandbox API。
+
+## boxlet
+
+节点级 agent，默认监听 `127.0.0.1:8081`。
+
+- 创建和恢复 sandbox 本地目录。
+- 启动或连接每 sandbox 的 boxshim。
+- 分配 network slot 和 host access IP。
+- 创建 network namespace、veth、tap、路由和 NAT。
+- 构建 Firecracker snapshot template 和 gVisor directory-rootfs template。
+- 管理 template、image、snapshot 和 sandbox metadata。
+- 将 balloon 请求转发到支持该能力的 boxshim。
+
+## boxshim
+
+每个 sandbox 一个 runtime supervisor，使用 sandbox 目录中的 Unix socket 提供 RPC。
+
+- 保持为 runtime 父进程。
+- 隔离 Firecracker、gVisor 等实现差异。
+- 负责 create/start/pause/resume/stop/reboot/kill/status。
+- Firecracker driver 负责 API socket、jailer、snapshot、metrics 和 balloon。
+- gVisor driver 负责 OCI bundle、runsc state、网络 namespace 和 CDI/GPU 注入。
+
+## boxd
+
+sandbox 内 agent。Firecracker 中运行在 guest VM；gVisor 中作为 OCI init 进程运行。
+
+- health check
+- 命令执行
+- interactive shell / PTY
+- process/connect 兼容接口
+- guest 内服务入口
+
+template build 会把 host 上的 `boxd` 注入 artifact。Firecracker 使用只读 agent drive；gVisor 直接将文件放入 directory rootfs。
+
+## boxproxy
+
+数据面代理，默认监听 `127.0.0.1:8082`。
+
+- 转发 exec 和 shell。
+- 支持 WebSocket 升级。
+- 解析 sandbox ID 或端口域名。
+- 从数据库读取 network slot，通过 host access IP 连接 boxd。
+
+## boxctl
+
+本地管理 CLI。生命周期和 artifact 请求走 boxapi，exec/shell 走 boxproxy。
+
+## SQLite
+
+boxapi 和 boxlet 使用 SQLite 保存 template、build、image、sandbox 和 network slot 等元数据。数据库记录不是 artifact 本体；删除或迁移时要同时考虑数据库和 `$ROOT` 文件。
+

--- a/docs/zh/architecture/file-layout.md
+++ b/docs/zh/architecture/file-layout.md
@@ -1,0 +1,44 @@
+# 文件布局
+
+安装脚本默认使用 `/data/novitabox`；程序配置默认根目录是 `/var/lib/novitabox`。下面统一写作 `$ROOT`。
+
+```text
+$ROOT/db/novitabox.db
+
+$ROOT/images/<image_id>/rootfs.ext4
+$ROOT/images/<image_id>/rootfs/             # gVisor directory rootfs
+
+$ROOT/templates/<template_id>/rootfs.ext4
+$ROOT/templates/<template_id>/memfile
+$ROOT/templates/<template_id>/snapfile
+$ROOT/templates/<template_id>/rootfs/       # gVisor directory rootfs
+
+$ROOT/sandboxes/<sandbox_id>/shim.sock
+$ROOT/sandboxes/<sandbox_id>/shim.pid
+$ROOT/sandboxes/<sandbox_id>/fc.sock
+$ROOT/sandboxes/<sandbox_id>/firecracker.log
+$ROOT/sandboxes/<sandbox_id>/firecracker-metrics.json
+$ROOT/sandboxes/<sandbox_id>/kernel
+$ROOT/sandboxes/<sandbox_id>/snapshot/
+
+$ROOT/sandboxes/<sandbox_id>/bundle/config.json
+$ROOT/sandboxes/<sandbox_id>/runsc/
+$ROOT/sandboxes/<sandbox_id>/runsc.log
+$ROOT/sandboxes/<sandbox_id>/rootfs/
+
+$ROOT/boxapi
+$ROOT/boxctl
+$ROOT/boxd
+$ROOT/boxlet
+$ROOT/boxproxy
+$ROOT/boxshim
+$ROOT/firecracker
+$ROOT/jailer
+$ROOT/runsc
+$ROOT/vmlinux.bin
+```
+
+使用 Firecracker jailer 时，还会在 jailer chroot 下 bind mount runtime 所需的 kernel、rootfs、snapshot、metrics 和 API socket。删除 sandbox 前需要先解除这些 mount；否则目录删除可能失败或留下 busy mount。
+
+排查时不要只看数据库。sandbox 目录、shim socket、runtime pid、network namespace 和 host route 都可能保留独立状态。
+

--- a/docs/zh/architecture/lifecycle.md
+++ b/docs/zh/architecture/lifecycle.md
@@ -1,0 +1,50 @@
+# Sandbox 生命周期
+
+状态大致如下：
+
+```text
+Creating -> Running
+Running  -> Pausing  -> Paused
+Paused   -> Resuming -> Running
+Running  -> Stopping -> Stopped
+Stopped  -> Starting -> Running
+Running  -> Rebooting -> Running
+*        -> Killing  -> Killed
+失败时   -> Failed / Unknown
+```
+
+## Create
+
+boxlet 准备 artifact、网络和 sandbox 目录，启动 boxshim，再由 driver 创建 runtime。创建来源可以是 template、image 或 snapshot，但是否支持取决于 runtime capability。
+
+## Pause/Resume
+
+Firecracker pause 会保存 sandbox-bound full snapshot，并停止当前 VM；resume 从该 snapshot 恢复。gVisor 当前返回不支持。
+
+## Poweroff/Poweron
+
+poweroff 停止 runtime，但保留 sandbox rootfs、metadata 和可恢复文件。poweron 使用保留状态重新启动。它与 delete/kill 不同。
+
+## Reboot
+
+由 boxshim 停止并重新启动同一 runtime spec。运行时错误会写入 `RuntimeInfo.error_message`，Firecracker 错误通常还会附带日志尾部。
+
+## Delete/Kill
+
+终止 runtime、关闭 shim、清理网络、mount 和 sandbox 文件，并更新/删除 metadata。异常退出后如果清理未完成，应检查：
+
+- shim/runtime 进程
+- jailer mount
+- network namespace
+- host veth 和 route
+- sandbox 目录
+
+## Balloon 生命周期
+
+Balloon 是 Firecracker running 状态下的在线操作，不创建新的 sandbox 状态：
+
+- target 可随时增减。
+- statistics polling interval 可在线修改。
+- free-page hinting 是一次性 run，需要显式 start/stop。
+- runtime 退出或 API socket 不可用时，balloon 请求会失败。
+

--- a/docs/zh/architecture/network.md
+++ b/docs/zh/architecture/network.md
@@ -1,0 +1,81 @@
+# 网络模型
+
+默认配置：
+
+```text
+host_access_cidr = 10.11.0.0/16
+veth_cidr        = 10.12.0.0/16
+guest_ip         = 169.254.0.21
+gateway_ip       = 169.254.0.22
+guest_mac        = 02:FC:00:00:00:05
+boxd_port        = 49983
+```
+
+每个 sandbox 获得一个 network slot。slot 同时决定：
+
+- 唯一 host access IP。
+- host/netns veth 地址对。
+- host 路由。
+- sandbox metadata 中的 network slot。
+
+## 公共准备流程
+
+boxlet 创建 network namespace 后：
+
+1. 删除同名残留 host veth、peer veth、namespace veth 和 tap。
+2. 创建 veth pair。
+3. 将 peer 移入 network namespace 并改名为 `eth0`。
+4. 配置 host 和 namespace 地址。
+5. 启用 loopback 和 `net.ipv4.ip_forward=1`。
+6. 配置 namespace 默认路由。
+7. 在 host 上添加 host access IP 的 `/32` 路由。
+8. 根据 runtime 类型继续配置 Firecracker 或 gVisor 网络。
+9. 配置宿主机 internet masquerade。
+
+network namespace 和接口名称会通过 sandbox ID 生成 Linux 接口安全的短名称，避免超过 15 字符限制。
+
+## Firecracker
+
+```text
+host
+  -> host veth
+  -> sandbox netns eth0
+  -> DNAT/SNAT
+  -> tap0 gateway 169.254.0.22/30
+  -> guest eth0 169.254.0.21/30
+  -> boxd :49983
+```
+
+Firecracker driver 将 `tap0` 和固定 guest MAC 写入 network interface 配置。每个 MicroVM 都可以复用固定 guest IP，因为它们位于不同 network namespace。
+
+## gVisor
+
+```text
+host
+  -> host veth
+  -> sandbox netns eth0（唯一 host access IP）
+  -> runsc sandbox
+  -> boxd 0.0.0.0:49983
+```
+
+gVisor 不创建 tap。为了兼容固定 guest 地址，boxlet 还会将 guest IP 配置到 namespace loopback；runsc 直接加入已经准备好的 network namespace。
+
+## 出网和访问
+
+- sandbox 出网依赖 host ip forwarding 和 iptables masquerade。
+- host 访问 sandbox 通过唯一 host access IP。
+- boxproxy 根据数据库中的 slot 计算访问地址。
+- Firecracker 在 namespace 内使用 DNAT/SNAT 将 host access IP 映射到固定 guest IP。
+
+## 检查命令
+
+```bash
+ip netns list
+ip route show
+iptables -t nat -S
+ip netns exec <netns> ip addr
+ip netns exec <netns> ip route
+```
+
+如果 template build 报 `Device or resource busy`，重点检查相同 namespace 内是否残留 `tap0`，以及运行中的 boxlet 是否已包含按 runtime 分流、创建前删除残留 tap 的实现。
+

--- a/docs/zh/architecture/overview.md
+++ b/docs/zh/architecture/overview.md
@@ -1,0 +1,149 @@
+# 架构概览
+
+NovitaBox 由宿主机控制面、节点 agent、runtime shim、guest agent 和代理服务组成。
+
+详细主题：
+
+- [组件职责](components.md)
+- [运行时和能力矩阵](runtime.md)
+- [网络模型](network.md)
+- [Artifact 模型](artifact.md)
+- [文件布局](file-layout.md)
+- [生命周期](lifecycle.md)
+- [安全模型](security.md)
+
+```text
+Client / SDK / CLI
+        |
+        | HTTP / WebSocket
+        v
+     boxapi
+        |
+        +--> boxlet
+        |      - 管理本机 sandbox 生命周期
+        |      - 准备 rootfs、snapshot、kernel、agent disk 或 gVisor directory rootfs
+        |      - 创建 network namespace、veth、tap 或 gVisor veth 地址、路由和 NAT
+        |      - 构建 template 和 image
+        |
+        +--> sqlite metadata
+
+     boxproxy
+        |
+        | sandbox exec / shell / service proxy
+        v
+     sandbox guest boxd
+
+     boxshim
+        |
+        | one shim per sandbox
+        v
+     Firecracker / gVisor / runtime process
+```
+
+## 组件
+
+### boxapi
+
+`boxapi` 是 HTTP API 入口，负责：
+
+- template、sandbox、image API
+- SDK/CLI 兼容路由
+- 调用 boxlet 执行本机操作
+- 返回统一 JSON 错误
+
+### boxlet
+
+`boxlet` 是节点 agent，负责：
+
+- 管理 sandbox artifact
+- 启动和连接 boxshim
+- 分配网络 slot
+- 创建 network namespace、tap、veth、路由和 NAT
+- 构建 template 和 image
+- 维护 sqlite 元数据
+
+### boxshim
+
+`boxshim` 是每个 sandbox 的 runtime supervisor，负责：
+
+- 作为 Firecracker、gVisor 等 runtime 的父进程
+- 通过 Unix socket 暴露 runtime RPC
+- 执行 start、pause、resume、stop、reboot、kill
+- 为 Firecracker 提供 balloon target、statistics 和 free-page hinting
+- 在 boxlet 重启时继续托管 runtime
+
+runtime driver：
+
+- Firecracker：MicroVM、kernel、tap、`rootfs.ext4`、`memfile/snapfile`
+- Firecracker Balloon：virtio-balloon、metrics、动态回收和 page hinting
+- gVisor：`runsc`、OCI bundle、directory rootfs、可选 NVIDIA GPU
+- Cloud Hypervisor：通过同一套 capability 模型暴露
+
+gVisor GPU 通过 `runsc --nvproxy` 和 NVIDIA CDI 实现。宿主机需要 NVIDIA driver、`nvidia-ctk`、`nvidia-cdi-hook`，并生成 `/etc/cdi/nvidia.yaml`。
+
+### boxd
+
+`boxd` 运行在 guest 内部，负责：
+
+- health check
+- exec
+- interactive shell / PTY
+- SDK connect 风格的 process API
+- agent reexec
+
+### boxproxy
+
+`boxproxy` 是数据面代理，负责：
+
+- 把 exec/shell 请求转发到 sandbox 内的 boxd
+- 通过 sandbox id 查找 host access IP
+- 支持 WebSocket 和 HTTP proxy
+
+## 默认网络
+
+```text
+host_access_cidr = 10.11.0.0/16
+veth_cidr        = 10.12.0.0/16
+guest_ip         = 169.254.0.21
+gateway_ip       = 169.254.0.22
+boxd_port        = 49983
+```
+
+每个 sandbox 的 guest IP 固定，宿主机通过唯一 host access IP 访问：
+
+```text
+Firecracker:
+host -> 10.11.x.y -> netns DNAT -> 169.254.0.21:49983
+
+gVisor:
+host -> 10.11.x.y -> netns veth -> boxd 0.0.0.0:49983
+```
+
+## Artifact
+
+```text
+Firecracker Image    = rootfs.ext4
+Firecracker Template = rootfs.ext4 + memfile + snapfile
+Firecracker Snapshot = sandbox-bound rootfs.ext4 + memfile + snapfile
+
+gVisor Image         = rootfs directory
+gVisor Template      = rootfs directory
+```
+
+Image 更适合迁移，Template 更适合快速启动，Snapshot 绑定具体 sandbox 生命周期。gVisor 当前不支持 Firecracker 风格的 pause/resume snapshot。
+
+## 控制面与数据面
+
+控制面请求进入 `boxapi`，由 `boxlet` 管理节点资源，再由每 sandbox 的 `boxshim` 操作 runtime：
+
+```text
+HTTP -> boxapi -> gRPC -> boxlet -> Unix gRPC -> boxshim -> runtime
+```
+
+exec、shell 和用户服务流量进入 `boxproxy`，根据 sandbox 元数据找到唯一 host access IP，再转发给 sandbox 内的 `boxd`：
+
+```text
+HTTP/WebSocket -> boxproxy -> host access IP -> boxd
+```
+
+这两个平面分开后，runtime 生命周期失败不会直接破坏代理进程，控制面重启也不要求立即杀死由 boxshim 托管的 runtime。

--- a/docs/zh/architecture/runtime.md
+++ b/docs/zh/architecture/runtime.md
@@ -1,0 +1,68 @@
+# 运行时与能力矩阵
+
+## RuntimeSpec
+
+`RuntimeSpec` 是 boxlet 与 boxshim 的内部契约，包含：
+
+- sandbox ID 和 runtime type
+- vCPU、内存、hugepages、GPU
+- kernel、rootfs 和 snapshot 路径
+- network、agent、jailer 和 extra drives
+- Firecracker balloon 初始配置
+- labels 和 annotations
+
+runtime-specific 参数应在 driver 内解释，上层不应直接拼接 Firecracker API 或 OCI spec。
+
+## Firecracker
+
+Firecracker 是默认 runtime：
+
+- MicroVM 隔离。
+- `rootfs.ext4`。
+- guest kernel。
+- `memfile`、`snapfile` full snapshot。
+- network namespace 内的 tap 网络。
+- vsock、serial console 和 jailer。
+- virtio-balloon、statistics、free-page hinting/reporting。
+
+Firecracker 当前不支持 diff snapshot，GPU capability 为 false。
+
+## gVisor
+
+gVisor driver 使用 `runsc`：
+
+- directory rootfs。
+- OCI bundle：`bundle/config.json`。
+- 使用 boxlet 已准备好的 network namespace。
+- 没有 Firecracker tap、kernel、memfile 和 snapfile。
+- 不支持 Firecracker 风格 pause/resume snapshot。
+- 可通过 `runsc --nvproxy` 和 NVIDIA CDI 使用 GPU。
+
+GPU 流程会读取 `/etc/cdi/nvidia.yaml` 等 CDI spec，注入请求的 `/dev/nvidia*`、driver libraries、环境变量和受支持 hooks。`update-ldcache` hook 不直接在 runsc 中执行；NovitaBox 注入 library path，并通过 CDI symlink hook 准备 `libcuda.so.1` 和 `libnvidia-ml.so.1`。
+
+## Cloud Hypervisor
+
+Cloud Hypervisor 通过相同 capability 模型暴露。节点 capability 当前声明 image/template/snapshot、pause/resume、GPU、vsock、tap、hotplug 和 jailer 等能力；实际使用前仍应确认对应 runtime driver 和二进制已部署。
+
+## 能力矩阵
+
+| 能力 | Firecracker | gVisor | Cloud Hypervisor |
+| --- | --- | --- | --- |
+| Image 启动 | 是 | 是 | 是 |
+| Template 启动 | 是 | 是 | 是 |
+| Snapshot 启动 | 是 | 否 | 是 |
+| Pause/Resume | 是 | 否 | 是 |
+| Full snapshot | 是 | 否 | 是 |
+| Diff snapshot | 否 | 否 | 否 |
+| GPU | 否 | 是 | 节点能力声明为是 |
+| vsock | 是 | 否 | 是 |
+| tap network | 是 | 否 | 是 |
+| Balloon | boxshim 支持 | 否 | 未实现 |
+| Graceful shutdown | 是 | 是 | 是 |
+| Serial console | 是 | 否 | 是 |
+| Jailer | 是 | 否 | 是 |
+
+### 当前已知 capability 差异
+
+Firecracker boxshim driver 已设置 `balloon=true`，balloon HTTP/RPC 也会直接向 sandbox boxshim 查询 capability 后执行。但 boxlet 的静态 `firecrackerCapabilities()` 当前尚未设置 balloon 字段，因此 `/v1/runtimes/firecracker/capabilities` 可能显示 `balloon=false`。判断实际 balloon 操作是否可用时，以 Firecracker sandbox 的 balloon API 返回为准，直到两层 capability 同步。
+

--- a/docs/zh/architecture/security.md
+++ b/docs/zh/architecture/security.md
@@ -1,0 +1,39 @@
+# 安全模型
+
+## Firecracker
+
+Firecracker 提供 MicroVM 边界。启用 jailer 时还包括：
+
+- chroot 文件系统视图。
+- 非特权 UID/GID。
+- PID namespace。
+- sandbox network namespace。
+- Firecracker seccomp。
+- 仅 bind mount runtime 必需文件。
+
+Jailer chroot 中只应出现 kernel、rootfs、snapshot、metrics 和 API socket 等必要资源。
+
+## gVisor
+
+gVisor 使用 runsc sandbox 和 OCI namespace 隔离。它不是硬件 VM；安全假设和 Firecracker 不同。选择 runtime 时应根据 workload 风险、性能和设备需求决定。
+
+## NVIDIA GPU
+
+GPU 访问会扩大 sandbox 可见的宿主机设备和 driver surface：
+
+- 仅 gVisor 路径实现 GPU 注入。
+- 依赖 NVIDIA CDI spec。
+- 会暴露请求的 `/dev/nvidia*` 设备。
+- 会注入 CUDA/NVML driver libraries 和环境变量。
+- `NVIDIA_VISIBLE_DEVICES`、`CUDA_VISIBLE_DEVICES` 和 `NVIDIA_DRIVER_CAPABILITIES` 会进入 sandbox。
+
+CDI spec 属于高权限宿主机配置，应由管理员生成和审查，不应接受不可信用户直接上传。
+
+## 网络和控制面
+
+默认服务监听 loopback，Caddy 承担本地 HTTPS 和 wildcard 路由。当前本地兼容部署通常使用 dummy API key；这不等同于生产级认证。将 boxapi、boxlet、boxproxy 或 shim socket 暴露到不可信网络前，需要额外的认证、TLS、访问控制和防火墙策略。
+
+## Artifact
+
+从不可信 Docker image 构建 template 会执行 image 内命令和用户提供的 build steps。生产环境应限制允许的 registry、build 命令、网络访问、secret 注入和宿主机目录挂载。
+

--- a/docs/zh/changelog/unreleased.md
+++ b/docs/zh/changelog/unreleased.md
@@ -1,0 +1,28 @@
+---
+title: 未发布变更
+---
+
+# 未发布变更
+
+本页记录当前工作区已经实现、但尚未归入正式版本号的能力。
+
+## Firecracker Balloon
+
+- 在 `RuntimeSpec` 中增加 `BalloonSpec`。
+- Firecracker 创建时配置 virtio-balloon，默认 target 为 `0 MiB`。
+- 默认启用 `deflate_on_oom`、statistics、free-page hinting 和 free-page reporting。
+- 支持在线设置 balloon target。
+- 支持读取完整 balloon statistics。
+- 支持在线调整 statistics polling interval。
+- 支持启动、停止和查询一次性 free-page hinting run。
+- 为 Firecracker 创建和配置 `firecracker-metrics.json`。
+- 通过 boxshim、boxlet、boxapi 和 boxctl 暴露完整调用链。
+- gVisor、stub 和 unsupported driver 返回明确的不支持错误。
+- 增加 Firecracker API、默认配置和 hinting 状态单元测试。
+
+## 已知差异
+
+- Firecracker boxshim capability 已设置 `balloon=true`。
+- boxlet 静态 Firecracker capability 尚未同步 balloon 字段，public runtime capability API 可能仍显示 false。
+- 当前 `boxctl template build` 没有 `--runtime` 参数；gVisor template 需要通过 v3 API 指定 `runtimeType`。
+

--- a/docs/zh/changelog/v0.0.1.md
+++ b/docs/zh/changelog/v0.0.1.md
@@ -1,0 +1,24 @@
+---
+title: v0.0.1 — 2026.06.30
+---
+
+## 2026.06.30 Release v0.0.1
+
+NovitaBox 本地 sandbox 初始版本。
+
+### 新增
+
+- `boxapi`：template、sandbox、image、runtime、health 和兼容路由。
+- `boxlet`：本机 artifact 管理、template build、sandbox 生命周期和网络管理。
+- `boxshim`：Firecracker runtime supervisor。
+- `boxd`：guest 内 agent，支持 health、exec、interactive shell、PTY 和 process API。
+- `boxproxy`：sandbox exec/shell 和 SDK connect 风格流量代理。
+- `boxctl`：template、sandbox、image、runtime 和 exec CLI。
+- rootfs、memfile、snapfile 的 reflink 拷贝。
+- 基于 Btrfs 的一键安装脚本和 systemd 服务。
+- 固定 guest IP + 每 sandbox 独立 host access IP 的网络模型。
+- DNS 和 Caddy 反向代理文档，支持 SDK 本地兼容。
+
+### 注意
+
+Firecracker full snapshot 依赖宿主机 KVM 能力。部分嵌套 KVM 环境会在 snapshot 阶段报错：`Failed to get KVM vcpu msr: 0x3a`。

--- a/docs/zh/changelog/v0.0.3.md
+++ b/docs/zh/changelog/v0.0.3.md
@@ -1,0 +1,32 @@
+---
+title: v0.0.3 — 2026.07.22
+---
+
+## 2026.07.22 Release v0.0.3
+
+新增 gVisor runtime 和 NVIDIA GPU sandbox 支持。
+
+### 新增
+
+- 基于 `runsc` 的 gVisor runtime driver。
+- gVisor directory-rootfs template、image 和 sandbox。
+- template 创建支持 `runtimeType: "gvisor"`。
+- sandbox 创建支持 `runtime_type: "gvisor"`。
+- template 创建 API 支持 `runtimeType: "gvisor"`；`boxctl sandbox create` 支持 `--runtime gvisor`。
+- gVisor sandbox 支持 `--gpu <count>`。
+- 通过 runsc `nvproxy` 和 NVIDIA CDI 注入 GPU。
+- 自动配置常见 CUDA/NVML workload 需要的 NVIDIA driver library path 和 symlink。
+- runtime capability API 支持上报 gVisor 能力。
+
+### 变更
+
+- sandbox 网络会按 runtime 准备 Firecracker 或 gVisor 对应的 namespace 配置。
+- template 和 image artifact 清理同时支持 `rootfs.ext4` 和 directory rootfs。
+- sandbox 删除时会先卸载 rootfs 下泄漏的 runtime mount，再删除目录。
+
+### 注意
+
+- gVisor 需要 `$ROOT/runsc`，或者通过 `--runsc-bin` 指定。
+- gVisor GPU 需要宿主机安装 NVIDIA driver、`nvidia-ctk`、`nvidia-cdi-hook`，并生成 `/etc/cdi/nvidia.yaml` 等 CDI spec。
+- GPU 支持当前只针对 NVIDIA。
+- gVisor 暂不支持 Firecracker 风格的 pause/resume snapshot。

--- a/docs/zh/cli/README.md
+++ b/docs/zh/cli/README.md
@@ -1,0 +1,40 @@
+# boxctl CLI
+
+`boxctl` 是 NovitaBox 的本地管理 CLI。
+
+```bash
+boxctl --api http://127.0.0.1:8080 \
+       --proxy http://127.0.0.1:8082 \
+       <command>
+```
+
+- `--api`：template、image、sandbox 生命周期、runtime 和 balloon。
+- `--proxy`：exec、交互式 shell 和 sandbox 数据面连接。
+
+## 命令组
+
+- [Template](template.md)：创建、构建、查询、转换和删除。
+- [Sandbox](sandbox.md)：创建、执行命令、生命周期、GPU 和 balloon。
+- [Image](image.md)：从 template 创建 rootfs-only image。
+- [Runtime](runtime.md)：查询 runtime 和 capability。
+
+别名：
+
+```text
+sandbox -> sbx
+template -> tpl
+image -> img
+list -> ls
+delete -> rm
+```
+
+常用示例：
+
+```bash
+boxctl template build python-dev --from-image ubuntu:22.04 --run 'apt-get update'
+boxctl sandbox create tpl-xxxxxxxxxxxxxxxxxxxx
+boxctl exec -it sbx-xxxxxxxxxxxxxxxxxxxx /bin/sh
+boxctl sandbox balloon set sbx-xxxxxxxxxxxxxxxxxxxx --amount-mib 512
+boxctl runtime capabilities firecracker
+```
+

--- a/docs/zh/cli/image.md
+++ b/docs/zh/cli/image.md
@@ -1,0 +1,35 @@
+# Image CLI
+
+Image 是 rootfs-only artifact：
+
+```text
+Firecracker Image = rootfs.ext4 + metadata
+gVisor Image      = rootfs directory + metadata
+```
+
+从 template 创建：
+
+```bash
+boxctl image create tpl-xxxxxxxxxxxxxxxxxxxx
+boxctl image create tpl-xxxxxxxxxxxxxxxxxxxx --image img-xxxxxxxxxxxxxxxxxxxx
+boxctl image create tpl-xxxxxxxxxxxxxxxxxxxx --label env=dev --label owner=agent
+```
+
+查询和删除：
+
+```bash
+boxctl image list
+boxctl image ls
+boxctl image get img-xxxxxxxxxxxxxxxxxxxx
+boxctl image delete img-xxxxxxxxxxxxxxxxxxxx
+boxctl image rm img-xxxxxxxxxxxxxxxxxxxx
+```
+
+也可以通过 template 命令转换：
+
+```bash
+boxctl template convert tpl-xxxxxxxxxxxxxxxxxxxx --image img-xxxxxxxxxxxxxxxxxxxx
+```
+
+Image 不包含运行时内存状态，比 Firecracker template 更适合迁移和长期保存，但启动时需要重新创建 runtime 状态。
+

--- a/docs/zh/cli/runtime.md
+++ b/docs/zh/cli/runtime.md
@@ -1,0 +1,29 @@
+# Runtime CLI
+
+```bash
+boxctl runtime list
+boxctl runtime show firecracker
+boxctl runtime show gvisor
+boxctl runtime capabilities firecracker
+boxctl runtime capabilities gvisor
+```
+
+常见 capability：
+
+- `startFromImage`
+- `startFromTemplate`
+- `startFromSnapshot`
+- `pause` / `resume`
+- `fullSnapshot` / `diffSnapshot`
+- `gpu`
+- `vsock`
+- `tapNetwork`
+- `hotplugDisk` / `hotplugNetwork`
+- `liveResizeCPU` / `liveResizeMemory`
+- `balloon`
+- `gracefulShutdown`
+- `serialConsole`
+- `jailer`
+
+目前 Firecracker 声明支持 balloon。gVisor 声明 GPU 能力，但不支持 Firecracker 风格的 pause/resume snapshot 和 balloon。
+

--- a/docs/zh/cli/sandbox.md
+++ b/docs/zh/cli/sandbox.md
@@ -1,0 +1,98 @@
+# Sandbox CLI
+
+## 创建
+
+从 template：
+
+```bash
+boxctl sandbox create tpl-xxxxxxxxxxxxxxxxxxxx
+boxctl sandbox create --template tpl-xxxxxxxxxxxxxxxxxxxx
+```
+
+从 image 或 snapshot：
+
+```bash
+boxctl sandbox create --image img-xxxxxxxxxxxxxxxxxxxx
+boxctl sandbox create --snapshot snap-xxxxxxxxxxxxxxxxxxxx
+```
+
+指定 runtime 和 GPU：
+
+```bash
+boxctl sandbox create \
+  --template tpl-xxxxxxxxxxxxxxxxxxxx \
+  --runtime gvisor \
+  --gpu 1
+```
+
+GPU 当前只在 gVisor driver 中实现，依赖宿主机 NVIDIA driver、CDI spec 和 `runsc --nvproxy`。
+
+## 查询和删除
+
+```bash
+boxctl sandbox list
+boxctl sandbox ls
+boxctl sandbox get sbx-xxxxxxxxxxxxxxxxxxxx
+boxctl sandbox delete sbx-xxxxxxxxxxxxxxxxxxxx
+boxctl sandbox rm sbx-xxxxxxxxxxxxxxxxxxxx
+boxctl sandbox kill sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+## Exec 和 Shell
+
+```bash
+boxctl sandbox exec sbx-xxx /bin/sh -c 'pwd && ls -alh'
+boxctl sandbox exec --cwd /root sbx-xxx /bin/sh -c pwd
+boxctl sandbox exec -it sbx-xxx /bin/sh
+boxctl exec -it sbx-xxx /bin/sh
+boxctl sandbox shell sbx-xxx
+boxctl sandbox shell --shell /bin/bash --cwd /root sbx-xxx
+```
+
+rootfs 不一定提供 `/bin/bash`，通用脚本优先使用 `/bin/sh`。
+
+## 生命周期
+
+```bash
+boxctl sandbox pause sbx-xxx
+boxctl sandbox resume sbx-xxx
+boxctl sandbox poweroff sbx-xxx
+boxctl sandbox poweron sbx-xxx
+boxctl sandbox reboot sbx-xxx
+```
+
+`stop`、`start`、`restart` 是隐藏兼容命令，分别映射到 poweroff、poweron 和 reboot。pause/resume 依赖 runtime capability。
+
+## Firecracker Balloon
+
+设置和读取目标：
+
+```bash
+boxctl sandbox balloon set sbx-xxx --amount-mib 1024
+boxctl sandbox balloon get sbx-xxx
+boxctl sandbox balloon set sbx-xxx --amount-mib 0
+```
+
+统计：
+
+```bash
+boxctl sandbox balloon stats sbx-xxx
+boxctl sandbox balloon stats-interval sbx-xxx --interval-s 2
+```
+
+free-page hinting：
+
+```bash
+boxctl sandbox balloon hinting start sbx-xxx
+boxctl sandbox balloon hinting get sbx-xxx
+boxctl sandbox balloon hinting stop sbx-xxx
+```
+
+`hinting start` 默认发送 `acknowledgeOnStop=true`；需要调用方自行控制完成确认时，可以使用：
+
+```bash
+boxctl sandbox balloon hinting start sbx-xxx --acknowledge-on-stop=false
+```
+
+Balloon 只支持 Firecracker。它要求 guest kernel 启用 virtio-balloon；API 成功只代表 Firecracker 接受配置，不保证 guest 内一定有可回收页。
+

--- a/docs/zh/cli/template.md
+++ b/docs/zh/cli/template.md
@@ -1,0 +1,60 @@
+# Template CLI
+
+Template 保存可快速启动的 runtime artifact。
+
+## 创建记录
+
+```bash
+boxctl template create python-dev
+boxctl template create python-dev --template tpl-xxxxxxxxxxxxxxxxxxxx --cpu 2 --memory 2048
+```
+
+命令会调用 `POST /v3/templates` 并返回 template ID 和 build ID，但不会自动完成 build。
+
+## 创建并构建
+
+```bash
+boxctl template build python-dev \
+  --from-image ubuntu:22.04 \
+  --run 'apt-get update' \
+  --run 'apt-get install -y python3 python3-pip' \
+  --exec 'python3 --version'
+```
+
+参数：
+
+- `--template`：指定 template ID。
+- `--cpu`：build runtime 的 CPU 数。
+- `--memory`：build runtime 的内存 MiB。
+- `--from-image`：Docker/OCI image。
+- `--from-template`：已有 template ID。
+- `--start-cmd`：template 启动命令。
+- `--ready-cmd`：ready 检查命令。
+- `--run`：shell build step，可重复。
+- `--exec`：按空格拆成参数的直接执行 step，可重复。
+
+当前代码中的 `boxctl template create/build` 没有 `--runtime` 参数，因此 CLI 创建的是 API 默认 runtime，也就是 Firecracker。需要创建 gVisor template 时，请使用 [HTTP API](../api/http.md) 中的 gVisor template 流程设置 `runtimeType: "gvisor"`。
+
+## 查询状态
+
+```bash
+boxctl template status tpl-xxxxxxxxxxxxxxxxxxxx build-id
+boxctl template list
+boxctl template get tpl-xxxxxxxxxxxxxxxxxxxx
+```
+
+## 转换为 Image
+
+```bash
+boxctl template convert tpl-xxxxxxxxxxxxxxxxxxxx --image img-xxxxxxxxxxxxxxxxxxxx
+```
+
+- Firecracker 转换会保留 rootfs，丢弃 `memfile` 和 `snapfile`。
+- gVisor 转换会复制 directory rootfs。
+
+## 删除
+
+```bash
+boxctl template delete tpl-xxxxxxxxxxxxxxxxxxxx
+boxctl template rm tpl-xxxxxxxxxxxxxxxxxxxx
+```

--- a/docs/zh/quick-start/dns.md
+++ b/docs/zh/quick-start/dns.md
@@ -1,0 +1,34 @@
+# 本地 DNS
+
+如果使用 Caddy 的 `novitabox.localhost` 和 wildcard sandbox 域名，所有域名都应解析到 `127.0.0.1`。
+
+## dnsmasq
+
+```text
+address=/novitabox.localhost/127.0.0.1
+address=/.novitabox.localhost/127.0.0.1
+```
+
+安装脚本在启用 DNS 时会写入对应配置。检查：
+
+```bash
+resolvectl query novitabox.localhost
+resolvectl query sbx-xxxxxxxxxxxxxxxxxxxx.novitabox.localhost
+getent hosts novitabox.localhost
+```
+
+## macOS
+
+macOS + Lima 可以选择由安装脚本配置宿主机 DNS。若不启用宿主机 DNS，可在 Linux VM 内直连 `127.0.0.1:8080`，或手动将 `novitabox.localhost` 和 wildcard 域名指向本地代理。
+
+## DNS 正常但 HTTPS 失败
+
+DNS 解析和 TLS 信任是两件事：
+
+```bash
+curl -v --resolve novitabox.localhost:443:127.0.0.1 \
+  https://novitabox.localhost/health
+```
+
+如果 `--resolve` 成功但普通域名失败，问题在 DNS；如果返回证书错误，安装 Caddy local CA；如果返回连接失败，检查 Caddy、boxapi 和 boxproxy 状态。
+

--- a/docs/zh/quick-start/install.md
+++ b/docs/zh/quick-start/install.md
@@ -1,0 +1,178 @@
+# 安装与服务检查
+
+## 选择部署方式
+
+| 场景 | 推荐方式 |
+| --- | --- |
+| Linux 直接运行 Firecracker | Linux 安装脚本，宿主机提供 KVM 和 TUN/TAP |
+| Linux 运行 gVisor | Linux 安装脚本并提供 `RUNSC_VERSION`、`RUNSC_URL` 或 `RUNSC_PATH` |
+| macOS 本地开发 | macOS + Lima 安装脚本 |
+| 只验证 HTTP/CLI | 可关闭 DNS/Caddy，直接访问 loopback 端口 |
+
+## Linux 环境要求
+
+- x86_64 或 arm64 Linux。
+- Firecracker/Cloud Hypervisor 需要 `/dev/kvm`。
+- Firecracker 网络需要 `/dev/net/tun`。
+- Docker 用于导出 Docker/OCI image rootfs。
+- `iproute2`、`iptables`、`mkfs.ext4`、`debugfs` 等系统工具。
+- 安装脚本要求 Btrfs root，并执行 reflink 能力检查。
+- gVisor 需要 `runsc`。
+- gVisor GPU 需要 NVIDIA driver、`nvidia-ctk`、`nvidia-cdi-hook` 和 CDI spec。
+
+检查：
+
+```bash
+test -e /dev/kvm && echo KVM_OK
+test -e /dev/net/tun && echo TUN_OK
+docker version
+ip -V
+iptables --version
+```
+
+## Release 安装
+
+Linux：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | \
+  RELEASE_VERSION=<release-version> sudo -E bash
+```
+
+macOS + Lima：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | \
+  RELEASE_VERSION=<release-version> bash
+```
+
+`install-release.sh` 会下载平台对应的预编译组件，再调用平台安装脚本。runtime assets 可以独立使用 `RUNTIME_ASSET_VERSION`，因此应用版本和 Firecracker/kernel 资产版本可以不同。
+
+网络受代理限制时可设置：
+
+```bash
+CURL_PROXY=http://proxy.example:8080
+```
+
+## 从源码安装
+
+```bash
+sudo -E scripts/install-linux.sh
+```
+
+常用变量：
+
+| 变量 | 默认值/作用 |
+| --- | --- |
+| `ROOT_DIR` | `/data/novitabox` |
+| `IMAGE_PATH` | `/data/novitabox.img` |
+| `IMAGE_SIZE` | `50G` |
+| `DOMAIN` | `novitabox.localhost` |
+| `ENABLE_DNS` | `1` |
+| `ENABLE_CADDY` | `1` |
+| `REQUIRE_KVM` | `1` |
+| `BOXAPI_ADDR` | `127.0.0.1:8080` |
+| `BOXLET_ADDR` | `127.0.0.1:8081` |
+| `BOXPROXY_ADDR` | `127.0.0.1:8082` |
+| `INSTALL_GO` | `auto` |
+| `SKIP_BUILD` | `0` |
+| `CONFIGURE_DOCKER_MIRRORS` | `0`，默认不修改 Docker mirror |
+
+runtime asset 可以通过本地路径、URL 或版本控制：
+
+```text
+FIRECRACKER_PATH / FIRECRACKER_URL
+KERNEL_PATH      / KERNEL_URL
+JAILER_PATH      / JAILER_URL
+RUNSC_PATH       / RUNSC_URL / RUNSC_VERSION
+```
+
+示例：
+
+```bash
+ROOT_DIR=/data/novitabox \
+IMAGE_SIZE=100G \
+RUNSC_VERSION=<runsc-release> \
+sudo -E scripts/install-linux.sh
+```
+
+不配置本地域名和 HTTPS：
+
+```bash
+ENABLE_DNS=0 ENABLE_CADDY=0 sudo -E scripts/install-linux.sh
+```
+
+## macOS + Lima
+
+macOS 安装脚本会准备 Lima VM，并在 VM 内运行 Linux 组件。主要变量：
+
+```text
+VM_NAME
+LIMA_CPUS
+LIMA_MEMORY
+LIMA_DISK
+LIMA_IMAGE_PATH / LIMA_IMAGE_URL / LIMA_IMAGE_DIGEST
+RUNSC_PATH / RUNSC_URL / RUNSC_VERSION
+ENABLE_MAC_DNS
+ENABLE_MAC_PROXY
+```
+
+Firecracker 是否能在 Lima 内运行取决于嵌套虚拟化/KVM 能力。macOS 本地环境若无法使用 Firecracker full snapshot，可以优先验证 gVisor 路径。
+
+## NVIDIA CDI
+
+```bash
+nvidia-smi
+sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+nvidia-ctk cdi list
+```
+
+确认 `runsc`：
+
+```bash
+/data/novitabox/runsc --version
+/data/novitabox/boxctl runtime capabilities gvisor
+```
+
+## 服务检查
+
+```bash
+systemctl status novitabox-boxlet novitabox-boxapi novitabox-boxproxy --no-pager
+curl -fsS http://127.0.0.1:8080/health
+curl -fsS http://127.0.0.1:8082/healthz
+```
+
+日志：
+
+```bash
+journalctl -u novitabox-boxlet -n 200 --no-pager
+journalctl -u novitabox-boxapi -n 200 --no-pager
+journalctl -u novitabox-boxproxy -n 200 --no-pager
+```
+
+文件系统和资产：
+
+```bash
+findmnt /data/novitabox
+ls -l /data/novitabox/{boxapi,boxlet,boxproxy,boxshim,boxd,boxctl}
+ls -l /data/novitabox/{firecracker,jailer,vmlinux.bin,runsc} 2>/dev/null
+```
+
+## 卸载
+
+Linux：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/uninstall-linux.sh | \
+  sudo -E FORCE=1 bash
+```
+
+macOS：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/uninstall-macos-lima.sh | \
+  FORCE=1 bash
+```
+
+卸载会影响服务、mount、Lima VM 或本地数据。执行前确认 `$ROOT` 中没有需要保留的 template、image 和 sandbox。
+

--- a/docs/zh/quick-start/proxy.md
+++ b/docs/zh/quick-start/proxy.md
@@ -1,0 +1,66 @@
+# Caddy 反向代理
+
+NovitaBox 有两个本地 HTTP 服务：
+
+```text
+boxapi   127.0.0.1:8080   控制面和 artifact API
+boxproxy 127.0.0.1:8082   exec、shell 和 sandbox 数据面
+```
+
+推荐用 Caddy 提供本地 CA、API 域名和 wildcard sandbox 域名。
+
+## Caddyfile
+
+```caddyfile
+{
+  local_certs
+}
+
+novitabox.localhost {
+  tls internal
+  reverse_proxy 127.0.0.1:8080
+}
+
+*.novitabox.localhost {
+  tls internal
+  reverse_proxy 127.0.0.1:8082
+}
+```
+
+安装并重启：
+
+```bash
+sudo apt install -y caddy
+sudo systemctl restart caddy
+sudo systemctl status caddy --no-pager
+```
+
+安装 Caddy 本地 CA：
+
+```bash
+sudo cp /var/lib/caddy/.local/share/caddy/pki/authorities/local/root.crt \
+  /usr/local/share/ca-certificates/caddy-local.crt
+sudo update-ca-certificates
+```
+
+## 路由
+
+```text
+https://novitabox.localhost
+  -> 127.0.0.1:8080
+
+https://<sandbox-or-port>.novitabox.localhost
+  -> 127.0.0.1:8082
+```
+
+boxproxy 会从 host/header 中解析 sandbox identity，再从本地数据库查询 host access IP。
+
+## 检查
+
+```bash
+curl -k https://novitabox.localhost/health
+curl http://127.0.0.1:8082/healthz
+```
+
+客户端仍然证书错误时，检查系统 CA、`REQUESTS_CA_BUNDLE`、`SSL_CERT_FILE`、`NODE_EXTRA_CA_CERTS` 和 `NO_PROXY`。
+

--- a/docs/zh/quick-start/sdk.md
+++ b/docs/zh/quick-start/sdk.md
@@ -1,0 +1,62 @@
+# SDK 与本地域名
+
+Novita Sandbox SDK 可以把 NovitaBox 作为本地后端。典型本地拓扑：
+
+```text
+https://novitabox.localhost       -> boxapi 127.0.0.1:8080
+https://*.novitabox.localhost     -> boxproxy 127.0.0.1:8082
+```
+
+## 环境变量
+
+```bash
+export NOVITA_DOMAIN=novitabox.localhost
+export NOVITA_API_KEY=dummy
+export NOVITA_ACCESS_TOKEN=dummy
+export NO_PROXY=.novitabox.localhost,localhost,127.0.0.1,::1
+export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+export NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/caddy-local.crt
+```
+
+如果语言运行时不读取系统 CA，可显式设置：
+
+```bash
+export SSL_CERT_FILE=/usr/local/share/ca-certificates/caddy-local.crt
+```
+
+## Python
+
+```bash
+pip install novita-sandbox==2.0.5
+```
+
+```python
+from novita_sandbox import Sandbox
+
+sbx = Sandbox(template="tpl-xxxxxxxxxxxxxxxxxxxx")
+result = sbx.commands.run("echo hello from NovitaBox")
+print(result.stdout)
+sbx.close()
+```
+
+## Node CLI
+
+```bash
+npm install -g novita-sandbox-cli@2.0.5
+novita-sandbox-cli sbx create tpl-xxxxxxxxxxxxxxxxxxxx
+```
+
+## 先验证底层
+
+SDK 报错时先排除控制面和 runtime 问题：
+
+```bash
+/data/novitabox/boxctl template list
+/data/novitabox/boxctl sandbox list
+/data/novitabox/boxctl exec -it sbx-xxxxxxxxxxxxxxxxxxxx /bin/sh
+curl -k https://novitabox.localhost/health
+journalctl -u novitabox-boxapi -n 100 --no-pager
+```
+
+runtime 选择和 GPU 数量属于 NovitaBox 原生创建参数。需要 gVisor/GPU 时，先通过原生 API/boxctl 创建正确 runtime 的 template 和 sandbox，再让 SDK 连接或使用它们。
+

--- a/docs/zh/troubleshooting.md
+++ b/docs/zh/troubleshooting.md
@@ -1,0 +1,157 @@
+# 故障排查
+
+## 排查顺序
+
+1. 确认 boxapi/boxlet/boxproxy 服务状态。
+2. 查 API 返回的 sandbox/template/build ID。
+3. 查 boxlet 日志，定位失败阶段。
+4. 查 sandbox 目录中的 runtime 日志。
+5. 查 shim/runtime 进程、mount、network namespace 和 route。
+6. 最后再检查 SDK、DNS、Caddy 和证书。
+
+## template build 网络错误
+
+错误包装可能是：
+
+```text
+prepare template build network: ...
+```
+
+检查：
+
+```bash
+ip netns list
+ip route show
+ip -o link show
+journalctl -u novitabox-boxlet -n 300 --no-pager
+```
+
+### `TUNSETIFF: Device or resource busy`
+
+通常表示同一 network namespace 里的 `tap0` 已存在、被旧 runtime 持有，或运行中的 boxlet 仍是旧版本网络逻辑。
+
+```bash
+ip netns exec <netns> ip link show
+ip netns exec <netns> ip link show tap0
+```
+
+当前代码在公共网络准备阶段会删除残留 tap，并且 gVisor 走 `prepareGVisorNamespace`，不会创建 tap。若 gVisor build 仍尝试创建 `tap0`，优先确认部署二进制是否与当前源码一致。
+
+### `no route to host`
+
+这经常是 runtime 已提前退出后的次生错误。继续检查：
+
+```bash
+find /data/novitabox/sandboxes -name firecracker.log -print
+tail -200 /data/novitabox/sandboxes/<build-id>/firecracker.log
+find /data/novitabox/sandboxes -name runsc.log -print
+tail -200 /data/novitabox/sandboxes/<build-id>/runsc.log
+```
+
+## Firecracker snapshot 失败
+
+```text
+Failed to get KVM vcpu msr: 0x3a
+```
+
+表示 Firecracker 无法在当前 KVM 环境保存 vCPU MSR 状态，常见于嵌套虚拟化。它不是网络错误。可尝试：
+
+- 换用具备完整 KVM snapshot 支持的宿主机。
+- 在本地开发环境改用 gVisor。
+- 确认 kernel、Firecracker 和宿主机 KVM 组合兼容。
+
+## gVisor template build 仍走 Firecracker
+
+当前 `boxctl template build` 没有 `--runtime` 参数。使用 CLI 直接 build 时 API 默认 runtime 是 Firecracker。gVisor template 必须先调用：
+
+```http
+POST /v3/templates
+{"name":"...","runtimeType":"gvisor"}
+```
+
+再调用对应 v2 build 路由。检查 template metadata 中的 `runtimeType` 是否为 `gvisor`。
+
+## gVisor GPU
+
+宿主机检查：
+
+```bash
+nvidia-smi
+nvidia-ctk cdi list
+test -f /etc/cdi/nvidia.yaml
+/data/novitabox/runsc --version
+```
+
+sandbox 检查：
+
+```bash
+boxctl sandbox exec sbx-xxx /usr/bin/nvidia-smi
+boxctl sandbox exec sbx-xxx /bin/sh -c 'echo "$NVIDIA_VISIBLE_DEVICES"; echo "$LD_LIBRARY_PATH"'
+```
+
+若 `nvidia-smi` 能运行但 CUDA sample 失败，继续检查 driver/library 版本、CDI symlink、`libcuda.so.1` 和 `libnvidia-ml.so.1`。
+
+## Balloon
+
+### 返回不支持
+
+Balloon 只支持 Firecracker。gVisor 会返回不支持错误。
+
+### API 成功但内存没有下降
+
+检查：
+
+- guest kernel 是否加载 virtio-balloon。
+- guest 是否有足够可回收页。
+- target 是否超过合理范围。
+- statistics 是否更新。
+- `firecracker-metrics.json` 是否持续写入。
+
+```bash
+boxctl sandbox balloon get sbx-xxx
+boxctl sandbox balloon stats sbx-xxx
+tail -f /data/novitabox/sandboxes/sbx-xxx/firecracker-metrics.json
+```
+
+### capability 显示 false
+
+当前 Firecracker boxshim 已声明 balloon 支持，但 boxlet 的静态 runtime capability 还未同步该字段。因此 public capability API 可能显示 false，而运行中 Firecracker sandbox 的 balloon API仍可工作。
+
+## Exec 找不到程序
+
+```text
+executable file not found
+```
+
+进入 `/bin/sh` 检查 rootfs：
+
+```bash
+boxctl exec -it sbx-xxx /bin/sh
+command -v bash
+command -v sh
+```
+
+很多最小镜像没有 bash、curl、ip 或 systemd。
+
+## HTTPS 证书
+
+```bash
+ls -l /usr/local/share/ca-certificates/caddy-local.crt
+sudo update-ca-certificates
+curl -k https://novitabox.localhost/health
+```
+
+Python 使用 `REQUESTS_CA_BUNDLE`/`SSL_CERT_FILE`，Node 使用 `NODE_EXTRA_CA_CERTS`。还要确保 `NO_PROXY` 包含 `.novitabox.localhost`。
+
+## 残留资源
+
+```bash
+ps -ef | grep -E 'boxshim|firecracker|runsc'
+findmnt -rn | grep /data/novitabox
+ip netns list
+ip -o link show | grep -E 'vh-|tap0'
+ip route show | grep 10.11
+```
+
+删除残留资源属于有状态操作。先确认对应 sandbox/runtime 已停止，再按 sandbox ID 精确清理，不要批量删除所有 network namespace 或 mount。
+

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -1,0 +1,500 @@
+# NovitaBox 使用手册
+
+这份文档按实际使用顺序组织：安装、检查服务、构建 template、创建 sandbox、进入 shell、管理生命周期、Firecracker Balloon、网络和排错。按主题拆分的文档入口见 [中文文档首页](README.md)。
+
+## 1. 环境要求
+
+NovitaBox 支持单机 Linux 部署，也支持 macOS 通过 Lima 启动 Linux VM。Linux 直接部署需要：
+
+- Linux x86_64 或 arm64
+- Firecracker 和 Cloud Hypervisor 需要 KVM：`/dev/kvm`
+- Firecracker tap 网络需要 TUN/TAP：`/dev/net/tun`
+- Docker：用于从 Docker image 导出 rootfs
+- 支持 reflink 的文件系统，推荐 Btrfs
+- `iptables`、`iproute2`、`debugfs`、`mkfs.ext4`
+- gVisor sandbox 需要 `runsc`。release installer 可以在设置 `RUNSC_VERSION` 时自动下载。
+- gVisor GPU sandbox 需要宿主机 NVIDIA driver、`nvidia-ctk`、`nvidia-cdi-hook` 和 CDI spec
+
+macOS 安装需要：
+
+- Homebrew
+- Lima
+- 支持 Apple Virtualization Framework 的 macOS 环境
+
+一键安装脚本会在 macOS 上自动安装 Homebrew 和 Lima（如果缺失）。
+
+如果使用 Firecracker full snapshot，宿主机的 KVM 必须支持 Firecracker 保存 vCPU 状态。部分嵌套 KVM 环境会失败，典型错误是：
+
+```text
+Failed to get KVM vcpu msr: 0x3a
+```
+
+这表示 guest 已经启动，但 Firecracker 创建 full snapshot 失败。
+
+## 2. 一键安装（推荐）
+
+直接从 GitHub Release 下载预编译组件安装，不需要本地编译。
+
+Linux：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | RELEASE_VERSION=<release-version> sudo -E bash
+```
+
+macOS + Lima：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | RELEASE_VERSION=<release-version> bash
+```
+
+macOS 默认不会在宿主机配置 DNS 和 proxy。如果需要 `https://novitabox.localhost` 和 `https://*.novitabox.localhost`：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/install-release.sh | \
+  RELEASE_VERSION=<release-version> ENABLE_MAC_DNS=1 ENABLE_MAC_PROXY=1 bash
+```
+
+安装脚本会根据系统和架构下载对应组件：
+
+```text
+Linux:  novitabox-linux-amd64.tar.gz 或 novitabox-linux-arm64.tar.gz
+macOS:  novitabox-darwin-<arch>.tar.gz + novitabox-linux-<arch>.tar.gz
+```
+
+`firecracker` 和 `vmlinux.bin` 默认继续从稳定的 `v0.0.1` runtime assets 下载。
+
+卸载：
+
+```bash
+# Linux
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/uninstall-linux.sh | sudo -E FORCE=1 bash
+
+# macOS + Lima
+curl -fsSL https://raw.githubusercontent.com/novitalabs/NovitaBox/main/scripts/uninstall-macos-lima.sh | FORCE=1 bash
+```
+
+## 3. 从源码安装
+
+在项目根目录执行：
+
+```bash
+sudo -E scripts/install-linux.sh
+```
+
+常用参数：
+
+```bash
+ROOT_DIR=/data/novitabox \
+IMAGE_PATH=/data/novitabox.img \
+IMAGE_SIZE=100G \
+DOMAIN=novitabox.localhost \
+sudo -E scripts/install-linux.sh
+```
+
+如果已经准备好 Firecracker 和 kernel：
+
+```bash
+FIRECRACKER_PATH=/path/to/firecracker \
+KERNEL_PATH=/path/to/vmlinux.bin \
+sudo -E scripts/install-linux.sh
+```
+
+如果只需要本机 `127.0.0.1` 调试，不配置 Caddy：
+
+```bash
+ENABLE_CADDY=0 sudo -E scripts/install-linux.sh
+```
+
+安装脚本会完成：
+
+- 创建并挂载 Btrfs root
+- 编译 `boxapi`、`boxctl`、`boxd`、`boxlet`、`boxproxy`、`boxshim`
+- 安装 Firecracker 和 guest kernel
+- 使用 `$ROOT_DIR/runsc` 启动 gVisor sandbox（如果存在）
+- 写入 systemd 服务
+- 配置 IP forwarding
+- 可选配置 dnsmasq 和 Caddy
+
+如果需要 gVisor GPU，先在宿主机生成 NVIDIA CDI spec：
+
+```bash
+sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+```
+
+## 4. 检查服务
+
+```bash
+systemctl status novitabox-boxlet novitabox-boxapi novitabox-boxproxy --no-pager
+
+curl http://127.0.0.1:8080/health
+curl http://127.0.0.1:8082/healthz
+```
+
+如果开启 Caddy：
+
+```bash
+curl -k https://novitabox.localhost/health
+```
+
+日志：
+
+```bash
+journalctl -u novitabox-boxlet -f
+journalctl -u novitabox-boxapi -f
+journalctl -u novitabox-boxproxy -f
+```
+
+## 5. 构建 Template
+
+从 Docker image 构建：
+
+```bash
+/data/novitabox/boxctl \
+  --api http://127.0.0.1:8080 \
+  template build my-template \
+  --from-image ubuntu:22.04 \
+  --run 'echo hello from novitabox'
+```
+
+安装软件：
+
+```bash
+/data/novitabox/boxctl template build python-template \
+  --from-image ubuntu:22.04 \
+  --run 'apt-get update' \
+  --run 'apt-get install -y python3 python3-pip' \
+  --exec 'python3 --version'
+```
+
+命令说明：
+
+- `--run`：通过 `/bin/sh -c` 执行，适合 shell 命令。
+- `--exec`：按空格切分后直接执行，适合简单二进制命令。
+- `--template`：指定 template id；不指定则自动生成 `tpl-...`。
+- `--cpu`、`--memory`：设置构建时 VM 资源。
+- 当前 `boxctl template build` 没有 `--runtime` 参数，CLI 默认创建 Firecracker template。
+
+构建 gVisor template 时，需要先通过 v3 API 设置 `runtimeType: "gvisor"`：
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/v3/templates \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"cuda-template","runtimeType":"gvisor"}'
+```
+
+从返回值取得 `templateID` 和 `buildID` 后：
+
+```bash
+curl -sS -X POST \
+  http://127.0.0.1:8080/v2/templates/<templateID>/builds/<buildID> \
+  -H 'Content-Type: application/json' \
+  -d '{"fromImage":"nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubi8"}'
+```
+
+查看 template：
+
+```bash
+/data/novitabox/boxctl template list
+/data/novitabox/boxctl template get tpl-xxxxxxxxxxxxxxxxxxxx
+```
+
+删除 template：
+
+```bash
+/data/novitabox/boxctl template delete tpl-xxxxxxxxxxxxxxxxxxxx
+```
+
+## 6. 创建 Sandbox
+
+```bash
+/data/novitabox/boxctl \
+  --api http://127.0.0.1:8080 \
+  sandbox create tpl-xxxxxxxxxxxxxxxxxxxx
+```
+
+返回结果里会包含 `sandboxID`，格式为：
+
+```text
+sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+查看：
+
+```bash
+/data/novitabox/boxctl sandbox list
+/data/novitabox/boxctl sandbox get sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+创建 gVisor sandbox：
+
+```bash
+/data/novitabox/boxctl sandbox create \
+  --template tpl-xxxxxxxxxxxxxxxxxxxx \
+  --runtime gvisor
+```
+
+创建带 1 张 NVIDIA GPU 的 gVisor sandbox：
+
+```bash
+/data/novitabox/boxctl sandbox create \
+  --template tpl-xxxxxxxxxxxxxxxxxxxx \
+  --runtime gvisor \
+  --gpu 1
+```
+
+验证 GPU：
+
+```bash
+/data/novitabox/boxctl sandbox exec sbx-xxxxxxxxxxxxxxxxxxxx /usr/bin/nvidia-smi
+/data/novitabox/boxctl sandbox exec sbx-xxxxxxxxxxxxxxxxxxxx /cuda-samples/vectorAdd
+```
+
+`nvidia-smi` 能显示 GPU 表示 NVML/driver 通路正常。`vectorAdd` 输出 `Test PASSED` 表示 CUDA kernel 执行正常。
+
+## 7. 执行命令和进入 Shell
+
+执行命令：
+
+```bash
+/data/novitabox/boxctl \
+  --proxy http://127.0.0.1:8082 \
+  exec sbx-xxxxxxxxxxxxxxxxxxxx /bin/sh -c 'pwd && ls -alh'
+```
+
+交互式 shell：
+
+```bash
+/data/novitabox/boxctl \
+  --proxy http://127.0.0.1:8082 \
+  exec -it sbx-xxxxxxxxxxxxxxxxxxxx /bin/sh
+```
+
+也可以使用 sandbox 子命令：
+
+```bash
+/data/novitabox/boxctl sandbox exec -it sbx-xxxxxxxxxxxxxxxxxxxx /bin/sh
+/data/novitabox/boxctl sandbox shell sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+如果 rootfs 中没有 `/bin/bash`，使用 `/bin/sh`。
+
+## 8. Sandbox 生命周期
+
+```bash
+/data/novitabox/boxctl sandbox pause sbx-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl sandbox resume sbx-xxxxxxxxxxxxxxxxxxxx
+
+/data/novitabox/boxctl sandbox poweroff sbx-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl sandbox poweron sbx-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl sandbox reboot sbx-xxxxxxxxxxxxxxxxxxxx
+
+/data/novitabox/boxctl sandbox delete sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+删除命令也支持：
+
+```bash
+/data/novitabox/boxctl sandbox rm sbx-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl sandbox kill sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+## 9. Firecracker Balloon
+
+Firecracker sandbox 默认创建 virtio-balloon，初始回收目标为 `0 MiB`。动态设置 target：
+
+```bash
+/data/novitabox/boxctl sandbox balloon set sbx-xxxxxxxxxxxxxxxxxxxx --amount-mib 1024
+/data/novitabox/boxctl sandbox balloon get sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+把 target 设回零会 deflate balloon：
+
+```bash
+/data/novitabox/boxctl sandbox balloon set sbx-xxxxxxxxxxxxxxxxxxxx --amount-mib 0
+```
+
+查看 guest 统计并修改轮询间隔：
+
+```bash
+/data/novitabox/boxctl sandbox balloon stats sbx-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl sandbox balloon stats-interval sbx-xxxxxxxxxxxxxxxxxxxx --interval-s 2
+```
+
+执行一次 free-page hinting：
+
+```bash
+/data/novitabox/boxctl sandbox balloon hinting start sbx-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl sandbox balloon hinting get sbx-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl sandbox balloon hinting stop sbx-xxxxxxxxxxxxxxxxxxxx
+```
+
+注意：
+
+- Balloon 只由 Firecracker runtime 支持。
+- guest kernel 必须启用 virtio-balloon。
+- `amountMiB` 是回收目标，不是修改 VM 总内存。
+- free-page hinting 是一次性 run，不是后台周期任务。
+- Firecracker metrics 写入 sandbox 目录的 `firecracker-metrics.json`。
+
+## 10. Image
+
+Image 是 rootfs-only artifact，不包含内存和 Firecracker snapshot。
+
+Firecracker image 使用 `rootfs.ext4`。gVisor image 使用 directory rootfs。
+
+从 template 创建 image：
+
+```bash
+/data/novitabox/boxctl image create tpl-xxxxxxxxxxxxxxxxxxxx \
+  --image img-xxxxxxxxxxxxxxxxxxxx
+```
+
+查看和删除：
+
+```bash
+/data/novitabox/boxctl image list
+/data/novitabox/boxctl image get img-xxxxxxxxxxxxxxxxxxxx
+/data/novitabox/boxctl image delete img-xxxxxxxxxxxxxxxxxxxx
+```
+
+也可以通过 template convert：
+
+```bash
+/data/novitabox/boxctl template convert tpl-xxxxxxxxxxxxxxxxxxxx \
+  --image img-xxxxxxxxxxxxxxxxxxxx
+```
+
+## 11. SDK 和 CLI 环境变量
+
+如果使用 Caddy 和 `novitabox.localhost`：
+
+```bash
+export NOVITA_DOMAIN=novitabox.localhost
+export NOVITA_API_KEY=dummy
+export NOVITA_ACCESS_TOKEN=dummy
+export NO_PROXY=.novitabox.localhost,localhost,127.0.0.1,::1
+export NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/caddy-local.crt
+```
+
+Node CLI：
+
+```bash
+npm install -g novita-sandbox-cli@2.0.5
+novita-sandbox-cli sbx create tpl-xxxxxxxxxxxxxxxxxxxx
+```
+
+Python SDK：
+
+```python
+import os
+from novita_sandbox import Sandbox
+
+os.environ["NOVITA_DOMAIN"] = "novitabox.localhost"
+os.environ["NOVITA_API_KEY"] = "dummy"
+os.environ["NOVITA_ACCESS_TOKEN"] = "dummy"
+
+sbx = Sandbox(template="tpl-xxxxxxxxxxxxxxxxxxxx")
+result = sbx.commands.run("echo hello")
+print(result.stdout)
+sbx.close()
+```
+
+## 12. 网络模型
+
+默认网络：
+
+```text
+host_access_cidr = 10.11.0.0/16
+veth_cidr        = 10.12.0.0/16
+guest_ip         = 169.254.0.21
+gateway_ip       = 169.254.0.22
+boxd_port        = 49983
+```
+
+每个 sandbox 有唯一的 host access IP，但 guest 内部 IP 固定：
+
+```text
+Firecracker:
+host -> 10.11.x.y -> netns DNAT -> 169.254.0.21:49983
+
+gVisor:
+host -> 10.11.x.y -> netns veth -> boxd 0.0.0.0:49983
+```
+
+gVisor 没有 VM tap 设备。`boxd` 作为 `runsc` sandbox 的 init 进程运行在 network namespace 里，`boxlet` 会把唯一的 host access IP 配到 namespace veth 上，并把兼容用的 `169.254.0.21/30` 配到 loopback。
+
+检查网络：
+
+```bash
+ip netns list
+ip route | grep 10.11
+journalctl -u novitabox-boxlet -n 200 --no-pager
+```
+
+## 13. 常见问题
+
+### template build 报 no route to host
+
+先看 Firecracker 日志。很多时候 `no route to host` 是表象，真实原因是 VM 已退出。
+
+```bash
+find /data/novitabox/sandboxes -name firecracker.log -print
+tail -200 /data/novitabox/sandboxes/<build-id>/firecracker.log
+```
+
+如果看到：
+
+```text
+Requested init /novitabox/init failed
+```
+
+说明 rootfs 里没有正确注入 init。
+
+如果看到：
+
+```text
+starting boxd
+Failed to get KVM vcpu msr: 0x3a
+```
+
+说明 guest 已启动，boxd 已启动，但 Firecracker snapshot 创建失败。
+
+### boxctl exec 报 executable file not found
+
+检查命令是否在 rootfs 中存在：
+
+```bash
+/data/novitabox/boxctl exec -it sbx-xxxxxxxxxxxxxxxxxxxx /bin/sh
+```
+
+Ubuntu 基础镜像一般有 `/bin/sh`，不一定有 `/bin/bash`。
+
+### SDK HTTPS 证书错误
+
+确认 Caddy local CA 已安装：
+
+```bash
+ls -l /usr/local/share/ca-certificates/caddy-local.crt
+sudo update-ca-certificates
+```
+
+Node CLI 需要：
+
+```bash
+export NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/caddy-local.crt
+```
+
+### 服务启动了但没有进程
+
+检查 systemd：
+
+```bash
+systemctl status novitabox-boxlet novitabox-boxapi novitabox-boxproxy --no-pager
+journalctl -u novitabox-boxlet -n 200 --no-pager
+```
+
+确认 `/data/novitabox` 是 Btrfs 挂载点：
+
+```bash
+findmnt /data/novitabox
+```


### PR DESCRIPTION
- add virtio-balloon configuration, statistics, and free-page hinting
- expose balloon operations through boxshim, boxlet, HTTP API, and boxctl
- configure Firecracker metrics and report runtime capability support
- document Firecracker, gVisor, GPU, networking, artifacts, and lifecycle behavior
- correct gVisor template build instructions to use runtimeType and the v2 build API
- add Chinese API, CLI, architecture, installation, SDK, and troubleshooting guides